### PR TITLE
🎨 Palette: Render missing deepfake and attachment threats in CLI alerts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -161,6 +161,3 @@
 ## 2026-05-10 - Consistent CLI Output Formatting
 **Learning:** Directly concatenating ANSI escape codes (e.g., `f"{Colors.GREEN}Text{Colors.RESET}"`) in print statements breaks accessibility and output formatting in non-TTY environments (like CI/CD logs or files), because it bypasses the central color detection logic.
 **Action:** Always use the centralized helper `Colors.colorize("Text", Colors.GREEN)` when formatting strings for the CLI. This ensures fallback mechanisms work as expected, maintaining readable outputs across all environments.
-## 2025-05-15 - Missing Threat Indicators in CLI Output
-**Learning:** In the `AlertSystem` CLI rendering logic, the `_print_media_details` function only checked for `file_type_warnings`. If an email contained deepfakes (`potential_deepfakes`) or malicious scripts (`suspicious_attachments`) but no generic file type warnings, the CLI would falsely output "✓ Attachments appear safe". This omission created a dangerous disconnect where the underlying security engine detected a threat, but the UI hid it from the user.
-**Action:** When rendering summary views of complex objects (like `media_analysis`), always ensure all relevant state indicators are explicitly checked before falling back to a "safe/empty" state to maintain accurate user feedback and prevent false positives.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -161,3 +161,6 @@
 ## 2026-05-10 - Consistent CLI Output Formatting
 **Learning:** Directly concatenating ANSI escape codes (e.g., `f"{Colors.GREEN}Text{Colors.RESET}"`) in print statements breaks accessibility and output formatting in non-TTY environments (like CI/CD logs or files), because it bypasses the central color detection logic.
 **Action:** Always use the centralized helper `Colors.colorize("Text", Colors.GREEN)` when formatting strings for the CLI. This ensures fallback mechanisms work as expected, maintaining readable outputs across all environments.
+## 2025-05-15 - Missing Threat Indicators in CLI Output
+**Learning:** In the `AlertSystem` CLI rendering logic, the `_print_media_details` function only checked for `file_type_warnings`. If an email contained deepfakes (`potential_deepfakes`) or malicious scripts (`suspicious_attachments`) but no generic file type warnings, the CLI would falsely output "✓ Attachments appear safe". This omission created a dangerous disconnect where the underlying security engine detected a threat, but the UI hid it from the user.
+**Action:** When rendering summary views of complex objects (like `media_analysis`), always ensure all relevant state indicators are explicitly checked before falling back to a "safe/empty" state to maintain accurate user feedback and prevent false positives.

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -532,6 +532,8 @@ class AlertSystem:
             )
 
     def _print_media_details(self, media_analysis: Dict, risk_color: str) -> None:
+        has_media_warnings = False
+
         if media_analysis.get("file_type_warnings"):
             self._print_alert_row(
                 Colors.colorize("File Warnings:", Colors.BOLD), risk_color, indent=3
@@ -544,7 +546,37 @@ class AlertSystem:
                     risk_color,
                     indent=5,
                 )
-        else:
+            has_media_warnings = True
+
+        if media_analysis.get("potential_deepfakes"):
+            self._print_alert_row(
+                Colors.colorize("Deepfake Warnings:", Colors.BOLD), risk_color, indent=3
+            )
+            for warning in media_analysis["potential_deepfakes"][
+                : self.MAX_MEDIA_WARNINGS_DISPLAY
+            ]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.RED)} {warning}",
+                    risk_color,
+                    indent=5,
+                )
+            has_media_warnings = True
+
+        if media_analysis.get("suspicious_attachments"):
+            self._print_alert_row(
+                Colors.colorize("Suspicious Attachments:", Colors.BOLD), risk_color, indent=3
+            )
+            for warning in media_analysis["suspicious_attachments"][
+                : self.MAX_MEDIA_WARNINGS_DISPLAY
+            ]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.RED)} {warning}",
+                    risk_color,
+                    indent=5,
+                )
+            has_media_warnings = True
+
+        if not has_media_warnings:
             self._print_alert_row(
                 f"{Colors.colorize('✓', Colors.GREEN)} Attachments appear safe",
                 risk_color,

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -9,7 +9,6 @@ import re
 import shutil
 import textwrap
 import threading
-import unicodedata
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import Dict, List, Optional
@@ -531,49 +530,49 @@ class AlertSystem:
                 indent=3,
             )
 
+    def _print_media_warning_section(
+        self, title: str, warnings: List[str], item_color: str, risk_color: str
+    ) -> None:
+        if not warnings:
+            return
+        self._print_alert_row(
+            Colors.colorize(title, Colors.BOLD), risk_color, indent=3
+        )
+        for warning in warnings[: self.MAX_MEDIA_WARNINGS_DISPLAY]:
+            self._print_alert_row(
+                f"{Colors.colorize('•', item_color)} {warning}",
+                risk_color,
+                indent=5,
+            )
+
     def _print_media_details(self, media_analysis: Dict, risk_color: str) -> None:
         has_media_warnings = False
 
         if media_analysis.get("file_type_warnings"):
-            self._print_alert_row(
-                Colors.colorize("File Warnings:", Colors.BOLD), risk_color, indent=3
+            self._print_media_warning_section(
+                "File Warnings:",
+                media_analysis["file_type_warnings"],
+                Colors.YELLOW,
+                risk_color,
             )
-            for warning in media_analysis["file_type_warnings"][
-                : self.MAX_MEDIA_WARNINGS_DISPLAY
-            ]:
-                self._print_alert_row(
-                    f"{Colors.colorize('•', Colors.YELLOW)} {warning}",
-                    risk_color,
-                    indent=5,
-                )
             has_media_warnings = True
 
         if media_analysis.get("potential_deepfakes"):
-            self._print_alert_row(
-                Colors.colorize("Deepfake Warnings:", Colors.BOLD), risk_color, indent=3
+            self._print_media_warning_section(
+                "Deepfake Warnings:",
+                media_analysis["potential_deepfakes"],
+                Colors.RED,
+                risk_color,
             )
-            for warning in media_analysis["potential_deepfakes"][
-                : self.MAX_MEDIA_WARNINGS_DISPLAY
-            ]:
-                self._print_alert_row(
-                    f"{Colors.colorize('•', Colors.RED)} {warning}",
-                    risk_color,
-                    indent=5,
-                )
             has_media_warnings = True
 
         if media_analysis.get("suspicious_attachments"):
-            self._print_alert_row(
-                Colors.colorize("Suspicious Attachments:", Colors.BOLD), risk_color, indent=3
+            self._print_media_warning_section(
+                "Suspicious Attachments:",
+                media_analysis["suspicious_attachments"],
+                Colors.RED,
+                risk_color,
             )
-            for warning in media_analysis["suspicious_attachments"][
-                : self.MAX_MEDIA_WARNINGS_DISPLAY
-            ]:
-                self._print_alert_row(
-                    f"{Colors.colorize('•', Colors.RED)} {warning}",
-                    risk_color,
-                    indent=5,
-                )
             has_media_warnings = True
 
         if not has_media_warnings:
@@ -676,7 +675,7 @@ class AlertSystem:
             if rec.startswith(self.RECOMMENDATION_PREFIXES_TUPLE):
                 for prefix in self.RECOMMENDATION_PREFIXES:
                     if rec.startswith(prefix):
-                        rec = rec[len(prefix) :]
+                        rec = rec[len(prefix):]
 
             # Optimization: compiled regex search is faster than any() generator loop for substring matching
             if self.RED_KEYWORDS_PATTERN.search(rec_upper):


### PR DESCRIPTION
Updated the CLI rendering logic in `AlertSystem._print_media_details` to explicitly display `potential_deepfakes` and `suspicious_attachments`.

Previously, if an email contained deepfakes but lacked generic file type warnings, the CLI would falsely output "✓ Attachments appear safe". This created a dangerous false sense of security by visually hiding valid threats detected by the security engine.

This fix ensures critical threat data is surfaced to users relying on the CLI output, preventing the omission of nested list-based threat indicators.

---
*PR created automatically by Jules for task [9845709085349977667](https://jules.google.com/task/9845709085349977667) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->