### PR TITLE
🎨 Palette: Improve NO_COLOR fallback by using Colors.colorize consistently

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -158,3 +158,6 @@
 ## 2026-05-03 - Avoid Double Negatives in Empty States
 **Learning:** Using "Disabled: None" to indicate an empty list of features is highly confusing (it reads as a double negative). Also, empty states should accurately reflect the system's response (e.g., don't say "Pipeline will idle" if the pipeline actually crashes on missing config).
 **Action:** Always use explicit, friendly phrasing like "⚠ No [item] configured" colored in YELLOW for empty states, ensuring the text aligns with actual system behavior.
+## 2026-05-08 - Use Colors.colorize for graceful NO_COLOR degradation
+**Learning:** Hardcoded ANSI escape codes in f-strings (e.g. `f"{Colors.GREEN}Text{Colors.RESET}"`) fail to degrade gracefully if terminal environment dynamically removes color support after import. Screen readers and log viewers will be cluttered with unparsed escape codes.
+**Action:** Always use the centralized `Colors.colorize()` helper method instead of direct string concatenation to ensure non-TTY/NO_COLOR fallback mechanisms function correctly.

--- a/src/main.py
+++ b/src/main.py
@@ -254,14 +254,14 @@ class EmailSecurityPipeline:
                     )
                     CountdownTimer.wait(
                         self.config.system.check_interval,
-                        f"{Colors.GREY}Waiting for next check{Colors.RESET}",
+                        Colors.colorize("Waiting for next check", Colors.GREY),
                     )
 
             except Exception as e:
                 self.logger.error(f"Error in monitoring loop: {e}", exc_info=True)
                 if self.metrics:
                     self.metrics.record_error("monitoring_loop_error")
-                CountdownTimer.wait(30, f"{Colors.RED}Retrying in{Colors.RESET}")
+                CountdownTimer.wait(30, Colors.colorize("Retrying in", Colors.RED))
 
     def _analyze_email(
         self,
@@ -426,14 +426,14 @@ class EmailSecurityPipeline:
         )
 
         media_status = (
-            f"{Colors.GREEN}✔ Active{Colors.RESET}"
+            Colors.colorize("✔ Active", Colors.GREEN)
             if self.config.analysis.check_media_attachments
-            else f"{Colors.GREY}✖ Disabled{Colors.RESET}"
+            else Colors.colorize("✖ Disabled", Colors.GREY)
         )
         deepfake_status = (
-            f"{Colors.GREEN}✔ Enabled{Colors.RESET}"
+            Colors.colorize("✔ Enabled", Colors.GREEN)
             if self.config.analysis.deepfake_detection_enabled
-            else f"{Colors.GREY}✖ Disabled{Colors.RESET}"
+            else Colors.colorize("✖ Disabled", Colors.GREY)
         )
         print(f"    - Media Check:      {media_status} (Deepfake: {deepfake_status})")
 

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -435,18 +435,18 @@ class AlertSystem:
             return s
 
         self._print_alert_row(
-            f"{Colors.BOLD}Timestamp:{Colors.RESET} {formatted_time}", risk_color
+            f"{Colors.colorize('Timestamp:', Colors.BOLD)} {formatted_time}", risk_color
         )
         self._print_alert_row(
-            f"{Colors.BOLD}Subject:{Colors.RESET}   {safe_field(report.subject)}",
+            f"{Colors.colorize('Subject:', Colors.BOLD)}   {safe_field(report.subject)}",
             risk_color,
         )
         self._print_alert_row(
-            f"{Colors.BOLD}From:{Colors.RESET}      {safe_field(report.sender)}",
+            f"{Colors.colorize('From:', Colors.BOLD)}      {safe_field(report.sender)}",
             risk_color,
         )
         self._print_alert_row(
-            f"{Colors.BOLD}To:{Colors.RESET}        {safe_field(report.recipient)}",
+            f"{Colors.colorize('To:', Colors.BOLD)}        {safe_field(report.recipient)}",
             risk_color,
         )
         self._print_alert_row("", risk_color)
@@ -462,7 +462,8 @@ class AlertSystem:
         meter_color = Colors.get_risk_color(risk_level)
 
         self._print_alert_row(
-            f"{Colors.BOLD}THREAT SCORE:{Colors.RESET} {score:.2f}/100", risk_color
+            f"{Colors.colorize('THREAT SCORE:', Colors.BOLD)} {score:.2f}/100",
+            risk_color,
         )
         self._print_alert_row(f"{Colors.colorize(bar, meter_color)}", risk_color)
 
@@ -497,7 +498,9 @@ class AlertSystem:
         has_nlp = False
         if nlp_analysis.get("social_engineering_indicators"):
             self._print_alert_row(
-                f"{Colors.BOLD}Social Engineering:{Colors.RESET}", risk_color, indent=3
+                Colors.colorize("Social Engineering:", Colors.BOLD),
+                risk_color,
+                indent=3,
             )
             for ind in nlp_analysis["social_engineering_indicators"][
                 : self.MAX_NLP_INDICATORS_DISPLAY
@@ -509,7 +512,7 @@ class AlertSystem:
 
         if nlp_analysis.get("authority_impersonation"):
             self._print_alert_row(
-                f"{Colors.BOLD}Authority Impersonation:{Colors.RESET}",
+                Colors.colorize("Authority Impersonation:", Colors.BOLD),
                 risk_color,
                 indent=3,
             )
@@ -531,7 +534,7 @@ class AlertSystem:
     def _print_media_details(self, media_analysis: Dict, risk_color: str) -> None:
         if media_analysis.get("file_type_warnings"):
             self._print_alert_row(
-                f"{Colors.BOLD}File Warnings:{Colors.RESET}", risk_color, indent=3
+                Colors.colorize("File Warnings:", Colors.BOLD), risk_color, indent=3
             )
             for warning in media_analysis["file_type_warnings"][
                 : self.MAX_MEDIA_WARNINGS_DISPLAY
@@ -555,7 +558,7 @@ class AlertSystem:
         color = Colors.get_risk_color(level)
         symbol = Colors.get_risk_symbol(level)
         self._print_alert_row(
-            f"{Colors.BOLD}{title}:{Colors.RESET} {Colors.colorize(level.upper(), color)} {symbol}",
+            f"{Colors.colorize(title + ':', Colors.BOLD)} {Colors.colorize(level.upper(), color)} {symbol}",
             risk_color,
         )
 
@@ -592,7 +595,7 @@ class AlertSystem:
     ) -> List[tuple[str, int]]:
         rows: List[tuple[str, int]] = []
         if header_issues:
-            rows.append((f"{Colors.BOLD}Header Issues:{Colors.RESET}", 3))
+            rows.append((Colors.colorize("Header Issues:", Colors.BOLD), 3))
         rows.extend(
             (f"{Colors.colorize('•', Colors.YELLOW)} {issue}", 5)
             for issue in header_issues[: self.MAX_HEADER_ISSUES_DISPLAY]
@@ -602,7 +605,7 @@ class AlertSystem:
     def _spam_url_rows(self, suspicious_urls: List[str]) -> List[tuple[str, int]]:
         rows: List[tuple[str, int]] = []
         if suspicious_urls:
-            rows.append((f"{Colors.BOLD}Suspicious URLs:{Colors.RESET}", 3))
+            rows.append((Colors.colorize("Suspicious URLs:", Colors.BOLD), 3))
         rows.extend(
             (f"{Colors.colorize('•', Colors.RED)} {self._safe_console_url(url)}", 5)
             for url in suspicious_urls[: self.MAX_URLS_DISPLAY]
@@ -749,7 +752,8 @@ class AlertSystem:
 
         sep = Colors.colorize("│", Colors.GREY)
 
-        prefix = f"{Colors.GREEN}✓ CLEAN{Colors.RESET} {sep} {time_str} {sep} Score: {score_val:4.1f} {visual_bar} {sep} From: "
+        clean_str = Colors.colorize("✓ CLEAN", Colors.GREEN)
+        prefix = f"{clean_str} {sep} {time_str} {sep} Score: {score_val:4.1f} {visual_bar} {sep} From: "
         prefix_len = self._get_visual_length(prefix)
 
         suffix_sep = f" {sep} "
@@ -783,8 +787,9 @@ class AlertSystem:
 
         # Format:
         # ✓ CLEAN | HH:MM:SS | Score: XX.X [■■···] | From: Sender                       | Subject
+        clean_str = Colors.colorize("✓ CLEAN", Colors.GREEN)
         print(
-            f"{Colors.GREEN}✓ CLEAN{Colors.RESET} "
+            f"{clean_str} "
             f"{sep} {time_str} "
             f"{sep} Score: {score_val:4.1f} {visual_bar} "
             f"{sep} From: {sender:<{sender_width}} "

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -32,12 +32,14 @@ class ColoredFormatter(logging.Formatter):
         if isinstance(record.msg, str):
             if "Monitoring Cycle" in record.msg:
                 # Highlight the cycle start
-                record.msg = f"{Colors.MAGENTA}{Colors.BOLD}{record.msg}{Colors.RESET}"
+                record.msg = Colors.colorize(
+                    str(record.msg), Colors.MAGENTA + Colors.BOLD
+                )
             elif "Waiting" in record.msg and "seconds until next check" in record.msg:
                 # Dim the waiting message to reduce visual noise
-                record.msg = f"{Colors.GREY}{record.msg}{Colors.RESET}"
+                record.msg = Colors.colorize(str(record.msg), Colors.GREY)
             elif "Analysis complete" in record.msg:
                 # Highlight success
-                record.msg = f"{Colors.GREEN}{record.msg}{Colors.RESET}"
+                record.msg = Colors.colorize(str(record.msg), Colors.GREEN)
 
         return super().format(record)

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -34,7 +34,9 @@ except ImportError:
     Spinner = None
 
 # Centralized Outlook troubleshooting tip to avoid duplication/drift
-OUTLOOK_APP_PASSWORD_TIP = f"{Colors.YELLOW}Tip: Personal Outlook accounts NO LONGER support App Passwords.{Colors.RESET}"
+OUTLOOK_APP_PASSWORD_TIP = Colors.colorize(
+    "Tip: Personal Outlook accounts NO LONGER support App Passwords.", Colors.YELLOW
+)
 
 
 def _is_valid_email(email: str) -> bool:
@@ -118,7 +120,7 @@ def _test_connection(email: str, app_password: str, provider_choice: str) -> boo
         # We don't have access to the spinner here easily if the exception is outside,
         # but in most cases errors happen inside the context manager. If it happens
         # outside, we just print as before.
-        print(f"{Colors.RED}✘ Error during connection test: {e}{Colors.RESET}")
+        print(Colors.colorize(f"✘ Error during connection test: {e}", Colors.RED))
         if provider_choice == "3":
             print(OUTLOOK_APP_PASSWORD_TIP)
         return False
@@ -143,7 +145,9 @@ def _select_provider() -> str:
             if choice in ("1", "2", "3", "4"):
                 return choice
             print(
-                f"{Colors.YELLOW}Invalid choice. Please enter 1, 2, 3, or 4.{Colors.RESET}"
+                Colors.colorize(
+                    "Invalid choice. Please enter 1, 2, 3, or 4.", Colors.YELLOW
+                )
             )
         except EOFError:
             return "4"
@@ -169,14 +173,17 @@ def _get_credentials(choice: str, provider_name: str) -> tuple[str, str]:
                 )
                 email = input(prompt).strip()
                 if not email:
-                    print(f"{Colors.YELLOW}Email is required.{Colors.RESET}")
+                    print(Colors.colorize("Email is required.", Colors.YELLOW))
                     continue
 
                 if _is_valid_email(email):
                     break
 
                 print(
-                    f"{Colors.YELLOW}Invalid email format. Please enter a valid email address (e.g., user@example.com).{Colors.RESET}"
+                    Colors.colorize(
+                        "Invalid email format. Please enter a valid email address (e.g., user@example.com).",
+                        Colors.YELLOW,
+                    )
                 )
 
             # Context-specific help
@@ -212,7 +219,7 @@ def _get_credentials(choice: str, provider_name: str) -> tuple[str, str]:
             )
             app_secret = getpass.getpass(prompt).strip()
             while not app_secret:
-                print(f"{Colors.YELLOW}Password is required.{Colors.RESET}")
+                print(Colors.colorize("Password is required.", Colors.YELLOW))
                 app_secret = getpass.getpass(prompt).strip()
 
             # Test the connection immediately
@@ -232,7 +239,9 @@ def _get_credentials(choice: str, provider_name: str) -> tuple[str, str]:
             retry = input(prompt).strip().lower()
             if retry not in ("", "y", "yes"):
                 print(
-                    f"{Colors.GREY}Proceeding with entered credentials (unverified).{Colors.RESET}"
+                    Colors.colorize(
+                        "Proceeding with entered credentials (unverified).", Colors.GREY
+                    )
                 )
                 return email, app_secret
 

--- a/test.py
+++ b/test.py
@@ -1,6 +1,0 @@
-from src.utils.sanitization import sanitize_for_logging
-
-# A string containing \n and an unprintable \x00 character
-text = "Hello\nWorld\x00"
-
-print(repr(sanitize_for_logging(text)))

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -308,7 +308,7 @@ OUTLOOK_APP_PASSWORD=password
         # Ensure the tip was printed during the first failure
         from src.utils.colors import Colors
 
-        expected_tip = f"{Colors.YELLOW}Tip: Personal Outlook accounts NO LONGER support App Passwords.{Colors.RESET}"
+        expected_tip = Colors.colorize("Tip: Personal Outlook accounts NO LONGER support App Passwords.", Colors.YELLOW)
 
         # Check if the tip string is in any of the print calls
         found_tip = any(


### PR DESCRIPTION
💡 What: Refactored direct ANSI escape codes inside f-strings to use the centralized `Colors.colorize()` helper method.

🎯 Why: Using direct string interpolation (e.g. `f"{Colors.GREEN}Text{Colors.RESET}"`) causes UI bugs when colors are disabled via NO_COLOR environment variables or in non-TTY terminals. Screen readers and logs get cluttered with unparsed ANSI codes.

♿ Accessibility: Screen reader users and folks with low-contrast environments using NO_COLOR will no longer encounter garbled escape characters.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->