### PR TITLE
🎨 Palette: Add CYAN color to CLI Spinner

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -54,3 +54,7 @@
 ## 2026-06-25 - Validation in Setup Wizards
 **Learning:** Setup wizards that blindly accept input lead to frustrating failures later. Immediate validation (e.g., regex checks) builds confidence and prevents configuration errors.
 **Action:** Always validate critical inputs like email addresses during setup, providing helpful feedback and allowing retry.
+
+## 2026-10-25 - Colorizing Loading States
+**Learning:** Loading states (like CLI spinners) are often ignored by users if they lack visual distinction. Colorizing the spinning indicator creates a subtle but effective cue that a process is actively running, distinguishing it from static text.
+**Action:** Always colorize loading indicators (e.g., `Spinner` in CLI) with a distinct, neutral color (like CYAN) to separate them from the accompanying message text.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -93,7 +93,8 @@ class Spinner:
     def _spin(self):
         while self.busy:
             # \r moves cursor to start of line, \033[K clears the line
-            sys.stdout.write(f"\r{next(self.spinner)} {self.message}   \033[K")
+            spin_char = Colors.colorize(next(self.spinner), Colors.CYAN)
+            sys.stdout.write(f"\r{spin_char} {self.message}   \033[K")
             sys.stdout.flush()
             time.sleep(self.delay)
             # Check again to avoid writing after stop


### PR DESCRIPTION
### 💡 What: 
Added a CYAN color to the spinning character in the CLI `Spinner` component (`src/utils/ui.py`).
Additionally, documented this UX enhancement in the `.Jules/palette.md` journal.

### 🎯 Why: 
Loading states, such as CLI spinners, can be easily overlooked if they lack visual distinction from the surrounding static text. By adding a subtle but distinct color to the spinner itself, users can instantly recognize the process is actively running without having to closely read the line.

### 📸 Before/After: 
*Before*: `⠋ Checking for new emails...` (all default terminal color)
*After*: `<CYAN>⠋</CYAN> Checking for new emails...` (the spinning symbol is colored, text remains default)

### ♿ Accessibility:
Provides an extra visual cue (color) alongside motion to indicate system state changes, making it slightly easier to parse for users scanning large amounts of terminal output.

---
*PR created automatically by Jules for task [13837418928910669142](https://jules.google.com/task/13837418928910669142) started by @abhimehro*