### PR TITLE
🎨 Palette: Improve empty state messages in CLI configuration summary

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -155,3 +155,6 @@
 ## 2025-04-30 - Omitted Threat Indicators in CLI
 **Learning:** Omission of nested list values (like suspicious_urls) in CLI views creates a disconnect where underlying threats are detected but visually hidden.
 **Action:** Ensure all list-based threats outputted in external webhooks (like Slack) also have an explicit rendering path in local console alerts.
+## 2025-05-05 - Avoid Double Negative Empty States
+**Learning:** Displaying empty states like "Disabled: None" is confusing because it's a double negative that requires cognitive parsing to understand that "no channels are configured".
+**Action:** Use explicit, clear language like "No alert channels configured" for empty states, paired with a distinct color (e.g., YELLOW) and a warning symbol (⚠) to draw attention to missing configuration.

--- a/src/main.py
+++ b/src/main.py
@@ -402,9 +402,7 @@ class EmailSecurityPipeline:
         # Accounts
         print(f"  📧 {Colors.CYAN}Monitored Accounts:{Colors.RESET}")
         if not self.config.email_accounts:
-            print(
-                f"    - {Colors.colorize('⚠ No accounts configured (Pipeline will idle)', Colors.GREY)}"
-            )
+            print(f"    - {Colors.colorize('⚠ No accounts configured', Colors.YELLOW)}")
         else:
             for account in self.config.email_accounts:
                 status = (
@@ -451,7 +449,7 @@ class EmailSecurityPipeline:
             print(f"    - {Colors.GREEN}✔ Enabled{Colors.RESET}: {', '.join(channels)}")
         else:
             print(
-                f"    - {Colors.GREY}✖ Disabled{Colors.RESET}: {Colors.YELLOW}None{Colors.RESET}"
+                f"    - {Colors.colorize('⚠ No alert channels configured', Colors.YELLOW)}"
             )
 
         print(f"  ⚙️ {Colors.CYAN}System:{Colors.RESET}")


### PR DESCRIPTION
**💡 What:** Replaced confusing double-negative empty state messages (`"Disabled: None"`, `"⚠ No accounts configured (Pipeline will idle)"`) with explicit, friendly warnings (`"⚠ No alert channels configured"`, `"⚠ No accounts configured"`). Updated the Accounts empty state warning to use `Colors.YELLOW` instead of `Colors.GREY`.

**🎯 Why:** "Disabled: None" is a double negative that requires cognitive parsing to understand that no channels are configured. Grey text for missing accounts blends in too much and does not draw proper attention to a critical misconfiguration that prevents the pipeline from doing anything useful. Using yellow (`⚠`) for missing configurations provides consistent, distinct visual feedback.

**♿ Accessibility:** Improves scanability and cognitive accessibility of the configuration summary.

---
*PR created automatically by Jules for task [80040254479486679](https://jules.google.com/task/80040254479486679) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->