### PR TITLE
🛡️ Sentinel: [CRITICAL] Add DMARC verification check

### DIFF
--- a/tests/test_spam_analyzer.py
+++ b/tests/test_spam_analyzer.py
@@ -136,3 +136,51 @@ def test_suspicious_urls(spam_analyzer, clean_email):
 
     assert len(result.suspicious_urls) > 0
     assert "http://bit.ly/suspicious" in result.suspicious_urls
+
+def test_dmarc_fail_detection(spam_analyzer):
+    """
+    Test that DMARC failure is detected in Authentication-Results header.
+
+    SECURITY STORY: DMARC (Domain-based Message Authentication, Reporting, and Conformance)
+    is crucial for preventing exact-domain spoofing. If SPF and DKIM pass but DMARC fails
+    (e.g., due to misalignment), the email should be treated as suspicious.
+    """
+    # Email with DMARC failure but potentially passing SPF/DKIM (e.g. unaligned)
+    headers = {
+        "authentication-results": "mx.google.com; dkim=pass header.i=@example.com; spf=pass (google.com: domain of sender@example.com designates ...); dmarc=fail (p=REJECT dis=NONE) header.from=example.com",
+        "from": "sender@example.com",
+        "to": "recipient@company.com",
+        "date": "Wed, 01 Jan 2025 00:00:00 -0000",
+        "message-id": "<test@example.com>",
+        "dkim-signature": "v=1; ..."
+    }
+
+    email_data = EmailData(
+        message_id="1",
+        subject="Test DMARC",
+        sender="sender@example.com",
+        recipient="recipient@company.com",
+        date=datetime.now(),
+        body_text="Test",
+        body_html="",
+        headers=headers,
+        attachments=[],
+        raw_email=None,
+        account_email="recipient@company.com",
+        folder="INBOX"
+    )
+
+    result = spam_analyzer.analyze(email_data)
+
+    # Check if DMARC failure is detected
+    found_dmarc_issue = False
+    for issue in result.header_issues:
+        if "DMARC" in issue and "fail" in issue.lower():
+            found_dmarc_issue = True
+            break
+
+    assert found_dmarc_issue, "DMARC failure was not detected in headers"
+
+    # DMARC fail is a strong signal, so score should be increased
+    # We expect at least 3.0 points (as implemented)
+    assert result.score >= 3.0


### PR DESCRIPTION
Added DMARC verification check to SpamAnalyzer to improve anti-spoofing capabilities. This addresses a critical gap where emails failing DMARC policy were not penalized if SPF/DKIM passed authentication but failed alignment.
Added a new test case `test_dmarc_fail_detection` to verify the functionality.
Ran all tests and confirmed they pass.

---
*PR created automatically by Jules for task [6258127816047425029](https://jules.google.com/task/6258127816047425029) started by @abhimehro*