### PR TITLE
🎨 Palette: Improve Spinner Failure Feedback

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -136,6 +136,7 @@ class EmailSecurityPipeline:
             # Initialize email clients
             with Spinner("Initializing email clients...") as spinner:
                 if not self.ingestion_manager.initialize_clients():
+                    spinner.fail("Failed to initialize email clients")
                     raise RuntimeError("Failed to initialize email clients")
                 spinner.success("Email clients initialized")
 
@@ -218,6 +219,10 @@ class EmailSecurityPipeline:
                     )
                     if emails:
                         spinner.success(f"Found {len(emails)} new emails")
+                    else:
+                        # Persist=False is used, so it typically disappears,
+                        # but just in case we can be explicit, though it's optional.
+                        pass
 
                 if not emails:
                     self.logger.info("No new emails to analyze")

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -86,7 +86,7 @@ def _test_connection(email: str, app_password: str, provider_choice: str) -> boo
 
     try:
         success = False
-        with Spinner("Connecting to IMAP server..."):
+        with Spinner("Connecting to IMAP server...") as spinner:
             # Suppress logging during check to avoid clutter
             import logging
             logging.disable(logging.CRITICAL)
@@ -98,16 +98,22 @@ def _test_connection(email: str, app_password: str, provider_choice: str) -> boo
             finally:
                 logging.disable(logging.NOTSET)
 
-        if success:
-            print(f"{Colors.GREEN}✔ Connection successful!{Colors.RESET}")
-            return True
-        else:
-            print(f"{Colors.RED}✘ Connection failed.{Colors.RESET}")
+            if success:
+                spinner.success("Connection successful!")
+            else:
+                spinner.fail("Connection failed.")
+
+        if not success:
             if provider_choice == '3':
                 print(OUTLOOK_APP_PASSWORD_TIP)
             return False
 
+        return True
+
     except Exception as e:
+        # We don't have access to the spinner here easily if the exception is outside,
+        # but in most cases errors happen inside the context manager. If it happens
+        # outside, we just print as before.
         print(f"{Colors.RED}✘ Error during connection test: {e}{Colors.RESET}")
         if provider_choice == '3':
             print(OUTLOOK_APP_PASSWORD_TIP)

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -153,7 +153,7 @@ class Spinner:
                     msg = self.message
                     warning = Colors.colorize("⚠", Colors.YELLOW)
                     final_message = f"{warning} {msg} (Cancelled)\n"
-                elif exc_type is not None:
+                elif exc_type is not None or self.fail_msg:
                     # Failure logic
                     msg = self.fail_msg if self.fail_msg else self.message
                     # Use Colors.colorize to ensure we get proper fallback if colors are disabled
@@ -180,7 +180,7 @@ class Spinner:
             # to avoid leaking escape sequences when stdout is redirected later.
             if exc_type is KeyboardInterrupt:
                 sys.stdout.write(f"⚠ {self.message} (Cancelled)\n")
-            elif exc_type is not None:
+            elif exc_type is not None or self.fail_msg:
                 msg = self.fail_msg if self.fail_msg else self.message
                 sys.stdout.write(f"✘ {msg}\n")
             elif self.success_msg:


### PR DESCRIPTION
🎨 Palette: Improve Spinner Failure Feedback

💡 What: Modified the `Spinner` context manager to output the designated failure message and symbol when `spinner.fail()` is explicitly called, even if the block completes without an exception. Also updated usages in `src/utils/setup_wizard.py` and `src/main.py` to actively use `spinner.fail` and `spinner.success`.
🎯 Why: Previously, if an operation failed but was caught or handled gracefully (returning a boolean), the `Spinner` context manager would incorrectly exit with a success message (e.g. `✔ Connecting...`) followed immediately by the failure message (e.g., `✘ Connection failed`). This was confusing visually.
♿ Accessibility: Provides clear, distinct terminal outputs (✔ vs ✘) mapping directly to the true result of the loaded action.

---
*PR created automatically by Jules for task [8420740950621416439](https://jules.google.com/task/8420740950621416439) started by @abhimehro*