### PR TITLE
🎨 Palette: Ensure all media threat indicators are rendered in CLI alerts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -161,3 +161,6 @@
 ## 2026-05-10 - Consistent CLI Output Formatting
 **Learning:** Directly concatenating ANSI escape codes (e.g., `f"{Colors.GREEN}Text{Colors.RESET}"`) in print statements breaks accessibility and output formatting in non-TTY environments (like CI/CD logs or files), because it bypasses the central color detection logic.
 **Action:** Always use the centralized helper `Colors.colorize("Text", Colors.GREEN)` when formatting strings for the CLI. This ensures fallback mechanisms work as expected, maintaining readable outputs across all environments.
+## 2027-02-15 - Ensure All Threat Indicators Render in CLI
+**Learning:** Omission of specific nested threat lists (like `suspicious_attachments` or `size_anomalies`) in CLI views creates a disconnect where underlying threats are detected and sent to webhooks, but visually hidden locally, falsely reporting 'Attachments appear safe'.
+**Action:** Explicitly check and render all relevant warning keys in `AlertSystem._print_media_details` and similar methods to accurately reflect the threat state.

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -531,58 +531,35 @@ class AlertSystem:
                 indent=3,
             )
 
+    def _print_media_indicator_list(self, title: str, items: List[str], item_color: str, risk_color: str) -> None:
+        """Helper to print a list of media threat indicators."""
+        if not items:
+            return
+        self._print_alert_row(
+            Colors.colorize(title, Colors.BOLD), risk_color, indent=3
+        )
+        for item in items[: self.MAX_MEDIA_WARNINGS_DISPLAY]:
+            self._print_alert_row(
+                f"{Colors.colorize('•', item_color)} {item}",
+                risk_color,
+                indent=5,
+            )
+
     def _print_media_details(self, media_analysis: Dict, risk_color: str) -> None:
         has_media_warnings = False
 
-        if media_analysis.get("suspicious_attachments"):
-            self._print_alert_row(
-                Colors.colorize("Suspicious Attachments:", Colors.BOLD), risk_color, indent=3
-            )
-            for att in media_analysis["suspicious_attachments"][: self.MAX_MEDIA_WARNINGS_DISPLAY]:
-                self._print_alert_row(
-                    f"{Colors.colorize('•', Colors.RED)} {att}",
-                    risk_color,
-                    indent=5,
-                )
-            has_media_warnings = True
+        indicators = [
+            ("Suspicious Attachments:", "suspicious_attachments", Colors.RED),
+            ("File Warnings:", "file_type_warnings", Colors.YELLOW),
+            ("Size Anomalies:", "size_anomalies", Colors.YELLOW),
+            ("Deepfake Warnings:", "potential_deepfakes", Colors.RED)
+        ]
 
-        if media_analysis.get("file_type_warnings"):
-            self._print_alert_row(
-                Colors.colorize("File Warnings:", Colors.BOLD), risk_color, indent=3
-            )
-            for warning in media_analysis["file_type_warnings"][
-                : self.MAX_MEDIA_WARNINGS_DISPLAY
-            ]:
-                self._print_alert_row(
-                    f"{Colors.colorize('•', Colors.YELLOW)} {warning}",
-                    risk_color,
-                    indent=5,
-                )
-            has_media_warnings = True
-
-        if media_analysis.get("size_anomalies"):
-            self._print_alert_row(
-                Colors.colorize("Size Anomalies:", Colors.BOLD), risk_color, indent=3
-            )
-            for anomaly in media_analysis["size_anomalies"][: self.MAX_MEDIA_WARNINGS_DISPLAY]:
-                self._print_alert_row(
-                    f"{Colors.colorize('•', Colors.YELLOW)} {anomaly}",
-                    risk_color,
-                    indent=5,
-                )
-            has_media_warnings = True
-
-        if media_analysis.get("potential_deepfakes"):
-            self._print_alert_row(
-                Colors.colorize("Deepfake Warnings:", Colors.BOLD), risk_color, indent=3
-            )
-            for deepfake in media_analysis["potential_deepfakes"][: self.MAX_MEDIA_WARNINGS_DISPLAY]:
-                self._print_alert_row(
-                    f"{Colors.colorize('•', Colors.RED)} {deepfake}",
-                    risk_color,
-                    indent=5,
-                )
-            has_media_warnings = True
+        for title, key, color in indicators:
+            items = media_analysis.get(key)
+            if items:
+                self._print_media_indicator_list(title, items, color, risk_color)
+                has_media_warnings = True
 
         if not has_media_warnings:
             self._print_alert_row(

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -532,6 +532,20 @@ class AlertSystem:
             )
 
     def _print_media_details(self, media_analysis: Dict, risk_color: str) -> None:
+        has_media_warnings = False
+
+        if media_analysis.get("suspicious_attachments"):
+            self._print_alert_row(
+                Colors.colorize("Suspicious Attachments:", Colors.BOLD), risk_color, indent=3
+            )
+            for att in media_analysis["suspicious_attachments"][: self.MAX_MEDIA_WARNINGS_DISPLAY]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.RED)} {att}",
+                    risk_color,
+                    indent=5,
+                )
+            has_media_warnings = True
+
         if media_analysis.get("file_type_warnings"):
             self._print_alert_row(
                 Colors.colorize("File Warnings:", Colors.BOLD), risk_color, indent=3
@@ -544,7 +558,33 @@ class AlertSystem:
                     risk_color,
                     indent=5,
                 )
-        else:
+            has_media_warnings = True
+
+        if media_analysis.get("size_anomalies"):
+            self._print_alert_row(
+                Colors.colorize("Size Anomalies:", Colors.BOLD), risk_color, indent=3
+            )
+            for anomaly in media_analysis["size_anomalies"][: self.MAX_MEDIA_WARNINGS_DISPLAY]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.YELLOW)} {anomaly}",
+                    risk_color,
+                    indent=5,
+                )
+            has_media_warnings = True
+
+        if media_analysis.get("potential_deepfakes"):
+            self._print_alert_row(
+                Colors.colorize("Deepfake Warnings:", Colors.BOLD), risk_color, indent=3
+            )
+            for deepfake in media_analysis["potential_deepfakes"][: self.MAX_MEDIA_WARNINGS_DISPLAY]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.RED)} {deepfake}",
+                    risk_color,
+                    indent=5,
+                )
+            has_media_warnings = True
+
+        if not has_media_warnings:
             self._print_alert_row(
                 f"{Colors.colorize('✓', Colors.GREEN)} Attachments appear safe",
                 risk_color,


### PR DESCRIPTION
**💡 What:** Added explicit checks and rendering in `_print_media_details` for `suspicious_attachments`, `size_anomalies`, and `potential_deepfakes` in the CLI output.
**🎯 Why:** Currently, the CLI view only displayed `file_type_warnings` and omitted other specific media threat indicators. This created a disconnect where threats might be detected and logged to external webhooks (like Slack) but visually hidden in the local console, falsely reporting 'Attachments appear safe'.
**♿ Accessibility:** Improves terminal user awareness of critical security warnings instead of relying solely on Slack integrations.

---
*PR created automatically by Jules for task [7488212728528221532](https://jules.google.com/task/7488212728528221532) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->