### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix file extension check bypass via trailing dots

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,8 @@
 **Vulnerability:** The deepfake detection module processed files based on their extension (e.g., `.mov`) even if they failed strict signature validation. This could allow attackers to bypass validation and trigger vulnerabilities in underlying media libraries (like OpenCV) by disguising malicious files with allowed extensions.
 **Learning:** Inconsistent validation logic (checking some extensions strictly but not others) creates security gaps. All inputs processed by complex parsers must be strictly validated against a known-good allowlist of signatures.
 **Prevention:** Updated `MediaAuthenticityAnalyzer` to enforce strict magic byte validation for all supported media extensions, preventing processing of any file that does not match a known secure signature.
+
+## 2026-06-26 - [File Extension Check Bypass]
+**Vulnerability:** File extension checks could be bypassed by appending a trailing dot (e.g., `malware.exe.`).
+**Learning:** Windows treats files with trailing dots as the file without the dot (e.g., `malware.exe.` executes as `malware.exe`), but exact-match extension checks often fail.
+**Prevention:** Always strip trailing dots from filenames before validation and processing, especially when dealing with cross-platform file handling.

--- a/src/modules/email_ingestion.py
+++ b/src/modules/email_ingestion.py
@@ -665,7 +665,12 @@ class IMAPClient:
         # 4. Collapse multiple dots (e.g., file..exe)
         filename = IMAPClient.FILENAME_COLLAPSE_DOTS_PATTERN.sub('.', filename)
 
-        return filename.strip() or "unnamed_attachment"
+        # 5. Remove trailing dots to prevent extension bypasses
+        # e.g., "malware.exe." -> "malware.exe"
+        # Security: Trailing dots are ignored by Windows but bypass exact-match extension checks
+        filename = filename.strip().rstrip('.')
+
+        return filename or "unnamed_attachment"
 
     @classmethod
     def _format_addresses(cls, header_value: str) -> str:

--- a/src/modules/media_analyzer.py
+++ b/src/modules/media_analyzer.py
@@ -182,7 +182,8 @@ class MediaAuthenticityAnalyzer:
         warnings = []
 
         # Sanitize filename (strip whitespace and null bytes for check)
-        filename_lower = filename.lower().strip().replace('\0', '')
+        # Also strip trailing dots which can bypass extension checks but still be executable on Windows
+        filename_lower = filename.lower().strip().replace('\0', '').rstrip('.')
 
         # Check for dangerous extensions
         for ext in self.DANGEROUS_EXTENSIONS:

--- a/tests/test_filename_bypass.py
+++ b/tests/test_filename_bypass.py
@@ -1,0 +1,44 @@
+
+import unittest
+import sys
+from unittest.mock import MagicMock
+from pathlib import Path
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.modules.email_ingestion import IMAPClient
+from src.modules.media_analyzer import MediaAuthenticityAnalyzer
+from src.utils.config import AnalysisConfig
+
+class TestFilenameBypass(unittest.TestCase):
+    def test_sanitize_filename_trailing_dot(self):
+        """Test that _sanitize_filename handles trailing dots correctly"""
+        dangerous_filename = "malware.exe."
+        sanitized = IMAPClient._sanitize_filename(dangerous_filename)
+
+        # Verify trailing dot is removed
+        self.assertFalse(sanitized.endswith('.'), "Sanitization failed to remove trailing dot")
+        self.assertEqual(sanitized, "malware.exe", "Sanitization did not produce expected output")
+
+    def test_check_file_extension_bypass(self):
+        """Test that _check_file_extension is not bypassed by trailing dots"""
+        # Mock config
+        config = MagicMock(spec=AnalysisConfig)
+        config.check_media_attachments = True
+
+        analyzer = MediaAuthenticityAnalyzer(config)
+
+        # Use a dangerous filename with trailing dot
+        # This simulates a case where sanitization might be bypassed or data comes from elsewhere
+        filename = "malware.php."
+
+        score, warnings = analyzer._check_file_extension(filename)
+
+        # Verify it is detected as dangerous
+        is_detected = score >= 5.0
+        self.assertTrue(is_detected, f"Dangerous file '{filename}' was not detected as high risk (Score: {score})")
+        self.assertTrue(any("Dangerous file type" in w for w in warnings), "Missing warning for dangerous file type")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Prevents file extension check bypass via trailing dots.
Updated `IMAPClient._sanitize_filename` and `MediaAuthenticityAnalyzer._check_file_extension` to strip trailing dots.
Added regression test `tests/test_filename_bypass.py`.


---
*PR created automatically by Jules for task [12809856383156559289](https://jules.google.com/task/12809856383156559289) started by @abhimehro*