### PR TITLE
🎨 Palette: Add visual progress bar to CLI countdown

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2025-11-25 - Visual Hierarchy in Console Lists
 **Learning:** Color-coding list bullets in CLI output significantly improves scannability, allowing users to instantly identify high-severity items in a list of mixed recommendations.
 **Action:** Use semantic colors (Red/Yellow/Green) for list markers when displaying prioritized or categorized information in terminal interfaces.
+
+## 2026-01-29 - Progress Bars for Wait Times
+**Learning:** A shrinking progress bar alongside a countdown timer provides a better visual sense of "remaining wait" than numbers alone in CLI interfaces.
+**Action:** When using `sys.stdout.write` for countdowns, include a visual bar (e.g., `[██░░]`) to enhance the user's time perception.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -7,6 +7,8 @@ import sys
 import time
 import threading
 
+from .colors import Colors
+
 
 class CountdownTimer:
     """
@@ -36,8 +38,18 @@ class CountdownTimer:
                 else:
                     time_str = f"{remaining}s"
 
+                # Calculate progress bar
+                total_width = 20
+                if self.duration > 0:
+                    filled = int((remaining / self.duration) * total_width)
+                else:
+                    filled = 0
+
+                bar = "█" * filled + "░" * (total_width - filled)
+                bar_colored = f"{Colors.CYAN}{bar}{Colors.RESET}"
+
                 # \r moves cursor to start of line, \033[K clears the line
-                sys.stdout.write(f"\r{self.message}: {time_str} ... \033[K")
+                sys.stdout.write(f"\r{self.message}: [{bar_colored}] {time_str} ... \033[K")
                 sys.stdout.flush()
 
                 time.sleep(self.interval)


### PR DESCRIPTION
🎨 Palette: Add visual progress bar to CLI countdown

💡 **What:** Added a visual progress bar (`[████░░]`) to the CLI countdown timer.
🎯 **Why:** To give users a better visual sense of the remaining wait time during polling intervals.
📸 **Before:** `Waiting: 25s ...`
📸 **After:** `Waiting: [████████████████████] 25s ...` (shrinking as time passes)
♿ **Accessibility:** Uses high-contrast cyan color for the bar. Text description of time remains clear.

Verified with manual test script and existing regression tests.

---
*PR created automatically by Jules for task [12383433705969832591](https://jules.google.com/task/12383433705969832591) started by @abhimehro*