### PR TITLE
🛡️ Sentinel: [HIGH] Fix Log Spoofing via BiDi Characters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -37,3 +37,8 @@
 **Vulnerability:** `MediaAuthenticityAnalyzer` created temporary files for OpenCV processing but failed to clean them up if an exception occurred during the `write` operation (e.g., disk full). This could lead to disk exhaustion (DoS).
 **Learning:** `tempfile.NamedTemporaryFile(delete=False)` requires manual cleanup in ALL exit paths. Standard `try...finally` blocks must encompass the file creation and writing steps to ensure `os.unlink` is always called.
 **Prevention:** Refactored `_check_deepfake_indicators` to wrap file creation, writing, and usage in a single `try...finally` block, ensuring deterministic cleanup.
+
+## 2026-06-18 - [Log Spoofing via BiDi Characters]
+**Vulnerability:** Logging functions sanitized control characters using `ord(ch) >= 32` but allowed Unicode Format characters (Category `Cf`), specifically Right-to-Left Override (`U+202E`). This allowed attackers to inject characters that reverse text direction in logs, enabling them to disguise malicious activity (e.g., masking a user or action).
+**Learning:** Checking for "printable" ASCII range (>= 32) is insufficient for Unicode security. Unicode contains "printable" or "format" characters that are dangerous in specific contexts (like logs or UIs). Sanitization must explicitly handle Unicode categories.
+**Prevention:** Updated sanitization logic to use `unicodedata.category` and strictly exclude dangerous categories (`Cc`, `Cf`, `Cs`, `Co`, `Cn`, `Zl`, `Zp`) while allowing safe exceptions like Tab.

--- a/tests/test_sanitization_security.py
+++ b/tests/test_sanitization_security.py
@@ -1,0 +1,38 @@
+
+import pytest
+from src.utils.sanitization import sanitize_for_logging
+
+def test_sanitize_bidi_characters():
+    """Test that BiDi control characters are removed to prevent log spoofing."""
+    # Right-to-Left Override (U+202E)
+    # This reverses the text display.
+    # "User admin[RLO]nimda" -> "User adminadmin" (if rendered blindly)
+    # Actually [RLO] flips direction. "User admin\u202Enimda" -> "User adminadmin" (displayed reversed)
+    input_text = "User admin\u202Enimda"
+    # We expect the \u202E to be removed
+    expected = "User adminnimda"
+    assert sanitize_for_logging(input_text) == expected
+
+def test_sanitize_c1_controls():
+    """Test that C1 control characters (0x80-0x9F) are removed."""
+    # U+0090 is Device Control String
+    input_text = "Data\u0090Loss"
+    expected = "DataLoss"
+    assert sanitize_for_logging(input_text) == expected
+
+def test_sanitize_line_separators():
+    """Test that unicode line separators are removed or replaced."""
+    # U+2028 is Line Separator
+    input_text = "Line1\u2028Line2"
+    # Should be removed or replaced. Current logic (proposed) removes them.
+    # Ideally it should be replaced by space or escaped, but removing is safer than allowing multiline.
+    # Let's assume removal for now as they are "formatting" or "separator" that we want to flatten.
+    expected = "Line1Line2"
+    assert sanitize_for_logging(input_text) == expected
+
+def test_sanitize_format_characters():
+    """Test that other format characters like Zero Width Space are removed."""
+    # U+200B Zero Width Space
+    input_text = "Hid\u200Bden"
+    expected = "Hidden"
+    assert sanitize_for_logging(input_text) == expected


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Log Spoofing via BiDi Characters

🚨 Severity: HIGH
💡 Vulnerability: The logging sanitization logic previously allowed Unicode "Format" characters (Category `Cf`), including the Right-to-Left Override (`U+202E`). This allowed attackers to inject characters into logs (e.g., via User-Agent or Input fields) that reverse the text direction, potentially masking malicious activity or spoofing log entries to confuse auditors.
🎯 Impact: Attackers could hide their tracks in logs or make innocent users appear to perform malicious actions.
🔧 Fix: Updated `sanitize_for_logging` in `src/utils/sanitization.py` to explicitly exclude dangerous Unicode categories (`Cc`, `Cf`, `Cs`, `Co`, `Cn`, `Zl`, `Zp`) while preserving safe characters.
✅ Verification: Added `tests/test_sanitization_security.py` which confirms that `\u202E` and other control characters are now stripped. Existing tests passed.

---
*PR created automatically by Jules for task [7998106120678502283](https://jules.google.com/task/7998106120678502283) started by @abhimehro*