### PR TITLE
🎨 Palette: Improve clean email report UX with sender info

### DIFF
--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -187,7 +187,17 @@ class AlertSystem:
         if len(sanitized_subject) > 60:
             subject += "..."
 
-        print(f"{Colors.GREEN}✓ CLEAN{Colors.RESET} [{time_str}] {subject} (Score: {score_val:.1f})")
+        # Sender truncated
+        sanitized_sender = self._sanitize_text(report.sender)
+        sender = sanitized_sender[:25]
+        if len(sanitized_sender) > 25:
+            sender += "..."
+
+        print(
+            f"{Colors.GREEN}✓ CLEAN{Colors.RESET} [{time_str}] "
+            f"{Colors.BOLD}{sender}{Colors.RESET}: {subject} "
+            f"(Score: {score_val:.1f})"
+        )
 
     def _webhook_alert(self, report: ThreatReport):
         """Send alert via webhook"""


### PR DESCRIPTION
Improved the CLI UX for clean email reports by including the sender's name. This provides better context at a glance for operators monitoring the logs. The sender name is sanitized, truncated, and bolded for readability.

---
*PR created automatically by Jules for task [9779271669235930409](https://jules.google.com/task/9779271669235930409) started by @abhimehro*