### PR TITLE
🎨 Palette: Add missing suspicious URLs display to CLI alerts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -152,3 +152,6 @@
 ## 2025-04-24 - Empty States in CLI Lists
 **Learning:** Displaying lists without an explicit empty state in the terminal can leave users confused about whether data is missing or the list is intentionally empty. This is still a good CLI pattern in general, but it only applies when the user can actually reach the list-rendering path.
 **Action:** Add an explicit, friendly empty state with gray or yellow coloring only for lists that are reachable at runtime. For account configuration specifically, the current application validates and exits before rendering a "No accounts configured" summary, so avoid documenting that message as current behavior unless validation changes.
+## 2025-04-30 - Omitted Threat Indicators in CLI
+**Learning:** Omission of nested list values (like suspicious_urls) in CLI views creates a disconnect where underlying threats are detected but visually hidden.
+**Action:** Ensure all list-based threats outputted in external webhooks (like Slack) also have an explicit rendering path in local console alerts.

--- a/pr_payload.json
+++ b/pr_payload.json
@@ -1,0 +1,6 @@
+{
+  "title": "🎨 Palette: Add missing suspicious URLs display to CLI alerts",
+  "body": "💡 What: Added missing CLI display for suspicious_urls in spam alerts.\n🎯 Why: Suspicious URLs were being processed and sent to Slack but were hidden in the local console, leading to reduced threat visibility.\n📸 Before/After: Visual change in the console report for spam.\n♿ Accessibility: N/A",
+  "head": "jules-ux-alert-urls",
+  "base": "main"
+}

--- a/pr_payload.json
+++ b/pr_payload.json
@@ -1,6 +1,0 @@
-{
-  "title": "🎨 Palette: Add missing suspicious URLs display to CLI alerts",
-  "body": "💡 What: Added missing CLI display for suspicious_urls in spam alerts.\n🎯 Why: Suspicious URLs were being processed and sent to Slack but were hidden in the local console, leading to reduced threat visibility.\n📸 Before/After: Visual change in the console report for spam.\n♿ Accessibility: N/A",
-  "head": "jules-ux-alert-urls",
-  "base": "main"
-}

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -282,7 +282,7 @@ class AppRunner:
 
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         if hasattr(os, "O_NOFOLLOW"):
-            flags |= os.O_NOFOLLOW
+            flags |= getattr(os, "O_NOFOLLOW", 0)
 
         fd = os.open(
             self.config_file,

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -490,6 +490,7 @@ class AlertSystem:
 
         # Spam
         print_section_header("📧 SPAM", report.spam_analysis)
+        has_spam = False
         if report.spam_analysis.get("indicators"):
             for indicator in report.spam_analysis["indicators"][
                 : self.MAX_SPAM_INDICATORS_DISPLAY
@@ -499,7 +500,19 @@ class AlertSystem:
                     risk_color,
                     indent=3,
                 )
-        else:
+            has_spam = True
+
+        if report.spam_analysis.get("suspicious_urls"):
+            self._print_alert_row(
+                f"{Colors.BOLD}Suspicious URLs:{Colors.RESET}", risk_color, indent=3
+            )
+            for url in report.spam_analysis["suspicious_urls"][:3]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.RED)} {url}", risk_color, indent=5
+                )
+            has_spam = True
+
+        if not has_spam:
             self._print_alert_row(
                 f"{Colors.colorize('✓', Colors.GREEN)} No suspicious patterns",
                 risk_color,

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -82,11 +82,10 @@ OUTLOOK_APP_PASSWORD=password
         # Verify permissions were set (0o600 = 384 in decimal)
         expected_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
         if hasattr(os, "O_NOFOLLOW"):
-            expected_flags |= os.O_NOFOLLOW
+            expected_flags |= getattr(os, "O_NOFOLLOW", 0)
 
         mock_os_open.assert_called_with(
             os.path.abspath(".env"),
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0),
             expected_flags,
             0o600,
         )


### PR DESCRIPTION
💡 What: Added missing CLI display for suspicious_urls in spam alerts.
🎯 Why: Suspicious URLs were being processed and sent to Slack but were hidden in the local console, leading to reduced threat visibility.
📸 Before/After: Visual change in the console report for spam.
♿ Accessibility: N/A