### PR TITLE
🎨 Palette: Graceful spinner cancellation on KeyboardInterrupt

### DIFF
--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -149,7 +149,11 @@ class Spinner:
                     self.thread.join()
                 final_message = ""
 
-                if exc_type is not None:
+                if exc_type is KeyboardInterrupt:
+                    msg = self.message
+                    warning = Colors.colorize("⚠", Colors.YELLOW)
+                    final_message = f"{warning} {msg} (Cancelled)\n"
+                elif exc_type is not None:
                     # Failure logic
                     msg = self.fail_msg if self.fail_msg else self.message
                     # Use Colors.colorize to ensure we get proper fallback if colors are disabled
@@ -174,7 +178,9 @@ class Spinner:
             # Non-TTY: provide simple success/failure feedback without ANSI codes.
             # Colors.ENABLED is computed at import time, so use plain symbols here
             # to avoid leaking escape sequences when stdout is redirected later.
-            if exc_type is not None:
+            if exc_type is KeyboardInterrupt:
+                sys.stdout.write(f"⚠ {self.message} (Cancelled)\n")
+            elif exc_type is not None:
                 msg = self.fail_msg if self.fail_msg else self.message
                 sys.stdout.write(f"✘ {msg}\n")
             elif self.success_msg:

--- a/tests/test_ui_palette.py
+++ b/tests/test_ui_palette.py
@@ -44,3 +44,31 @@ class TestPaletteUI(TestCase):
             writes = "".join(call.args[0] for call in mock_stdout.write.mock_calls if call.args)
             self.assertNotIn("\033[?25l", writes)
             self.assertNotIn("\033[?25h", writes)
+
+    def test_spinner_keyboard_interrupt_tty(self):
+        """Test graceful cancellation message on KeyboardInterrupt in TTY mode"""
+        from src.utils.ui import Spinner
+        with patch('sys.stdout') as mock_stdout:
+            mock_stdout.isatty.return_value = True
+
+            spinner = Spinner(message="Test Cancel")
+            spinner.__enter__()
+            spinner.__exit__(KeyboardInterrupt, None, None)
+
+            writes = "".join(call.args[0] for call in mock_stdout.write.mock_calls if call.args)
+            self.assertIn("Test Cancel (Cancelled)", writes)
+            self.assertIn("⚠", writes)
+
+    def test_spinner_keyboard_interrupt_non_tty(self):
+        """Test graceful cancellation message on KeyboardInterrupt in non-TTY mode"""
+        from src.utils.ui import Spinner
+        with patch('sys.stdout') as mock_stdout:
+            mock_stdout.isatty.return_value = False
+
+            spinner = Spinner(message="Test Cancel")
+            spinner.__enter__()
+            spinner.__exit__(KeyboardInterrupt, None, None)
+
+            writes = "".join(call.args[0] for call in mock_stdout.write.mock_calls if call.args)
+            self.assertIn("Test Cancel (Cancelled)", writes)
+            self.assertIn("⚠", writes)


### PR DESCRIPTION
💡 **What:** Added graceful cancellation to the `Spinner` UI component when an operation is interrupted via `KeyboardInterrupt` (Ctrl+C).

🎯 **Why:** Previously, interrupting a spinner would result in a generic red error (`✘ [Message]`). This wasn't accurate or clear, as a cancellation is a user action, not a system failure. The new behavior outputs a yellow warning icon with `⚠ [Message] (Cancelled)` for better UX and clearer intent.

📸 **Before:** `✘ Loading...`
📸 **After:** `⚠ Loading... (Cancelled)`

♿ **Accessibility:** N/A (CLI UX improvement)

---
*PR created automatically by Jules for task [17096501202229455263](https://jules.google.com/task/17096501202229455263) started by @abhimehro*