### PR TITLE
🎨 Palette: Add interactive setup wizard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -35,3 +35,7 @@
 ## 2026-02-08 - Progress Bar for Countdown Timer
 **Learning:** A visual progress bar in the countdown timer provides immediate context for remaining time that a numeric countdown alone cannot convey. Use the block/shade characters (█/░) for universal terminal support.
 **Action:** Render a colored progress bar alongside the countdown timer, gated behind `sys.stdout.isatty()` for CI/CD compatibility.
+
+## 2026-03-22 - Interactive Setup Wizard
+**Learning:** For backend tools with complex configuration (like .env files), users often struggle with initial setup. A CLI wizard that interactively fills in the most critical values (e.g. credentials) reduces friction significantly.
+**Action:** Detect missing configuration and offer an interactive wizard to generate it, using secure input methods (`getpass`) and existing libraries (`python-dotenv`) to safely modify files.

--- a/src/main.py
+++ b/src/main.py
@@ -21,6 +21,7 @@ from src.utils.colors import Colors
 from src.utils.ui import CountdownTimer, Spinner
 from src.utils.logging_utils import ColoredFormatter
 from src.utils.sanitization import sanitize_for_logging
+from src.utils.setup_wizard import run_setup_wizard
 from src.modules.email_ingestion import EmailIngestionManager
 from src.modules.spam_analyzer import SpamAnalyzer
 from src.modules.nlp_analyzer import NLPThreatAnalyzer
@@ -325,6 +326,14 @@ def main():
                     try:
                         shutil.copy(".env.example", config_file)
                         print(f"Created '{config_file}' from '.env.example'.")
+
+                        try:
+                            if input(f"\nWould you like to run the setup wizard? [Y/n] ").strip().lower() in ('', 'y', 'yes'):
+                                run_setup_wizard(config_file)
+                                sys.exit(0)
+                        except Exception as e:
+                            print(f"{Colors.YELLOW}Warning: Wizard error ({e}). Please edit {config_file} manually.{Colors.RESET}")
+
                         print("IMPORTANT: Please edit .env with your actual credentials before proceeding.")
                         sys.exit(0)
                     except Exception as e:

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -1,0 +1,46 @@
+"""
+Interactive setup wizard for initial configuration.
+Simplifies the onboarding process by guiding users through key settings.
+"""
+
+import sys
+import getpass
+from pathlib import Path
+from dotenv import set_key
+from .colors import Colors
+
+def run_setup_wizard(config_file: str):
+    """Run interactive setup wizard for .env configuration"""
+    print(f"\n{Colors.CYAN}🔧 Configuration Wizard{Colors.RESET}")
+    print(f"{Colors.GREY}Let's get your email accounts set up.{Colors.RESET}\n")
+
+    # Gmail Setup
+    if _confirm("Configure Gmail account?"):
+        email = input(f"  {Colors.BOLD}Gmail Address:{Colors.RESET} ").strip()
+        print(f"  {Colors.GREY}(Use an App Password, not your login password){Colors.RESET}")
+        password = getpass.getpass(f"  {Colors.BOLD}App Password:{Colors.RESET} ").strip()
+
+        if email and password:
+            try:
+                _update_env(config_file, "GMAIL_ENABLED", "true")
+                _update_env(config_file, "GMAIL_EMAIL", email)
+                _update_env(config_file, "GMAIL_APP_PASSWORD", password)
+                print(f"  {Colors.GREEN}✔ Gmail configured{Colors.RESET}\n")
+            except Exception as e:
+                print(f"  {Colors.RED}❌ Error saving configuration: {e}{Colors.RESET}\n")
+
+    print(f"{Colors.GREEN}Configuration saved to {config_file}{Colors.RESET}")
+    print(f"{Colors.GREY}You can edit other settings manually in the file.{Colors.RESET}\n")
+
+def _confirm(question: str) -> bool:
+    """Ask a yes/no question"""
+    try:
+        response = input(f"{question} [Y/n] ").strip().lower()
+        return response in ('', 'y', 'yes')
+    except EOFError:
+        return False
+
+def _update_env(file: str, key: str, value: str):
+    """Update a key in the .env file"""
+    # quote_mode="auto" handles values with spaces or special chars correctly
+    set_key(file, key, value, quote_mode="auto")


### PR DESCRIPTION
Implemented an interactive setup wizard that runs when the `.env` file is missing. The wizard prompts the user to create the file from `.env.example` and then optionally configures Gmail credentials securely using `getpass`. This addresses the common friction point of manual configuration for new users.

Changes:
- Created `src/utils/setup_wizard.py`
- Modified `src/main.py` to call the wizard.
- Verified syntax and non-interactive behavior.

---
*PR created automatically by Jules for task [3130714513900144176](https://jules.google.com/task/3130714513900144176) started by @abhimehro*