### PR TITLE
🎨 Palette: Add actionable error tips for CLI authentication failures

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2025-11-25 - Visual Hierarchy in Console Lists
 **Learning:** Color-coding list bullets in CLI output significantly improves scannability, allowing users to instantly identify high-severity items in a list of mixed recommendations.
 **Action:** Use semantic colors (Red/Yellow/Green) for list markers when displaying prioritized or categorized information in terminal interfaces.
+
+## 2025-11-28 - Troubleshooting via Logging
+**Learning:** When adding user-facing tips to backend modules, avoiding direct `print` statements preserves architectural cleanliness while still reaching the user if the logger is configured for stdout.
+**Action:** Use `self.logger.warning` with semantic coloring to inject high-visibility tips into the standard application logs, ensuring they are captured by both the user's console and persistent log files.

--- a/src/modules/email_ingestion.py
+++ b/src/modules/email_ingestion.py
@@ -20,6 +20,7 @@ from email.utils import getaddresses
 
 from ..utils.config import EmailAccountConfig
 from ..utils.sanitization import sanitize_for_logging
+from ..utils.colors import Colors
 
 
 # Security limits
@@ -82,6 +83,28 @@ class IMAPClient:
         self.max_body_size = 1024 * 1024  # Default 1MB, overridden by manager
         self.connection: Optional[imaplib.IMAP4_SSL] = None
         self.logger = logging.getLogger(f"IMAPClient.{config.provider}")
+
+    def _get_auth_tip(self, error_msg: str) -> Optional[str]:
+        """Get actionable tip based on error and provider"""
+        msg_lower = error_msg.lower()
+        server_lower = self.config.imap_server.lower()
+
+        # Check for authentication failures
+        auth_keywords = ["authentication", "login", "credential", "logon"]
+
+        if not any(k in msg_lower for k in auth_keywords):
+            return None
+
+        if "outlook" in server_lower or "office365" in server_lower:
+            return "Personal Outlook/Hotmail accounts NO LONGER support passwords. You must use an App Password (if Business) or OAuth (not supported)."
+
+        if "gmail" in server_lower:
+            return "Gmail requires 2-Step Verification enabled and an App Password to use IMAP."
+
+        if "yahoo" in server_lower:
+             return "Yahoo Mail requires an App Password generated from account security settings."
+
+        return "Check your email and password. If using 2FA, you likely need an App Password."
 
     @staticmethod
     def _create_secure_ssl_context(verify_ssl: bool = True) -> ssl.SSLContext:
@@ -148,6 +171,9 @@ class IMAPClient:
 
         except imaplib.IMAP4.error as e:
             self.logger.error(f"IMAP connection error: {e}")
+            tip = self._get_auth_tip(str(e))
+            if tip:
+                self.logger.warning(f"{Colors.YELLOW}💡 {tip}{Colors.RESET}")
             return False
         except Exception as e:
             self.logger.error(f"Unexpected connection error: {e}")
@@ -589,7 +615,11 @@ class IMAPClient:
             result["valid"] = True
             conn.logout()
         except imaplib.IMAP4.error as e:
-            result["error"] = f"IMAP login failed: {e}"
+            error_msg = f"IMAP login failed: {e}"
+            tip = self._get_auth_tip(str(e))
+            if tip:
+                error_msg += f" (Tip: {tip})"
+            result["error"] = error_msg
         except Exception as e:
             result["error"] = f"Credential check failed with unexpected error: {e}"
         return result

--- a/tests/test_email_ingestion_security.py
+++ b/tests/test_email_ingestion_security.py
@@ -182,5 +182,31 @@ class TestEmailIngestionSecurity(unittest.TestCase):
         emails = self.client.fetch_unseen_emails("INBOX")
         self.assertEqual(len(emails), 0)
 
+    def test_auth_tips(self):
+        """Test that _get_auth_tip returns correct advice"""
+        # 1. Outlook
+        self.client.config.imap_server = "imap.outlook.com"
+        tip = self.client._get_auth_tip("NO [AUTHENTICATIONFAILED] Login failed.")
+        self.assertIn("Personal Outlook/Hotmail accounts NO LONGER support passwords", tip)
+
+        # 2. Gmail
+        self.client.config.imap_server = "imap.gmail.com"
+        tip = self.client._get_auth_tip("Invalid credentials (Failure)")
+        self.assertIn("Gmail requires 2-Step Verification", tip)
+
+        # 3. Yahoo
+        self.client.config.imap_server = "imap.mail.yahoo.com"
+        tip = self.client._get_auth_tip("AUTHENTICATIONFAILED")
+        self.assertIn("Yahoo Mail requires an App Password", tip)
+
+        # 4. Generic
+        self.client.config.imap_server = "imap.other.com"
+        tip = self.client._get_auth_tip("Login failed")
+        self.assertIn("Check your email and password", tip)
+
+        # 5. Non-auth error
+        tip = self.client._get_auth_tip("Connection timed out")
+        self.assertIsNone(tip)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
💡 What: Added context-aware troubleshooting tips for IMAP login failures in the CLI output.

🎯 Why: Users often struggle with generic "Login failed" errors when the root cause is a provider-specific requirement (like App Passwords for Gmail/Outlook). This change detects the provider and error type to offer specific remediation steps.

📸 Before:
```
ERROR: IMAP connection error: b'NO [AUTHENTICATIONFAILED] Login failed.'
```

📸 After:
```
ERROR: IMAP connection error: b'NO [AUTHENTICATIONFAILED] Login failed.'
WARNING: 💡 Personal Outlook/Hotmail accounts NO LONGER support passwords. You must use an App Password (if Business) or OAuth (not supported).
```

♿ Accessibility: Uses semantic colors (Yellow for warnings/tips) to distinguish helpful advice from the error stack trace, improving scannability.

---
*PR created automatically by Jules for task [5810247010743050112](https://jules.google.com/task/5810247010743050112) started by @abhimehro*