### PR TITLE
⚡ Bolt: Use time.monotonic() for TTLCache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -56,3 +56,6 @@
 ## 2024-05-24 - Avoid cap.set() for small jumps in OpenCV
 **Learning:** In OpenCV, `cap.set(cv2.CAP_PROP_POS_FRAMES, i)` incurs heavy decoding overhead for small frame jumps.
 **Action:** Always use a hybrid approach (like `_extract_frames_sampled`) that uses sequential `cap.grab()` for small intervals and `cap.set()` for large ones instead of manual `cap.set()` loops.
+## 2025-05-08 - Fast Caching Optimization
+**Learning:** Python's `datetime.now()` with `timedelta` objects incur high instantiation and garbage collection overhead, which compounds in hot cache eviction loops like `TTLCache`.
+**Action:** Replace `datetime.now()` and `timedelta` with `time.monotonic()` and float arithmetic. This avoids the object creation overhead and is more resilient to system clock adjustments.

--- a/src/utils/caching.py
+++ b/src/utils/caching.py
@@ -17,7 +17,7 @@ importing the full project dependency tree.
 """
 
 import threading
-from datetime import datetime, timedelta
+import time
 from typing import Any, List, Optional
 
 
@@ -47,9 +47,9 @@ class TTLCache:
             raise ValueError(
                 f"ttl_seconds must be a positive integer, got {ttl_seconds}"
             )
-        self._store: dict = {}  # key -> (value, datetime)
+        self._store: dict = {}  # key -> (value, float)
         self._max_size = max_size
-        self._ttl = timedelta(seconds=ttl_seconds)
+        self._ttl = float(ttl_seconds)
         self._lock = threading.Lock()
 
     # ------------------------------------------------------------------
@@ -76,7 +76,7 @@ class TTLCache:
         with self._lock:
             # Remove first so re-insertion places the key at the tail (newest)
             self._store.pop(key, None)
-            self._store[key] = (value, datetime.now())
+            self._store[key] = (value, time.monotonic())
             # Evict oldest entries until we are within the size budget
             while len(self._store) > self._max_size:
                 try:
@@ -103,7 +103,7 @@ class TTLCache:
 
     def keys(self) -> List[str]:
         """Return non-expired keys in LRU order (oldest first, newest last)."""
-        now = datetime.now()
+        now = time.monotonic()
         with self._lock:
             return [k for k, (_, ts) in self._store.items() if now - ts < self._ttl]
 
@@ -115,7 +115,7 @@ class TTLCache:
         if key not in self._store:
             return None
         value, timestamp = self._store[key]
-        if datetime.now() - timestamp >= self._ttl:
+        if time.monotonic() - timestamp >= self._ttl:
             del self._store[key]  # Lazy TTL eviction
             return None
         # Promote to most-recently-used by moving to the tail of the dict

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -11,7 +11,7 @@ class TestTTLCache(unittest.TestCase):
         """Test TTLCache initialization with valid parameters."""
         cache = TTLCache(max_size=100, ttl_seconds=60)
         self.assertEqual(cache._max_size, 100)
-        self.assertEqual(cache._ttl.total_seconds(), 60)
+        self.assertEqual(cache._ttl, 60.0)
 
     def test_initialization_invalid(self):
         """Test TTLCache initialization with invalid parameters."""


### PR DESCRIPTION
💡 **What:** Replaced `datetime.now()` and `timedelta` with `time.monotonic()` and float arithmetic in `TTLCache`.
🎯 **Why:** `datetime.now()` incurs object instantiation and garbage collection overhead, which compounds in hot cache eviction loops.
📊 **Impact:** Reduces object creation overhead and is more resilient to system clock adjustments during LRU/TTL promotions and evictions.
🔬 **Measurement:** Verify tests still pass identically and check overhead through a profiler when heavy LRU usage occurs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->