### PR TITLE
🎨 Palette: Add elapsed time to long-running CLI spinners

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -113,3 +113,7 @@
 ## 2025-02-15 - Consistent Input Prompt Styling
 **Learning:** In CLI applications, unstyled `input()` prompts can blend into the surrounding informational text, causing users to pause and wonder if the program is hung.
 **Action:** Styled all interactive input and getpass prompts consistently with `Colors.BOLD` (using `Colors.colorize()` to respect fallback logic) to clearly signal when user action is required.
+
+## 2026-02-15 - Interactive Spinner Timing Indicators
+**Learning:** Operations with indeterminate progress (spinners) cause user anxiety if they run longer than expected. Adding a subtle elapsed time indicator (`[1.2s]`) to the spinner after a brief delay (1s) transforms the experience from "Is it hung?" to active feedback, without cluttering fast operations.
+**Action:** Always track and display elapsed time on indeterminate loading states that might exceed 1 second. Ensure the time format is subtle (e.g., greyed out) to maintain focus on the primary message.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -121,9 +121,11 @@ class Spinner:
 
     def _spin(self):
         while self.busy:
+            elapsed = time.time() - getattr(self, "start_time", time.time())
+            time_str = Colors.colorize(f" [{elapsed:.1f}s]", Colors.GREY) if elapsed >= 1.0 else ""
             # \r moves cursor to start of line, \033[K clears the line
             spin_char = Colors.colorize(next(self.spinner), Colors.CYAN)
-            sys.stdout.write(f"\r{spin_char} {self.message}   \033[K")
+            sys.stdout.write(f"\r{spin_char} {self.message}{time_str}   \033[K")
             sys.stdout.flush()
             time.sleep(self.delay)
             # Check again to avoid writing after stop
@@ -131,6 +133,7 @@ class Spinner:
                 break
 
     def __enter__(self):
+        self.start_time = time.time()
         if sys.stdout.isatty():
             # Hide cursor
             sys.stdout.write(CURSOR_HIDE)
@@ -140,10 +143,16 @@ class Spinner:
             self.thread = threading.Thread(target=self._spin)
             self.thread.start()
         else:
-            print(f"{self.message}...")
+            msg = self.message
+            if not msg.endswith("..."):
+                msg += "..."
+            print(msg)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        elapsed = time.time() - getattr(self, "start_time", time.time())
+        time_str = Colors.colorize(f" [{elapsed:.1f}s]", Colors.GREY) if elapsed >= 1.0 else ""
+
         if sys.stdout.isatty():
             try:
                 self.busy = False
@@ -154,21 +163,21 @@ class Spinner:
                 if exc_type is KeyboardInterrupt:
                     msg = self.message
                     warning = Colors.colorize("⚠", Colors.YELLOW)
-                    final_message = f"{warning} {msg} (Cancelled)\n"
+                    final_message = f"{warning} {msg} (Cancelled){time_str}\n"
                 elif exc_type is not None or self.fail_msg:
                     # Failure logic
                     msg = self.fail_msg if self.fail_msg else self.message
                     # Use Colors.colorize to ensure we get proper fallback if colors are disabled
                     cross = Colors.colorize("✘", Colors.RED)
-                    final_message = f"{cross} {msg}\n"
+                    final_message = f"{cross} {msg}{time_str}\n"
                 elif self.success_msg:
                     # Explicit success message always persists
                     check = Colors.colorize("✔", Colors.GREEN)
-                    final_message = f"{check} {self.success_msg}\n"
+                    final_message = f"{check} {self.success_msg}{time_str}\n"
                 elif self.persist:
                     # Default persistence
                     check = Colors.colorize("✔", Colors.GREEN)
-                    final_message = f"{check} {self.message}\n"
+                    final_message = f"{check} {self.message}{time_str}\n"
 
                 sys.stdout.write(f"\r\033[K{final_message}")
                 sys.stdout.flush()
@@ -180,13 +189,14 @@ class Spinner:
             # Non-TTY: provide simple success/failure feedback without ANSI codes.
             # Colors.ENABLED is computed at import time, so use plain symbols here
             # to avoid leaking escape sequences when stdout is redirected later.
+            raw_time_str = f" [{elapsed:.1f}s]" if elapsed >= 1.0 else ""
             if exc_type is KeyboardInterrupt:
-                sys.stdout.write(f"⚠ {self.message} (Cancelled)\n")
+                sys.stdout.write(f"⚠ {self.message} (Cancelled){raw_time_str}\n")
             elif exc_type is not None or self.fail_msg:
                 msg = self.fail_msg if self.fail_msg else self.message
-                sys.stdout.write(f"✘ {msg}\n")
+                sys.stdout.write(f"✘ {msg}{raw_time_str}\n")
             elif self.success_msg:
-                sys.stdout.write(f"✔ {self.success_msg}\n")
+                sys.stdout.write(f"✔ {self.success_msg}{raw_time_str}\n")
             elif self.persist:
-                sys.stdout.write(f"✔ {self.message}\n")
+                sys.stdout.write(f"✔ {self.message}{raw_time_str}\n")
             sys.stdout.flush()


### PR DESCRIPTION
🎨 Palette: Add elapsed time to long-running CLI spinners

💡 **What:** Added a subtle elapsed time tracker (e.g., `[1.2s]`) to the `Spinner` component that appears when an operation takes 1.0 second or longer. Also fixed a minor string duplication bug for non-TTY mode (`...` was being appended multiple times).
🎯 **Why:** Indeterminate loading states (spinners) cause user anxiety if they run longer than expected. By providing an active elapsed time counter, the UX transforms from "Is it hung?" to "It's working and has been running for X seconds." Gating it behind a 1-second delay prevents clutter on fast operations.
♿ **Accessibility:** N/A (CLI improvement for sighted users; screen reader behavior remains unaffected as the message update interval is constant).

### Changes:
*   Updated `Spinner.__enter__` to record `start_time` and prevent duplicating `...` in non-TTY mode.
*   Updated `Spinner._spin` to dynamically append `[X.Xs]` (in `Colors.GREY`) if `elapsed >= 1.0`.
*   Updated `Spinner.__exit__` to include the final elapsed time in the completion/failure message.
*   Added learning to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [5443294948413126190](https://jules.google.com/task/5443294948413126190) started by @abhimehro*