### PR TITLE
🎨 Palette: Ensure textual statuses in CLI output use consistent semantic colors and indicators

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-17 - Semantic colors and visual indicators for textual statuses
+**Learning:** In complex CLI configurations summaries, plain text indicating "Enabled" or "Disabled" state may lack visual distinctiveness, resulting in poor scanability. Combining semantic ANSI color codes (e.g., green for positive states, grey for negative states) with visual symbols ensures immediate visual recognition for accessibility.
+**Action:** Consistently pair textual statuses like "Active/Enabled" and "Disabled/None" with corresponding symbols (`✔`/`✖`) and colors (`Colors.GREEN`/`Colors.GREY`) in CLI outputs.

--- a/payload.json
+++ b/payload.json
@@ -1,4 +1,6 @@
 {
-  "title": "🛡️ Sentinel: [CRITICAL] Fix insecure deserialization in Hugging Face models",
-  "body": "🚨 **Severity:** CRITICAL\n💡 **Vulnerability:** Hugging Face models and tokenizers in `nlp_analyzer.py` were loaded without enforcing the `safetensors` format, making them susceptible to arbitrary code execution via malicious Pickle files.\n🎯 **Impact:** If malicious weights are provided or a supply-chain attack occurs, loading unsafe models could result in Remote Code Execution (RCE) on the host running the pipeline.\n🔧 **Fix:** Added `use_safetensors=True` to the `AutoTokenizer.from_pretrained` and `AutoModelForSequenceClassification.from_pretrained` calls.\n✅ **Verification:** Verified by running `pytest tests/test_nlp_analyzer.py` which passes correctly without regressions."
+  "title": "🎨 Palette: Ensure textual statuses in CLI output use consistent semantic colors and indicators",
+  "body": "💡 **What:** Added `Colors.GREEN`/`Colors.GREY` semantic coloring and `✔`/`✖` visual indicators to the remaining textual statuses in `src/main.py` (`deepfake_status` and `channels` output) to match existing CLI styling.\n🎯 **Why:** To improve the scanability of complex configuration summaries and make it easier to distinguish enabled vs. disabled features at a glance.\n♿ **Accessibility:** Combining distinct visual symbols with semantic text coloring prevents information loss for colorblind users and reduces cognitive load during fast visual scans.",
+  "head": "palette/semantic-cli-colors",
+  "base": "main"
 }

--- a/src/main.py
+++ b/src/main.py
@@ -426,9 +426,9 @@ class EmailSecurityPipeline:
             else f"{Colors.GREY}✖ Disabled{Colors.RESET}"
         )
         deepfake_status = (
-            f"✔ Enabled"
+            f"{Colors.GREEN}✔ Enabled{Colors.RESET}"
             if self.config.analysis.deepfake_detection_enabled
-            else "✖ Disabled"
+            else f"{Colors.GREY}✖ Disabled{Colors.RESET}"
         )
         print(f"    - Media Check:      {media_status} (Deepfake: {deepfake_status})")
 
@@ -443,9 +443,11 @@ class EmailSecurityPipeline:
             channels.append("Slack")
 
         if channels:
-            print(f"    - ✔ Enabled: {', '.join(channels)}")
+            print(f"    - {Colors.GREEN}✔ Enabled{Colors.RESET}: {', '.join(channels)}")
         else:
-            print(f"    - ✖ Enabled: {Colors.YELLOW}None{Colors.RESET}")
+            print(
+                f"    - {Colors.GREY}✖ Disabled{Colors.RESET}: {Colors.YELLOW}None{Colors.RESET}"
+            )
 
         print(f"  ⚙️ {Colors.CYAN}System:{Colors.RESET}")
         print(f"    - Log Level:  {self.config.system.log_level}")


### PR DESCRIPTION
💡 **What:** Added `Colors.GREEN`/`Colors.GREY` semantic coloring and `✔`/`✖` visual indicators to the remaining textual statuses in `src/main.py` (`deepfake_status` and `channels` output) to match existing CLI styling.
🎯 **Why:** To improve the scanability of complex configuration summaries and make it easier to distinguish enabled vs. disabled features at a glance.
♿ **Accessibility:** Combining distinct visual symbols with semantic text coloring prevents information loss for colorblind users and reduces cognitive load during fast visual scans.

---
*PR created automatically by Jules for task [9172521637953136630](https://jules.google.com/task/9172521637953136630) started by @abhimehro*