### PR TITLE
🎨 Palette: Graceful KeyboardInterrupt handling in setup wizard

### DIFF
--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -208,52 +208,57 @@ def run_setup_wizard(config_file: str = ".env", template_file: str = ".env.examp
         print(f"{Colors.RED}Error: Template file '{template_file}' not found.{Colors.RESET}")
         return False
 
-    print(f"\n{Colors.BOLD}🧙 Welcome to the Email Security Pipeline Setup Wizard! 🧙{Colors.RESET}")
-    print(f"{Colors.GREY}Let's get your environment configured quickly.{Colors.RESET}")
-
-    # 1. Select Provider
-    choice = _select_provider()
-    if choice == '4':
-        return False
-
-    provider_map = {
-        '1': ('GMAIL', 'Gmail'),
-        '2': ('PROTON', 'Proton Mail'),
-        '3': ('OUTLOOK', 'Outlook')
-    }
-    selected_key, selected_name = provider_map[choice]
-
-    # 2. Get Credentials
-    email, app_secret = _get_credentials(choice, selected_name)
-    if not email or not app_secret:
-        return False
-
-    # 3. Read Template
     try:
-        with open(template_file, 'r') as f:
-            template_content = f.read()
-    except Exception as e:
-        print(f"{Colors.RED}Error reading template: {e}{Colors.RESET}")
+        print(f"\n{Colors.BOLD}🧙 Welcome to the Email Security Pipeline Setup Wizard! 🧙{Colors.RESET}")
+        print(f"{Colors.GREY}Let's get your environment configured quickly.{Colors.RESET}")
+
+        # 1. Select Provider
+        choice = _select_provider()
+        if choice == '4':
+            return False
+
+        provider_map = {
+            '1': ('GMAIL', 'Gmail'),
+            '2': ('PROTON', 'Proton Mail'),
+            '3': ('OUTLOOK', 'Outlook')
+        }
+        selected_key, selected_name = provider_map[choice]
+
+        # 2. Get Credentials
+        email, app_secret = _get_credentials(choice, selected_name)
+        if not email or not app_secret:
+            return False
+
+        # 3. Read Template
+        try:
+            with open(template_file, 'r') as f:
+                template_content = f.read()
+        except Exception as e:
+            print(f"{Colors.RED}Error reading template: {e}{Colors.RESET}")
+            return False
+
+        # 4. Generate Config
+        new_content = _generate_config_content(template_content, selected_key, email, app_secret)
+
+        # 5. Write Config
+        try:
+            # Create file with restrictive permissions (600)
+            # Using os.open to set mode atomically if possible, or chmod after
+            fd = os.open(config_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, 'w') as f:
+                f.write(new_content)
+
+            print(f"\n{Colors.GREEN}✔ Configuration saved to {config_file}{Colors.RESET}")
+        except Exception as e:
+            print(f"{Colors.RED}Error writing config: {e}{Colors.RESET}")
+            return False
+
+        print(f"\n{Colors.BOLD}Next Steps:{Colors.RESET}")
+        print("1. Review .env to ensure settings are correct.")
+        print("2. Run the pipeline!")
+
+        return True
+
+    except KeyboardInterrupt:
+        print(Colors.colorize("\n\nSetup wizard cancelled.", Colors.YELLOW))
         return False
-
-    # 4. Generate Config
-    new_content = _generate_config_content(template_content, selected_key, email, app_secret)
-
-    # 5. Write Config
-    try:
-        # Create file with restrictive permissions (600)
-        # Using os.open to set mode atomically if possible, or chmod after
-        fd = os.open(config_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(fd, 'w') as f:
-            f.write(new_content)
-
-        print(f"\n{Colors.GREEN}✔ Configuration saved to {config_file}{Colors.RESET}")
-    except Exception as e:
-        print(f"{Colors.RED}Error writing config: {e}{Colors.RESET}")
-        return False
-
-    print(f"\n{Colors.BOLD}Next Steps:{Colors.RESET}")
-    print("1. Review .env to ensure settings are correct.")
-    print("2. Run the pipeline!")
-
-    return True


### PR DESCRIPTION
🎨 Palette: Graceful KeyboardInterrupt handling in setup wizard

💡 What: Wrapped `run_setup_wizard()` in a `try...except KeyboardInterrupt` block that prints a friendly, colorized cancellation message instead of throwing a raw Python stack trace.

🎯 Why: Hitting Ctrl+C during CLI prompts is a standard way users abort operations. Previously, doing this threw an intimidating `KeyboardInterrupt` traceback. Catching the interrupt and exiting gracefully improves the CLI's UX by providing positive, clear feedback when the user cancels the action.

♿ Accessibility: Reduced cognitive load and anxiety for users by replacing noisy error output with a concise, color-coded confirmation that their cancellation intent was understood.

---
*PR created automatically by Jules for task [18071371000262124347](https://jules.google.com/task/18071371000262124347) started by @abhimehro*