### PR TITLE
⚡ Bolt: Faster Video Frame Extraction using Hybrid Seeking

### DIFF
--- a/payload.json
+++ b/payload.json
@@ -1,6 +1,0 @@
-{
-  "title": "⚡ Bolt: Faster Video Frame Extraction using Hybrid Seeking",
-  "body": "💡 What: Replace standard loop with `self._extract_frames_sampled` call.\n🎯 Why: Using `cap.set()` incurs significant decoding overhead for small jumps, while `cap.grab()` is faster.\n📊 Impact: Faster processing for sampled video frame extractions.\n🔬 Measurement: Tested via unit tests and local benchmarks.",
-  "head": "jules-5855862047043928786-4a59fdd2",
-  "base": "main"
-}

--- a/payload.json
+++ b/payload.json
@@ -1,0 +1,6 @@
+{
+  "title": "⚡ Bolt: Faster Video Frame Extraction using Hybrid Seeking",
+  "body": "💡 What: Replace standard loop with `self._extract_frames_sampled` call.\n🎯 Why: Using `cap.set()` incurs significant decoding overhead for small jumps, while `cap.grab()` is faster.\n📊 Impact: Faster processing for sampled video frame extractions.\n🔬 Measurement: Tested via unit tests and local benchmarks.",
+  "head": "jules-5855862047043928786-4a59fdd2",
+  "base": "main"
+}

--- a/src/modules/media_analyzer.py
+++ b/src/modules/media_analyzer.py
@@ -1058,13 +1058,9 @@ class MediaAuthenticityAnalyzer:
                             frames.append(self._resize_frame_if_needed(frame, max_dim))
                         count += 1
                 else:
-                    for i in range(0, total_frames, step):
-                        cap.set(cv2.CAP_PROP_POS_FRAMES, i)
-                        success, frame = cap.read()
-                        if success and frame is not None:
-                            frames.append(self._resize_frame_if_needed(frame, max_dim))
-                        if len(frames) >= max_frames:
-                            break
+                    frames = self._extract_frames_sampled(
+                        cap, total_frames, step, max_frames, max_dim
+                    )
 
             cap.release()
         except Exception as e:


### PR DESCRIPTION
💡 What: Replace standard loop with `self._extract_frames_sampled` call.
🎯 Why: Using `cap.set()` incurs significant decoding overhead for small jumps, while `cap.grab()` is faster.
📊 Impact: Faster processing for sampled video frame extractions.
🔬 Measurement: Tested via unit tests and local benchmarks.