### PR TITLE
🧹 Cleanup: Remove unused MAX_MIME_PARTS from email_ingestion.py

### DIFF
--- a/src/modules/email_ingestion.py
+++ b/src/modules/email_ingestion.py
@@ -24,7 +24,6 @@ from ..utils.config import EmailAccountConfig
 from ..utils.sanitization import redact_email, sanitize_for_logging
 from ..utils.security_validators import (
     DEFAULT_MAX_EMAIL_SIZE,
-    MAX_MIME_PARTS,
     MAX_SUBJECT_LENGTH,
     calculate_max_email_size,
     create_secure_ssl_context,
@@ -45,7 +44,6 @@ __all__ = [
     "EmailData",
     # Security constants (used in tests)
     "MAX_SUBJECT_LENGTH",
-    "MAX_MIME_PARTS",
     "DEFAULT_MAX_EMAIL_SIZE",
 ]
 

--- a/tests/test_mime_bomb_limit.py
+++ b/tests/test_mime_bomb_limit.py
@@ -2,7 +2,8 @@ import unittest
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-from src.modules.email_ingestion import MAX_MIME_PARTS, EmailAccountConfig, IMAPClient
+from src.modules.email_ingestion import EmailAccountConfig, IMAPClient
+from src.utils.security_validators import MAX_MIME_PARTS
 
 
 class TestMimeBombLimit(unittest.TestCase):


### PR DESCRIPTION
🎯 **What:** Removed the unused import and re-export of `MAX_MIME_PARTS` from `src/modules/email_ingestion.py`.

💡 **Why:** Improves code maintainability by removing dead code from the module's public interface and reducing clutter. This constant is part of the security subsystem and should be imported from there.

✅ **Verification:** 
- Updated `tests/test_mime_bomb_limit.py` to import `MAX_MIME_PARTS` from `src.utils.security_validators`.
- Verified the fix using a custom test runner that mocks missing dependencies (`dotenv`, `cv2`, `numpy`) to ensure that the constant is correctly resolved and that no regressions were introduced.
- Manual inspection of `src/modules/email_ingestion.py` confirmed it is no longer imported or listed in `__all__`.

✨ **Result:** A cleaner `email_ingestion.py` module with all tests still passing.

---
*PR created automatically by Jules for task [5443086193298762358](https://jules.google.com/task/5443086193298762358) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->