### PR TITLE
🎨 Palette: Consistent colorization of status indicators in CLI configuration summary

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -417,9 +417,9 @@ class EmailSecurityPipeline:
             else f"{Colors.GREY}✖ Disabled{Colors.RESET}"
         )
         deepfake_status = (
-            f"✔ Enabled"
+            f"{Colors.GREEN}✔ Enabled{Colors.RESET}"
             if self.config.analysis.deepfake_detection_enabled
-            else "✖ Disabled"
+            else f"{Colors.GREY}✖ Disabled{Colors.RESET}"
         )
         print(f"    - Media Check:      {media_status} (Deepfake: {deepfake_status})")
 
@@ -434,15 +434,19 @@ class EmailSecurityPipeline:
             channels.append("Slack")
 
         if channels:
-            print(f"    - ✔ Enabled: {', '.join(channels)}")
+            print(f"    - {Colors.GREEN}✔ Enabled{Colors.RESET}: {', '.join(channels)}")
         else:
-            print(f"    - ✖ Enabled: {Colors.YELLOW}None{Colors.RESET}")
+            print(
+                f"    - {Colors.GREY}✖ Disabled{Colors.RESET}: {Colors.YELLOW}None{Colors.RESET}"
+            )
 
         print(f"  ⚙️ {Colors.CYAN}System:{Colors.RESET}")
         print(f"    - Log Level:  {self.config.system.log_level}")
         print(f"    - Log Format: {self.config.system.log_format}")
         if self.config.system.enable_metrics:
             print(f"    - Metrics:    {Colors.GREEN}✔ Enabled{Colors.RESET}")
+        else:
+            print(f"    - Metrics:    {Colors.GREY}✖ Disabled{Colors.RESET}")
         print(f"    - Interval:   {self.config.system.check_interval}s")
 
         # Documentation footer

--- a/src/main.py
+++ b/src/main.py
@@ -389,8 +389,18 @@ class EmailSecurityPipeline:
     def _print_configuration_summary(self):
         """Print a summary of the current configuration."""
         print(f"\n{Colors.BOLD}📊 System Configuration:{Colors.RESET}")
+        self._print_accounts_summary()
+        self._print_analysis_summary()
+        self._print_alerts_summary()
+        self._print_system_summary()
 
-        # Accounts
+        # Documentation footer
+        print(
+            f"\n📚 {Colors.GREY}For help, see README.md or OUTLOOK_TROUBLESHOOTING.md{Colors.RESET}\n"
+        )
+
+    def _print_accounts_summary(self):
+        """Print accounts configuration summary."""
         print(f"  📧 {Colors.CYAN}Monitored Accounts:{Colors.RESET}")
         for account in self.config.email_accounts:
             status = (
@@ -400,7 +410,8 @@ class EmailSecurityPipeline:
             )
             print(f"    - {account.provider.title()}: {account.email} ({status})")
 
-        # Analysis
+    def _print_analysis_summary(self):
+        """Print analysis layers configuration summary."""
         print(f"  🔍 {Colors.CYAN}Analysis Layers:{Colors.RESET}")
         print(
             f"    - Spam Detection:   {Colors.GREEN}✔ Active{Colors.RESET} "
@@ -423,7 +434,8 @@ class EmailSecurityPipeline:
         )
         print(f"    - Media Check:      {media_status} (Deepfake: {deepfake_status})")
 
-        # Alerts
+    def _print_alerts_summary(self):
+        """Print alert channels configuration summary."""
         print(f"  🔔 {Colors.CYAN}Alert Channels:{Colors.RESET}")
         channels = []
         if self.config.alerts.console:
@@ -440,6 +452,8 @@ class EmailSecurityPipeline:
                 f"    - {Colors.GREY}✖ Disabled{Colors.RESET}: {Colors.YELLOW}None{Colors.RESET}"
             )
 
+    def _print_system_summary(self):
+        """Print system configuration summary."""
         print(f"  ⚙️ {Colors.CYAN}System:{Colors.RESET}")
         print(f"    - Log Level:  {self.config.system.log_level}")
         print(f"    - Log Format: {self.config.system.log_format}")
@@ -448,11 +462,6 @@ class EmailSecurityPipeline:
         else:
             print(f"    - Metrics:    {Colors.GREY}✖ Disabled{Colors.RESET}")
         print(f"    - Interval:   {self.config.system.check_interval}s")
-
-        # Documentation footer
-        print(
-            f"\n📚 {Colors.GREY}For help, see README.md or OUTLOOK_TROUBLESHOOTING.md{Colors.RESET}\n"
-        )
 
 
 from src.app_runner import AppRunner

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -210,9 +210,7 @@ class AlertSystem:
         dispatched = False
         for attempt in range(self.MAX_DISPATCH_RETRIES):
             try:
-                await asyncio.wait_for(
-                    self._dispatch_alert_async(report), timeout=10.0
-                )
+                await asyncio.wait_for(self._dispatch_alert_async(report), timeout=10.0)
                 dispatched = True
                 break
             except asyncio.TimeoutError:

--- a/test.py
+++ b/test.py
@@ -1,6 +1,0 @@
-from src.utils.sanitization import sanitize_for_logging
-
-# A string containing \n and an unprintable \x00 character
-text = "Hello\nWorld\x00"
-
-print(repr(sanitize_for_logging(text)))


### PR DESCRIPTION
## 💡 What
The UX enhancement added standard color-coding (`Colors.GREEN`, `Colors.GREY`) to the `deepfake_status`, `channels`, and `Metrics` outputs in the CLI's configuration summary during startup. It also introduces a clear "✖ Disabled" output for metrics and channels instead of completely omitting the status or stating "✖ Enabled: None".

## 🎯 Why
This solves a visual inconsistency in the terminal interface where some configuration settings were colored and had clear enabled/disabled indicators, while others (like Deepfake, Channels, and Metrics) lacked color or only printed when enabled. Providing a consistent visual hierarchy allows users to scan the configuration state more quickly and confidently.

## 📸 Before/After
**Before:**
```
    - Media Check:      ✔ Active (Deepfake: ✔ Enabled)
  🔔 Alert Channels:
    - ✔ Enabled: Console
  ⚙️ System:
    - Metrics:    ✔ Enabled
```

**After:**
```
    - Media Check:      ✔ Active (Deepfake: ✔ Enabled)  # (with GREEN color applied)
  🔔 Alert Channels:
    - ✔ Enabled: Console  # (with GREEN color applied)
  ⚙️ System:
    - Metrics:    ✖ Disabled  # (with GREY color applied when false)
```

## ♿ Accessibility
Improves CLI scannability and reduces cognitive load by maintaining consistent visual indicators for binary states. Screen readers and standard logs are unaffected due to existing `Colors` fallback logic.

---
*PR created automatically by Jules for task [1162336938819170424](https://jules.google.com/task/1162336938819170424) started by @abhimehro*