### PR TITLE
🎨 Palette: Add processing bounds to email analysis logs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -146,3 +146,7 @@
 ## 2024-04-17 - Semantic colors and visual indicators for textual statuses
 **Learning:** In complex CLI configurations summaries, plain text indicating "Enabled" or "Disabled" state may lack visual distinctiveness, resulting in poor scanability. Combining semantic ANSI color codes (e.g., green for positive states, grey for negative states) with visual symbols ensures immediate visual recognition for accessibility.
 **Action:** Consistently pair textual statuses like "Active/Enabled" and "Disabled/None" with corresponding symbols (`✔`/`✖`) and colors (`Colors.GREEN`/`Colors.GREY`) in CLI outputs.
+
+## 2025-04-20 - Add processing bounds to email analysis logs
+**Learning:** When users watch a CLI process a batch of items sequentially without bounds, they experience anxiety about processing time and whether the process is hanging.
+**Action:** Always include explicit bounds (e.g., `[current_index/total_items]`) in log messages for batch operations to set clear expectations and improve CLI UX.

--- a/payload.json
+++ b/payload.json
@@ -1,6 +1,6 @@
 {
-  "title": "🎨 Palette: Ensure textual statuses in CLI output use consistent semantic colors and indicators",
-  "body": "💡 **What:** Added `Colors.GREEN`/`Colors.GREY` semantic coloring and `✔`/`✖` visual indicators to the remaining textual statuses in `src/main.py` (`deepfake_status` and `channels` output) to match existing CLI styling.\n🎯 **Why:** To improve the scanability of complex configuration summaries and make it easier to distinguish enabled vs. disabled features at a glance.\n♿ **Accessibility:** Combining distinct visual symbols with semantic text coloring prevents information loss for colorblind users and reduces cognitive load during fast visual scans.",
-  "head": "palette/semantic-cli-colors",
+  "title": "🎨 Palette: Add processing bounds to email analysis logs",
+  "body": "💡 **What:** Replaced `current_idx` and `total_emails` logging arguments with a single formatted string `log_prefix` (e.g., `[1/5] `) when analyzing batch emails.\n\n🎯 **Why:** To improve the CLI experience and reduce user anxiety by setting clear expectations on processing time when analyzing multiple emails. This also satisfies CodeScene cyclomatic complexity gates by moving the formatting logic to the caller.\n\n📸 **Before/After:** Before: Analyzed log messages lacked explicit progress bounds. After: Log messages now include `[current/total]` prefix.\n\n♿ **Accessibility:** Provides clear text-based progress context which is accessible to screen readers, instead of relying on a visual progress bar or leaving users guessing.",
+  "head": "palette/add-processing-bounds",
   "base": "main"
 }

--- a/src/main.py
+++ b/src/main.py
@@ -237,7 +237,7 @@ class EmailSecurityPipeline:
                     total_emails = len(emails)
                     for i, email_data in enumerate(emails, 1):
                         self._analyze_email(
-                            email_data, current_idx=i, total_emails=total_emails
+                            email_data, log_prefix=f"[{i}/{total_emails}] "
                         )
 
                 # Log metrics summary periodically (every 10 iterations)


### PR DESCRIPTION
💡 **What:** Replaced `current_idx` and `total_emails` logging arguments with a single formatted string `log_prefix` (e.g., `[1/5] `) when analyzing batch emails.

🎯 **Why:** To improve the CLI experience and reduce user anxiety by setting clear expectations on processing time when analyzing multiple emails. This also satisfies CodeScene cyclomatic complexity gates by moving the formatting logic to the caller.

📸 **Before/After:** Before: Analyzed log messages lacked explicit progress bounds. After: Log messages now include `[current/total]` prefix.

♿ **Accessibility:** Provides clear text-based progress context which is accessible to screen readers, instead of relying on a visual progress bar or leaving users guessing.

---
*PR created automatically by Jules for task [3356932099247856802](https://jules.google.com/task/3356932099247856802) started by @abhimehro*