### PR TITLE
🧪 Fix broken mock assertion in test_setup_wizard.py

### DIFF
--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -87,7 +87,6 @@ OUTLOOK_APP_PASSWORD=password
         mock_os_open.assert_called_with(
             os.path.abspath(".env"),
             os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0),
-            expected_flags,
             0o600,
         )
 


### PR DESCRIPTION
Daily Agentic QA found a broken mock assertion in `test_setup_wizard.py` due to an incorrect number of parameters passed to `os.open` in the test. The actual `os.open` implementation in `src/utils/setup_wizard.py` no longer passes `expected_flags`, leading to an `AssertionError` in tests. This PR updates the test assertion to correctly reflect the updated `os.open` parameters and fixes the build.