### PR TITLE
🧪 Jules Daily QA: Fix test_setup_wizard mock_os_open assertion

### DIFF
--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -86,7 +86,6 @@ OUTLOOK_APP_PASSWORD=password
 
         mock_os_open.assert_called_with(
             os.path.abspath(".env"),
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0),
             expected_flags,
             0o600,
         )


### PR DESCRIPTION
Daily Agentic QA found a broken mock assertion in `test_setup_wizard.py` due to an incorrect number of parameters passed to `os.open` in the test. This PR updates the test to match the actual implementation.