### PR TITLE
🔒 Security Fix: Explicit verify=True in requests.post

### DIFF
--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -814,6 +814,7 @@ class AlertSystem:
                 headers={"Content-Type": "application/json"},
                 timeout=10,
                 allow_redirects=False,
+                verify=True,
             )
 
             if response.status_code == 200:
@@ -1133,6 +1134,7 @@ class AlertSystem:
                 headers={"Content-Type": "application/json"},
                 timeout=10,
                 allow_redirects=False,
+                verify=True,
             )
 
             if response.status_code == 200:


### PR DESCRIPTION
### 🎯 What:
The vulnerability fixed is the missing explicit `verify=True` in `requests.post` calls in `src/modules/alert_system.py`.

### ⚠️ Risk:
While `requests` library currently defaults to `verify=True`, explicitly setting it ensures that TLS certificate verification is always enabled. This prevents potential MITM attacks if the default behavior changes or is overridden by environment-specific configurations.

### 🛡️ Solution:
Added `verify=True` to the `requests.post` calls in both `_webhook_alert` and `_slack_alert` methods.

### ✅ Verification:
- Created a custom verification script `verify_fix.py` that mocks the `requests` library and asserts that the `verify` parameter is set to `True`.
- Ran the full suite of relevant tests (`tests/test_alert_*.py`) using a custom test runner `run_tests.py` that mocks dependencies unavailable in the environment. All tests passed.

---
*PR created automatically by Jules for task [11316914226071857246](https://jules.google.com/task/11316914226071857246) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->