### PR TITLE
🎨 Palette: Add explicit progress bounds to email processing logs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -146,3 +146,6 @@
 ## 2024-04-17 - Semantic colors and visual indicators for textual statuses
 **Learning:** In complex CLI configurations summaries, plain text indicating "Enabled" or "Disabled" state may lack visual distinctiveness, resulting in poor scanability. Combining semantic ANSI color codes (e.g., green for positive states, grey for negative states) with visual symbols ensures immediate visual recognition for accessibility.
 **Action:** Consistently pair textual statuses like "Active/Enabled" and "Disabled/None" with corresponding symbols (`✔`/`✖`) and colors (`Colors.GREEN`/`Colors.GREY`) in CLI outputs.
+## 2024-10-24 - Explicit Progress Bounds in CLI Logging
+**Learning:** For command-line interfaces processing a batch of items sequentially, indicating progress visually reduces user anxiety. Adding a progress fraction like `[current_index/total_items]` dynamically provides clear boundaries on completion without overly polluting the log structure.
+**Action:** Always compute bounds string prefixes explicitly in callers where looping logic occurs and simply pass them as `log_prefix` to reusable methods that log progress context.

--- a/payload.json
+++ b/payload.json
@@ -1,6 +1,0 @@
-{
-  "title": "🎨 Palette: Ensure textual statuses in CLI output use consistent semantic colors and indicators",
-  "body": "💡 **What:** Added `Colors.GREEN`/`Colors.GREY` semantic coloring and `✔`/`✖` visual indicators to the remaining textual statuses in `src/main.py` (`deepfake_status` and `channels` output) to match existing CLI styling.\n🎯 **Why:** To improve the scanability of complex configuration summaries and make it easier to distinguish enabled vs. disabled features at a glance.\n♿ **Accessibility:** Combining distinct visual symbols with semantic text coloring prevents information loss for colorblind users and reduces cognitive load during fast visual scans.",
-  "head": "palette/semantic-cli-colors",
-  "base": "main"
-}

--- a/src/main.py
+++ b/src/main.py
@@ -237,7 +237,7 @@ class EmailSecurityPipeline:
                     total_emails = len(emails)
                     for i, email_data in enumerate(emails, 1):
                         self._analyze_email(
-                            email_data, current_idx=i, total_emails=total_emails
+                            email_data, log_prefix=f"[{i}/{total_emails}] "
                         )
 
                 # Log metrics summary periodically (every 10 iterations)


### PR DESCRIPTION
🎨 Palette: Add explicit progress bounds to email processing logs

## What
Added an explicit progress bound `[current_idx/total_emails]` prefix to log outputs in `_analyze_email`.

## Why
Providing progress feedback during batch processing operations reduces user anxiety by setting clear expectations on remaining workloads.

---
*PR created automatically by Jules for task [8748199225057373638](https://jules.google.com/task/8748199225057373638) started by @abhimehro*