### PR TITLE
🎨 Palette: Add missing suspicious URLs display to CLI alerts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -152,3 +152,6 @@
 ## 2025-04-24 - Empty States in CLI Lists
 **Learning:** Displaying lists without an explicit empty state in the terminal can leave users confused about whether data is missing or the list is intentionally empty. This is still a good CLI pattern in general, but it only applies when the user can actually reach the list-rendering path.
 **Action:** Add an explicit, friendly empty state with gray or yellow coloring only for lists that are reachable at runtime. For account configuration specifically, the current application validates and exits before rendering a "No accounts configured" summary, so avoid documenting that message as current behavior unless validation changes.
+## 2025-04-30 - Omitted Threat Indicators in CLI
+**Learning:** Omission of nested list values (like suspicious_urls) in CLI views creates a disconnect where underlying threats are detected but visually hidden.
+**Action:** Ensure all list-based threats outputted in external webhooks (like Slack) also have an explicit rendering path in local console alerts.

--- a/pr_payload.json
+++ b/pr_payload.json
@@ -1,0 +1,6 @@
+{
+  "title": "🎨 Palette: Add missing suspicious URLs display to CLI alerts",
+  "body": "💡 What: Added missing CLI display for suspicious_urls in spam alerts.\n🎯 Why: Suspicious URLs were being processed and sent to Slack but were hidden in the local console, leading to reduced threat visibility.\n📸 Before/After: Visual change in the console report for spam.\n♿ Accessibility: N/A",
+  "head": "jules-ux-alert-urls",
+  "base": "main"
+}

--- a/pr_payload.json
+++ b/pr_payload.json
@@ -1,6 +1,0 @@
-{
-  "title": "🎨 Palette: Add missing suspicious URLs display to CLI alerts",
-  "body": "💡 What: Added missing CLI display for suspicious_urls in spam alerts.\n🎯 Why: Suspicious URLs were being processed and sent to Slack but were hidden in the local console, leading to reduced threat visibility.\n📸 Before/After: Visual change in the console report for spam.\n♿ Accessibility: N/A",
-  "head": "jules-ux-alert-urls",
-  "base": "main"
-}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ requests>=2.31.0
 
 # Optional: NLP and ML (uncomment when needed)
 # These are large libraries and not required for core functionality.
-sentencepiece==0.2.1
-torch>=2.9.0
-transformers==5.0.0rc3
+# sentencepiece==0.2.1
+# torch>=2.9.0
+# transformers==5.0.0rc3
 # pytest-cov==4.1.0
 # black==23.11.0
 # flake8==6.1.0

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -282,7 +282,7 @@ class AppRunner:
 
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         if hasattr(os, "O_NOFOLLOW"):
-            flags |= os.O_NOFOLLOW
+            flags |= getattr(os, "O_NOFOLLOW", 0)
 
         fd = os.open(
             self.config_file,

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -280,9 +280,7 @@ class AppRunner:
         with open(".env.example", "rb") as src:
             content = src.read()
 
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-        if hasattr(os, "O_NOFOLLOW"):
-            flags |= getattr(os, "O_NOFOLLOW", 0)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
 
         fd = os.open(
             self.config_file,

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -467,6 +467,15 @@ class AlertSystem:
         )
         self._print_alert_row(f"{Colors.colorize(bar, meter_color)}", risk_color)
 
+    def _print_section_header(self, title: str, analysis_data: dict, risk_color: str):
+        level = analysis_data.get("risk_level", "unknown")
+        color = Colors.get_risk_color(level)
+        symbol = Colors.get_risk_symbol(level)
+        self._print_alert_row(
+            f"{Colors.BOLD}{title}:{Colors.RESET} {Colors.colorize(level.upper(), color)} {symbol}",
+            risk_color,
+        )
+
     def _print_analysis_details(
         self, report: ThreatReport, width: int, risk_color: str
     ):
@@ -478,18 +487,8 @@ class AlertSystem:
         )
         self._print_alert_row("", risk_color)
 
-        # Helper for analysis sections
-        def print_section_header(title, analysis_data):
-            level = analysis_data.get("risk_level", "unknown")
-            color = Colors.get_risk_color(level)
-            symbol = Colors.get_risk_symbol(level)
-            self._print_alert_row(
-                f"{Colors.BOLD}{title}:{Colors.RESET} {Colors.colorize(level.upper(), color)} {symbol}",
-                risk_color,
-            )
-
         # Spam
-        print_section_header("📧 SPAM", report.spam_analysis)
+        self._print_section_header("📧 SPAM", report.spam_analysis, risk_color)
         has_spam = False
         if report.spam_analysis.get("indicators"):
             for indicator in report.spam_analysis["indicators"][
@@ -521,7 +520,7 @@ class AlertSystem:
         self._print_alert_row("", risk_color)
 
         # NLP
-        print_section_header("🧠 NLP", report.nlp_analysis)
+        self._print_section_header("🧠 NLP", report.nlp_analysis, risk_color)
         nlp = report.nlp_analysis
         has_nlp = False
         if nlp.get("social_engineering_indicators"):
@@ -559,7 +558,7 @@ class AlertSystem:
         self._print_alert_row("", risk_color)
 
         # Media
-        print_section_header("📎 MEDIA", report.media_analysis)
+        self._print_section_header("📎 MEDIA", report.media_analysis, risk_color)
         media = report.media_analysis
         if media.get("file_type_warnings"):
             self._print_alert_row(

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -70,6 +70,7 @@ class AlertSystem:
     MAX_SPAM_INDICATORS_DISPLAY = 5
     MAX_NLP_INDICATORS_DISPLAY = 3
     MAX_MEDIA_WARNINGS_DISPLAY = 3
+    MAX_SUSPICIOUS_URLS_DISPLAY = 3
 
     # Maximum dispatch attempts per alert before giving up (worker mode).
     MAX_DISPATCH_RETRIES = 3
@@ -505,9 +506,16 @@ class AlertSystem:
             self._print_alert_row(
                 f"{Colors.BOLD}Suspicious URLs:{Colors.RESET}", risk_color, indent=3
             )
-            for url in report.spam_analysis["suspicious_urls"][:3]:
+            for url in report.spam_analysis["suspicious_urls"][
+                : self.MAX_SUSPICIOUS_URLS_DISPLAY
+            ]:
+                # Sanitize URLs to prevent terminal escape sequence injection;
+                # these values originate from attacker-controlled email bodies.
+                sanitized_url = self._sanitize_text(url, csv_safe=True)
                 self._print_alert_row(
-                    f"{Colors.colorize('•', Colors.RED)} {url}", risk_color, indent=5
+                    f"{Colors.colorize('•', Colors.RED)} {sanitized_url}",
+                    risk_color,
+                    indent=5,
                 )
             has_spam = True
 

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -490,6 +490,7 @@ class AlertSystem:
 
         # Spam
         print_section_header("📧 SPAM", report.spam_analysis)
+        has_spam = False
         if report.spam_analysis.get("indicators"):
             for indicator in report.spam_analysis["indicators"][
                 : self.MAX_SPAM_INDICATORS_DISPLAY
@@ -499,7 +500,19 @@ class AlertSystem:
                     risk_color,
                     indent=3,
                 )
-        else:
+            has_spam = True
+
+        if report.spam_analysis.get("suspicious_urls"):
+            self._print_alert_row(
+                f"{Colors.BOLD}Suspicious URLs:{Colors.RESET}", risk_color, indent=3
+            )
+            for url in report.spam_analysis["suspicious_urls"][:3]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.RED)} {url}", risk_color, indent=5
+                )
+            has_spam = True
+
+        if not has_spam:
             self._print_alert_row(
                 f"{Colors.colorize('✓', Colors.GREEN)} No suspicious patterns",
                 risk_color,

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -82,11 +82,10 @@ OUTLOOK_APP_PASSWORD=password
         # Verify permissions were set (0o600 = 384 in decimal)
         expected_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
         if hasattr(os, "O_NOFOLLOW"):
-            expected_flags |= os.O_NOFOLLOW
+            expected_flags |= getattr(os, "O_NOFOLLOW", 0)
 
         mock_os_open.assert_called_with(
             os.path.abspath(".env"),
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0),
             expected_flags,
             0o600,
         )


### PR DESCRIPTION
💡 What: Added missing CLI display for suspicious_urls in spam alerts.
🎯 Why: Suspicious URLs were being processed and sent to Slack but were hidden in the local console, leading to reduced threat visibility.
📸 Before/After: Visual change in the console report for spam.
♿ Accessibility: N/A

Also fixes CI failures:
- Fixed test for setup_wizard because O_NOFOLLOW is not always defined in `os`.
- Fixed O_NOFOLLOW in app_runner.
- Comment out ML dependencies in requirements.txt to fix CI submit-pypi.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->