### PR TITLE
⚡ Bolt: Add instance-level TTLCache for SpamAnalyzer URL parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -50,3 +50,7 @@
 
 **Learning:** In `src/modules/media_analyzer.py`, seeking to specific video frames via `cap.set(cv2.CAP_PROP_POS_FRAMES, i)` incurs significant decoding overhead and is slow for small forward jumps. However, for large jumps, `cap.grab()` becomes slower than `cap.set()`.
 **Action:** Implement a hybrid approach: use sequential `cap.grab()` for small intervals (e.g., <= 30 frames) to avoid redundant decoding, and fall back to `cap.set()` for larger intervals.
+
+## 2025-08-01 - [Performance Optimization: Cross-email URL caching]
+**Learning:** The URL analysis in the SpamAnalyzer can be a bottleneck. The previous local cache only worked for identical URLs within a single email. Re-parsing the same suspicious domains across thousands of emails incurs heavy regex/parsing overhead.
+**Action:** Introduced an instance-level `TTLCache` to memoize the URL parsing/scoring across multiple emails. Local caching was retained for intra-email fast paths.

--- a/src/modules/spam_analyzer.py
+++ b/src/modules/spam_analyzer.py
@@ -361,32 +361,18 @@ class SpamAnalyzer:
 
         for url in urls:
             if url in local_checked_urls:
-                # Retrieve cached results
-                url_score, append_count = local_checked_urls[url]
-                score += url_score
-                # Replicate the exact number of appends
-                if append_count > 0:
-                    suspicious.extend([url] * append_count)
-                continue
+                result = local_checked_urls[url]
+            else:
+                result = self._url_cache.get(url)
+                if result is None:
+                    result = self._evaluate_url(url)
+                    self._url_cache.put(url, result)
+                local_checked_urls[url] = result
 
-            cached_result = self._url_cache.get(url)
-            if cached_result is not None:
-                url_score, append_count = cached_result
-                score += url_score
-                if append_count > 0:
-                    suspicious.extend([url] * append_count)
-                local_checked_urls[url] = cached_result
-                continue
-
-            current_url_score, append_count = self._evaluate_url(url)
-
-            score += current_url_score
+            url_score, append_count = result
+            score += url_score
             if append_count > 0:
                 suspicious.extend([url] * append_count)
-
-            result_tuple = (current_url_score, append_count)
-            local_checked_urls[url] = result_tuple
-            self._url_cache.put(url, result_tuple)
 
         return score, suspicious
 

--- a/src/modules/spam_analyzer.py
+++ b/src/modules/spam_analyzer.py
@@ -351,6 +351,19 @@ class SpamAnalyzer:
         except Exception:
             return 0.0, 0
 
+    def _get_cached_url_result(self, url: str, local_checked_urls: dict) -> Tuple[float, int]:
+        """Retrieve URL evaluation from local cache, instance cache, or compute it."""
+        if url in local_checked_urls:
+            return local_checked_urls[url]
+            
+        result = self._url_cache.get(url)
+        if result is None:
+            result = self._evaluate_url(url)
+            self._url_cache.put(url, result)
+            
+        local_checked_urls[url] = result
+        return result
+
     def _check_urls(self, urls: List[str]) -> Tuple[float, List[str]]:
         """Check for suspicious URLs."""
         score = 0.0
@@ -360,16 +373,7 @@ class SpamAnalyzer:
         local_checked_urls = {}
 
         for url in urls:
-            if url in local_checked_urls:
-                result = local_checked_urls[url]
-            else:
-                result = self._url_cache.get(url)
-                if result is None:
-                    result = self._evaluate_url(url)
-                    self._url_cache.put(url, result)
-                local_checked_urls[url] = result
-
-            url_score, append_count = result
+            url_score, append_count = self._get_cached_url_result(url, local_checked_urls)
             score += url_score
             if append_count > 0:
                 suspicious.extend([url] * append_count)

--- a/src/modules/spam_analyzer.py
+++ b/src/modules/spam_analyzer.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 from ..utils.pattern_compiler import compile_named_group_pattern, compile_patterns
 from ..utils.threat_scoring import calculate_risk_level
+from ..utils.caching import TTLCache
 from .email_data import EmailData
 
 
@@ -158,6 +159,7 @@ class SpamAnalyzer:
         """
         self.config = config
         self.logger = logging.getLogger("SpamAnalyzer")
+        self._url_cache = TTLCache(max_size=2048, ttl_seconds=3600)
 
     def analyze(self, email_data: EmailData) -> SpamAnalysisResult:
         """
@@ -335,17 +337,26 @@ class SpamAnalyzer:
         score = 0.0
         suspicious = []
 
-        # Cache results for unique URLs to avoid re-parsing
-        checked_urls = {}
+        # Local cache for the current email to avoid duplicate work if the same URL appears multiple times
+        local_checked_urls = {}
 
         for url in urls:
-            if url in checked_urls:
+            if url in local_checked_urls:
                 # Retrieve cached results
-                url_score, append_count = checked_urls[url]
+                url_score, append_count = local_checked_urls[url]
                 score += url_score
                 # Replicate the exact number of appends
                 if append_count > 0:
                     suspicious.extend([url] * append_count)
+                continue
+
+            cached_result = self._url_cache.get(url)
+            if cached_result is not None:
+                url_score, append_count = cached_result
+                score += url_score
+                if append_count > 0:
+                    suspicious.extend([url] * append_count)
+                local_checked_urls[url] = cached_result
                 continue
 
             try:
@@ -366,10 +377,12 @@ class SpamAnalyzer:
                 if append_count > 0:
                     suspicious.extend([url] * append_count)
 
-                checked_urls[url] = (current_url_score, append_count)
+                local_checked_urls[url] = (current_url_score, append_count)
+                self._url_cache.put(url, (current_url_score, append_count))
 
             except Exception:
-                checked_urls[url] = (0.0, 0)
+                local_checked_urls[url] = (0.0, 0)
+                self._url_cache.put(url, (0.0, 0))
 
         return score, suspicious
 

--- a/src/modules/spam_analyzer.py
+++ b/src/modules/spam_analyzer.py
@@ -332,6 +332,25 @@ class SpamAnalyzer:
                 indicators.append("Hidden text detected")
         return score, indicators
 
+    def _evaluate_url(self, url: str) -> Tuple[float, int]:
+        """Evaluate a single URL for suspicious characteristics and return its score and match count."""
+        try:
+            parsed = urlparse(url)
+            domain = parsed.netloc
+
+            current_url_score = 0.0
+            append_count = 0
+
+            # Check against combined suspicious patterns first
+            if self.COMBINED_URL_PATTERN.search(domain):
+                current_url_score += 0.5
+                append_count += 1
+
+            return current_url_score, append_count
+
+        except Exception:
+            return 0.0, 0
+
     def _check_urls(self, urls: List[str]) -> Tuple[float, List[str]]:
         """Check for suspicious URLs."""
         score = 0.0
@@ -359,30 +378,15 @@ class SpamAnalyzer:
                 local_checked_urls[url] = cached_result
                 continue
 
-            try:
-                parsed = urlparse(url)
-                domain = parsed.netloc
+            current_url_score, append_count = self._evaluate_url(url)
 
-                current_url_score = 0.0
-                append_count = 0
+            score += current_url_score
+            if append_count > 0:
+                suspicious.extend([url] * append_count)
 
-                # Check against combined suspicious patterns first
-                if self.COMBINED_URL_PATTERN.search(domain):
-                    # If matched, we just mark it. The original code broke after first match
-                    # in the loop, effectively counting only one match per URL from this list.
-                    current_url_score += 0.5
-                    append_count += 1
-
-                score += current_url_score
-                if append_count > 0:
-                    suspicious.extend([url] * append_count)
-
-                local_checked_urls[url] = (current_url_score, append_count)
-                self._url_cache.put(url, (current_url_score, append_count))
-
-            except Exception:
-                local_checked_urls[url] = (0.0, 0)
-                self._url_cache.put(url, (0.0, 0))
+            result_tuple = (current_url_score, append_count)
+            local_checked_urls[url] = result_tuple
+            self._url_cache.put(url, result_tuple)
 
         return score, suspicious
 


### PR DESCRIPTION
💡 What: Added a TTLCache to memoize parsed URL scores across emails.
🎯 Why: Avoids re-parsing the same suspicious domains across multiple emails, which was a major regex overhead.
📊 Impact: Fast path caching prevents redundant work, saving execution time when evaluating large batches of similar emails.
🔬 Measurement: Tested via test_spam_analyzer_optimization.py which shows equivalence but saves duplicate parsing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->