### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive webhook exposure in logs

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -56,9 +56,9 @@ class AlertConfig:
     """Configuration for alert system"""
     console: bool
     webhook_enabled: bool
-    webhook_url: Optional[str]
+    webhook_url: Optional[str] = field(repr=False)
     slack_enabled: bool
-    slack_webhook: Optional[str]
+    slack_webhook: Optional[str] = field(repr=False)
     threat_low: float
     threat_medium: float
     threat_high: float

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -1,8 +1,29 @@
 
 import unittest
-from src.utils.config import EmailAccountConfig, AnalysisConfig
+from src.utils.config import EmailAccountConfig, AnalysisConfig, AlertConfig
 
 class TestConfigSecurity(unittest.TestCase):
+    def test_alert_config_repr_security(self):
+        """Test that AlertConfig __repr__ does not leak webhooks"""
+        secret_webhook = "https://hooks.slack.com/services/T000/B000/SECRET"
+        secret_url = "https://example.com?token=SECRET"
+
+        config = AlertConfig(
+            console=True,
+            webhook_enabled=True,
+            webhook_url=secret_url,
+            slack_enabled=True,
+            slack_webhook=secret_webhook,
+            threat_low=30.0,
+            threat_medium=60.0,
+            threat_high=80.0
+        )
+
+        repr_str = str(config)
+        self.assertNotIn(secret_webhook, repr_str, "Slack webhook leaked in __repr__")
+        self.assertNotIn(secret_url, repr_str, "Webhook URL leaked in __repr__")
+        self.assertNotIn("slack_webhook", repr_str, "Field name should be hidden")
+
     def test_email_account_config_repr_security(self):
         """Test that EmailAccountConfig __repr__ does not leak app_password"""
         secret_password = "SUPER_SECRET_PASSWORD_123"


### PR DESCRIPTION
Identified and fixed a security vulnerability where `AlertConfig` was leaking sensitive webhook URLs (containing secrets) in its `__repr__` output. This could lead to credential exposure in logs.

Applied `field(repr=False)` to the sensitive fields, consistent with other config classes. Added a regression test to ensure these fields remain hidden in string representations.

---
*PR created automatically by Jules for task [3519248624970635212](https://jules.google.com/task/3519248624970635212) started by @abhimehro*