### PR TITLE
⚡ Bolt: Minimize IMAP round-trips with batch size tuning

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -67,3 +67,8 @@
 
 **Learning:** Python's `datetime.now()` with `timedelta` objects incur high instantiation and garbage collection overhead, which compounds in hot cache eviction loops like `TTLCache`.
 **Action:** Replace `datetime.now()` and `timedelta` with `time.monotonic()` and float arithmetic. This avoids the object creation overhead and is more resilient to system clock adjustments.
+
+## 2025-10-25 - [Performance Optimization: Batch size tuning for IMAP]
+
+**Learning:** Checking IMAP email metadata (like `RFC822.SIZE`) with very small batch sizes (e.g., 10) inside a fetch loop incurs redundant network round-trips and repeated rate-limit sleeps. However, checking ALL unread emails simultaneously without batching risks exceeding IMAP protocol command length limits and causing crashes.
+**Action:** Tune the fetch batch size to a safe but larger default (e.g. 50). This strikes the right balance between minimizing network overhead and respecting protocol limits.

--- a/src/modules/imap_connection.py
+++ b/src/modules/imap_connection.py
@@ -261,8 +261,11 @@ class IMAPConnection:
             self.logger.info(f"Found {len(email_ids)} unseen emails in {safe_folder}")
 
             # Process in batches for rate limiting
+            # Performance Optimization: Use a larger batch size (50) to minimize
+            # redundant network round-trips and repeated rate-limit sleeps while
+            # remaining within safe IMAP protocol command length limits.
             emails = []
-            batch_size = 10
+            batch_size = 50
 
             for i in range(0, len(email_ids), batch_size):
                 if i > 0:


### PR DESCRIPTION
💡 What: Increased the IMAP batch fetch size from 10 to 50 in `_fetch_emails_internal`.
🎯 Why: Checking IMAP email metadata inside a fetch loop with a small batch size causes redundant network round-trips and repeated rate-limit sleeps.
📊 Impact: Expected to reduce rate limit pausing duration by up to 5x for large bulk email fetches.
🔬 Measurement: Verify reduction in time taken to process large bursts of incoming emails by checking application logs for `Found N unseen emails` alongside the time taken.

---
*PR created automatically by Jules for task [15757868954206831735](https://jules.google.com/task/15757868954206831735) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->