### PR TITLE
🎨 Palette: Add explicit progress bounds during sequential item processing

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -146,3 +146,7 @@
 ## 2024-04-17 - Semantic colors and visual indicators for textual statuses
 **Learning:** In complex CLI configurations summaries, plain text indicating "Enabled" or "Disabled" state may lack visual distinctiveness, resulting in poor scanability. Combining semantic ANSI color codes (e.g., green for positive states, grey for negative states) with visual symbols ensures immediate visual recognition for accessibility.
 **Action:** Consistently pair textual statuses like "Active/Enabled" and "Disabled/None" with corresponding symbols (`✔`/`✖`) and colors (`Colors.GREEN`/`Colors.GREY`) in CLI outputs.
+
+## 2026-11-10 - Progress Bounds for Sequential Item Processing
+**Learning:** Sequential processing of a batch of items (like analyzing 10 emails) without indicating progress causes user anxiety, as they don't know how long the process will take or if it's stuck. Adding explicit bounds (e.g., "[1/10]") reduces this anxiety by setting clear expectations.
+**Action:** Always include explicit bounds (like `[current_index/total_items]`) in log messages when a CLI application processes a batch of items sequentially to set clear expectations and improve UX.

--- a/payload.json
+++ b/payload.json
@@ -1,6 +1,6 @@
 {
-  "title": "🎨 Palette: Ensure textual statuses in CLI output use consistent semantic colors and indicators",
-  "body": "💡 **What:** Added `Colors.GREEN`/`Colors.GREY` semantic coloring and `✔`/`✖` visual indicators to the remaining textual statuses in `src/main.py` (`deepfake_status` and `channels` output) to match existing CLI styling.\n🎯 **Why:** To improve the scanability of complex configuration summaries and make it easier to distinguish enabled vs. disabled features at a glance.\n♿ **Accessibility:** Combining distinct visual symbols with semantic text coloring prevents information loss for colorblind users and reduces cognitive load during fast visual scans.",
-  "head": "palette/semantic-cli-colors",
+  "title": "🎨 Palette: Add explicit progress bounds during sequential item processing",
+  "body": "💡 **What:** Added dynamic `[current/total]` progress bounds to the log prefix during sequential email analysis.\n\n🎯 **Why:** Sequential processing of a batch of items (like analyzing 10 emails) without indicating progress causes user anxiety, as they don't know how long the process will take or if it's stuck. Adding explicit bounds (e.g., `[1/10]`) reduces this anxiety by setting clear expectations.\n\n♿ **Accessibility:** Reduces cognitive load by providing clear contextual bounds instead of requiring the user to guess processing status.\n\n*(Also fixed a `TypeError` where `_analyze_email` was being called with invalid keyword arguments)*",
+  "head": "palette-progress-bounds",
   "base": "main"
 }

--- a/src/main.py
+++ b/src/main.py
@@ -237,7 +237,7 @@ class EmailSecurityPipeline:
                     total_emails = len(emails)
                     for i, email_data in enumerate(emails, 1):
                         self._analyze_email(
-                            email_data, current_idx=i, total_emails=total_emails
+                            email_data, log_prefix=f"[{i}/{total_emails}] "
                         )
 
                 # Log metrics summary periodically (every 10 iterations)


### PR DESCRIPTION
💡 **What:** Added dynamic `[current/total]` progress bounds to the log prefix during sequential email analysis.

🎯 **Why:** Sequential processing of a batch of items (like analyzing 10 emails) without indicating progress causes user anxiety, as they don't know how long the process will take or if it's stuck. Adding explicit bounds (e.g., `[1/10]`) reduces this anxiety by setting clear expectations.

♿ **Accessibility:** Reduces cognitive load by providing clear contextual bounds instead of requiring the user to guess processing status.

*(Also fixed a `TypeError` where `_analyze_email` was being called with invalid keyword arguments)*

---
*PR created automatically by Jules for task [7042194629687483815](https://jules.google.com/task/7042194629687483815) started by @abhimehro*