### PR TITLE
🎨 Palette: Add clean report for low-risk emails

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2025-11-25 - Visual Hierarchy in Console Lists
 **Learning:** Color-coding list bullets in CLI output significantly improves scannability, allowing users to instantly identify high-severity items in a list of mixed recommendations.
 **Action:** Use semantic colors (Red/Yellow/Green) for list markers when displaying prioritized or categorized information in terminal interfaces.
+
+## 2026-01-27 - Compact Positive Feedback
+**Learning:** When adding positive reinforcement to CLIs, use a compact, single-line format with distinct colors (Green) to distinguish it from verbose error/alert logs without cluttering the output.
+**Action:** Use `✓ CLEAN` or similar concise markers for success states to provide heartbeat confirmation.


### PR DESCRIPTION
🎨 Palette: Added clean report for low-risk emails

💡 **What:** Added a concise "✓ CLEAN" status message to the console for emails with low threat scores.
🎯 **Why:** To provide immediate visual confirmation that the system is active and processing emails correctly, addressing the "silence is golden" issue where users might think the process hung.
📸 **Visuals:**
`✓ CLEAN [23:25:11] Weekly Newsletter (Score: 5.0)`
(in Green)

♿ **Accessibility:** Uses semantic green color for success/safe state.

---
*PR created automatically by Jules for task [15062848102843343531](https://jules.google.com/task/15062848102843343531) started by @abhimehro*