### PR TITLE
🎨 Palette: Improve empty states in configuration summary

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -155,3 +155,6 @@
 ## 2025-04-30 - Omitted Threat Indicators in CLI
 **Learning:** Omission of nested list values (like suspicious_urls) in CLI views creates a disconnect where underlying threats are detected but visually hidden.
 **Action:** Ensure all list-based threats outputted in external webhooks (like Slack) also have an explicit rendering path in local console alerts.
+## 2025-05-05 - Avoid Double Negative Empty States
+**Learning:** Displaying empty states like "Disabled: None" is confusing because it's a double negative that requires cognitive parsing to understand that "no channels are configured".
+**Action:** Use explicit, clear language like "No alert channels configured" for empty states, paired with a distinct color (e.g., YELLOW) and a warning symbol (⚠) to draw attention to missing configuration.

--- a/src/main.py
+++ b/src/main.py
@@ -402,9 +402,7 @@ class EmailSecurityPipeline:
         # Accounts
         print(f"  📧 {Colors.CYAN}Monitored Accounts:{Colors.RESET}")
         if not self.config.email_accounts:
-            print(
-                f"    - {Colors.colorize('⚠ No accounts configured (Pipeline will idle)', Colors.GREY)}"
-            )
+            print(f"    - {Colors.colorize('⚠ No accounts configured', Colors.YELLOW)}")
         else:
             for account in self.config.email_accounts:
                 status = (
@@ -451,7 +449,7 @@ class EmailSecurityPipeline:
             print(f"    - {Colors.GREEN}✔ Enabled{Colors.RESET}: {', '.join(channels)}")
         else:
             print(
-                f"    - {Colors.GREY}✖ Disabled{Colors.RESET}: {Colors.YELLOW}None{Colors.RESET}"
+                f"    - {Colors.colorize('⚠ No alert channels configured', Colors.YELLOW)}"
             )
 
         print(f"  ⚙️ {Colors.CYAN}System:{Colors.RESET}")


### PR DESCRIPTION
## What
Replaced inaccurate 'Pipeline will idle' and double-negative 'Disabled: None' empty states in the system configuration summary with clear, explicit YELLOW empty states.

## Why
To improve CLI UX by providing immediate, unambiguous visual feedback when configurations are missing, per the project's accessibility and style guidelines.

## Accessibility
Uses `Colors.colorize()` instead of hardcoded ANSI string interpolations to ensure terminal accessibility fallbacks (NO_COLOR) function correctly for screen readers and logging environments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->