### PR TITLE
ci: fix placeholder in agentics maintenance workflow

### DIFF
--- a/.github/workflows/agentics-maintenance.yml
+++ b/.github/workflows/agentics-maintenance.yml
@@ -120,7 +120,7 @@ jobs:
             await main();
 
       - name: Install gh-aw
-        uses: github/gh-aw/actions/setup-cli@<FULL_40_CHARACTER_COMMIT_SHA_FOR_V0.67.0> # v0.67.0
+        uses: github/gh-aw/actions/setup-cli@245d16844b16f61042aebf5931af62a750b202fc # v0.67.0
         with:
           version: v0.55.0
 


### PR DESCRIPTION
This PR replaces the unresolved `<FULL_40_CHARACTER_COMMIT_SHA_FOR_V0.67.0>` placeholder in `.github/workflows/agentics-maintenance.yml` with the actual 40-character commit SHA (`245d16844b16f61042aebf5931af62a750b202fc`). Doing this secures the GitHub Action configuration by strictly pinning the version, eliminating syntax errors from the placeholder while preventing the workflow from being blocked during future CI/CD runs.

---
*PR created automatically by Jules for task [6843711032166986231](https://jules.google.com/task/6843711032166986231) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->