### PR TITLE
🎨 Palette: Graceful KeyboardInterrupt handling during config setup

### DIFF
--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -90,6 +90,9 @@ class AppRunner:
                 else:
                     print("Please create a .env file based on .env.example")
                     sys.exit(1)
+        except KeyboardInterrupt:
+            print("\n\n" + Colors.colorize("Setup cancelled by user. No changes were made.", Colors.YELLOW))
+            sys.exit(0)
         except EOFError:
             self._handle_missing_config_non_interactive()
 


### PR DESCRIPTION
This patch improves the CLI UX during the interactive setup flow. When `.env` is missing and the user is prompted to run the setup wizard, pressing Ctrl+C previously triggered a raw `KeyboardInterrupt` stack trace because the exception was not explicitly handled in `AppRunner._handle_missing_config_interactive()`. 

The update catches `KeyboardInterrupt` and cleanly exits with a yellow "Setup cancelled by user" message (reusing the styling pattern from `run_setup_wizard()`), while explicitly preserving the `EOFError` path to ensure non-interactive fallback execution remains functional.

---
*PR created automatically by Jules for task [13309747891151638042](https://jules.google.com/task/13309747891151638042) started by @abhimehro*