### PR TITLE
Fix pre-commit configuration errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,8 @@
 repos:
   # Basic file quality checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: <version>
+    rev: v4.5.0
     hooks:
-      - id: python-no-eval
-        exclude: ^src/modules/nlp_analyzer\.py$
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
       - id: end-of-file-fixer
@@ -35,6 +33,7 @@ repos:
       - id: python-check-blanket-noqa
       - id: python-check-mock-methods
       - id: python-no-eval
+        exclude: ^src/modules/nlp_analyzer\.py$
       - id: python-no-log-warn
       - id: python-use-type-annotations
 


### PR DESCRIPTION
Fixes the invalid `.pre-commit-config.yaml` by applying the correct `rev` version (`v4.5.0`) to the `pre-commit-hooks` and moving the `python-no-eval` hook to its proper source repository (`pygrep-hooks`), ensuring all security checks pass correctly.

---
*PR created automatically by Jules for task [2775665086477345716](https://jules.google.com/task/2775665086477345716) started by @abhimehro*