### PR TITLE
test: add pytest CI runner

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,30 @@
+name: Pytest
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-ci.txt
+
+      - name: Run tests
+        run: |
+          python -m pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,9 @@
+# CI/Test dependencies
+# NOTE: This intentionally avoids the optional NLP/ML stacks (torch/transformers)
+# so PR validation stays fast and reliable.
+
+python-dotenv>=1.0.0
+requests>=2.31.0
+numpy>=1.26.0
+opencv-python-headless>=4.8.0
+pytest>=8.0.0

--- a/tests/test_deepfake_detection.py
+++ b/tests/test_deepfake_detection.py
@@ -23,6 +23,9 @@ class TestDeepfakeDetection(unittest.TestCase):
         self.config.deepfake_api_key = None
         self.config.deepfake_api_url = None
         self.config.deepfake_model_path = None
+        # NOTE: MediaAuthenticityAnalyzer enforces a hard timeout on deepfake analysis.
+        # Some tests use MagicMock config, so we must provide this attribute explicitly.
+        self.config.media_analysis_timeout = 10
 
         self.analyzer = MediaAuthenticityAnalyzer(self.config)
 
@@ -76,6 +79,9 @@ class TestDeepfakeDetection(unittest.TestCase):
 
         # Mock frame extraction to return dummy frames
         self.analyzer._extract_frames_from_video = MagicMock(return_value=[np.zeros((100, 100, 3), dtype=np.uint8)])
+        # Avoid codec/ffmpeg variability in CI by mocking the other OpenCV-heavy steps.
+        self.analyzer._check_audio_visual_sync = MagicMock(return_value=(0.0, []))
+        self.analyzer._check_compression_artifacts = MagicMock(return_value=(0.0, []))
         # Mock model score to be high
         self.analyzer._run_deepfake_model = MagicMock(return_value=0.8)
 
@@ -108,6 +114,9 @@ class TestDeepfakeDetection(unittest.TestCase):
 
         # Mock frame extraction to return dummy frames
         self.analyzer._extract_frames_from_video = MagicMock(return_value=[np.zeros((100, 100, 3), dtype=np.uint8)])
+        # Avoid codec/ffmpeg variability in CI by mocking the other OpenCV-heavy steps.
+        self.analyzer._check_audio_visual_sync = MagicMock(return_value=(0.0, []))
+        self.analyzer._check_compression_artifacts = MagicMock(return_value=(0.0, []))
         # Mock some facial inconsistencies to get a score
         self.analyzer._analyze_facial_inconsistencies = MagicMock(return_value=(1.0, ["Facial issue"]))
         # Mock model score to be low

--- a/tests/test_media_security.py
+++ b/tests/test_media_security.py
@@ -21,7 +21,8 @@ class TestMediaDoS(unittest.TestCase):
         self.config.deepfake_detection_enabled = True
         self.analyzer = MediaAuthenticityAnalyzer(self.config)
 
-    @patch('cv2.VideoCapture')
+    # Patch the module-local cv2 reference used by MediaAuthenticityAnalyzer.
+    @patch('src.modules.media_analyzer.cv2.VideoCapture')
     def test_extract_large_frames(self, mock_capture):
         # Create a mock video capture
         mock_cap_instance = MagicMock()


### PR DESCRIPTION
Adds a lightweight pytest runner aligned with ctrld-sync:\n\n- Adds requirements-ci.txt (avoids optional torch/transformers to keep CI fast)\n- Adds pytest.ini for consistent discovery\n- Adds GitHub Actions workflow (.github/workflows/pytest.yml) to run pytest on PRs and main\n- Fixes a few media/deepfake tests to be deterministic (no dependency on video codecs)\n\nSECURITY: avoids installing ML stacks in CI; reduces risk of dependency bloat and flaky codec behavior.