### PR TITLE
🎨 Palette: Render missing deepfake and attachment threats in CLI alerts

### DIFF
--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -531,49 +531,32 @@ class AlertSystem:
                 indent=3,
             )
 
+    def _print_media_warning_section(self, title: str, warnings: List[str], item_color: str, risk_color: str) -> None:
+        if not warnings:
+            return
+        self._print_alert_row(
+            Colors.colorize(title, Colors.BOLD), risk_color, indent=3
+        )
+        for warning in warnings[: self.MAX_MEDIA_WARNINGS_DISPLAY]:
+            self._print_alert_row(
+                f"{Colors.colorize('•', item_color)} {warning}",
+                risk_color,
+                indent=5,
+            )
+
     def _print_media_details(self, media_analysis: Dict, risk_color: str) -> None:
         has_media_warnings = False
         
         if media_analysis.get("file_type_warnings"):
-            self._print_alert_row(
-                Colors.colorize("File Warnings:", Colors.BOLD), risk_color, indent=3
-            )
-            for warning in media_analysis["file_type_warnings"][
-                : self.MAX_MEDIA_WARNINGS_DISPLAY
-            ]:
-                self._print_alert_row(
-                    f"{Colors.colorize('•', Colors.YELLOW)} {warning}",
-                    risk_color,
-                    indent=5,
-                )
+            self._print_media_warning_section("File Warnings:", media_analysis["file_type_warnings"], Colors.YELLOW, risk_color)
             has_media_warnings = True
 
         if media_analysis.get("potential_deepfakes"):
-            self._print_alert_row(
-                Colors.colorize("Deepfake Warnings:", Colors.BOLD), risk_color, indent=3
-            )
-            for warning in media_analysis["potential_deepfakes"][
-                : self.MAX_MEDIA_WARNINGS_DISPLAY
-            ]:
-                self._print_alert_row(
-                    f"{Colors.colorize('•', Colors.RED)} {warning}",
-                    risk_color,
-                    indent=5,
-                )
+            self._print_media_warning_section("Deepfake Warnings:", media_analysis["potential_deepfakes"], Colors.RED, risk_color)
             has_media_warnings = True
 
         if media_analysis.get("suspicious_attachments"):
-            self._print_alert_row(
-                Colors.colorize("Suspicious Attachments:", Colors.BOLD), risk_color, indent=3
-            )
-            for warning in media_analysis["suspicious_attachments"][
-                : self.MAX_MEDIA_WARNINGS_DISPLAY
-            ]:
-                self._print_alert_row(
-                    f"{Colors.colorize('•', Colors.RED)} {warning}",
-                    risk_color,
-                    indent=5,
-                )
+            self._print_media_warning_section("Suspicious Attachments:", media_analysis["suspicious_attachments"], Colors.RED, risk_color)
             has_media_warnings = True
 
         if not has_media_warnings:

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -532,6 +532,8 @@ class AlertSystem:
             )
 
     def _print_media_details(self, media_analysis: Dict, risk_color: str) -> None:
+        has_media_warnings = False
+        
         if media_analysis.get("file_type_warnings"):
             self._print_alert_row(
                 Colors.colorize("File Warnings:", Colors.BOLD), risk_color, indent=3
@@ -544,7 +546,37 @@ class AlertSystem:
                     risk_color,
                     indent=5,
                 )
-        else:
+            has_media_warnings = True
+
+        if media_analysis.get("potential_deepfakes"):
+            self._print_alert_row(
+                Colors.colorize("Deepfake Warnings:", Colors.BOLD), risk_color, indent=3
+            )
+            for warning in media_analysis["potential_deepfakes"][
+                : self.MAX_MEDIA_WARNINGS_DISPLAY
+            ]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.RED)} {warning}",
+                    risk_color,
+                    indent=5,
+                )
+            has_media_warnings = True
+
+        if media_analysis.get("suspicious_attachments"):
+            self._print_alert_row(
+                Colors.colorize("Suspicious Attachments:", Colors.BOLD), risk_color, indent=3
+            )
+            for warning in media_analysis["suspicious_attachments"][
+                : self.MAX_MEDIA_WARNINGS_DISPLAY
+            ]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.RED)} {warning}",
+                    risk_color,
+                    indent=5,
+                )
+            has_media_warnings = True
+
+        if not has_media_warnings:
             self._print_alert_row(
                 f"{Colors.colorize('✓', Colors.GREEN)} Attachments appear safe",
                 risk_color,

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -9,7 +9,6 @@ import re
 import shutil
 import textwrap
 import threading
-import unicodedata
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import Dict, List, Optional
@@ -531,7 +530,9 @@ class AlertSystem:
                 indent=3,
             )
 
-    def _print_media_warning_section(self, title: str, warnings: List[str], item_color: str, risk_color: str) -> None:
+    def _print_media_warning_section(
+        self, title: str, warnings: List[str], item_color: str, risk_color: str
+    ) -> None:
         if not warnings:
             return
         self._print_alert_row(
@@ -546,17 +547,32 @@ class AlertSystem:
 
     def _print_media_details(self, media_analysis: Dict, risk_color: str) -> None:
         has_media_warnings = False
-        
+
         if media_analysis.get("file_type_warnings"):
-            self._print_media_warning_section("File Warnings:", media_analysis["file_type_warnings"], Colors.YELLOW, risk_color)
+            self._print_media_warning_section(
+                "File Warnings:",
+                media_analysis["file_type_warnings"],
+                Colors.YELLOW,
+                risk_color,
+            )
             has_media_warnings = True
 
         if media_analysis.get("potential_deepfakes"):
-            self._print_media_warning_section("Deepfake Warnings:", media_analysis["potential_deepfakes"], Colors.RED, risk_color)
+            self._print_media_warning_section(
+                "Deepfake Warnings:",
+                media_analysis["potential_deepfakes"],
+                Colors.RED,
+                risk_color,
+            )
             has_media_warnings = True
 
         if media_analysis.get("suspicious_attachments"):
-            self._print_media_warning_section("Suspicious Attachments:", media_analysis["suspicious_attachments"], Colors.RED, risk_color)
+            self._print_media_warning_section(
+                "Suspicious Attachments:",
+                media_analysis["suspicious_attachments"],
+                Colors.RED,
+                risk_color,
+            )
             has_media_warnings = True
 
         if not has_media_warnings:
@@ -659,7 +675,7 @@ class AlertSystem:
             if rec.startswith(self.RECOMMENDATION_PREFIXES_TUPLE):
                 for prefix in self.RECOMMENDATION_PREFIXES:
                     if rec.startswith(prefix):
-                        rec = rec[len(prefix) :]
+                        rec = rec[len(prefix):]
 
             # Optimization: compiled regex search is faster than any() generator loop for substring matching
             if self.RED_KEYWORDS_PATTERN.search(rec_upper):


### PR DESCRIPTION
## 💡 What
Updated the CLI rendering logic in `AlertSystem._print_media_details` to explicitly display `potential_deepfakes` and `suspicious_attachments`.

## 🎯 Why
Previously, if an email contained deepfakes but lacked generic file type warnings, the CLI would falsely output "✓ Attachments appear safe". This created a dangerous false sense of security by visually hiding valid threats detected by the security engine.

## ♿ Accessibility
Ensures critical threat data is surfaced to users relying on the CLI output, preventing the omission of nested list-based threat indicators.

ELIR
PURPOSE: Ensure all media threats (deepfakes, suspicious attachments) are displayed in the CLI, not just file type warnings.
SECURITY: Prevents false negatives in the UI where detected threats are hidden from the user.
FAILS IF: New keys are added to `media_analysis` without updating this render logic.
VERIFY: Run the CLI with an email containing deepfakes and ensure the red warning is printed instead of the green safe message.
MAINTAIN: When adding new media threat indicators, this function must be updated to explicitly render them.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->