### PR TITLE
🧹 code health: Remove unused security constants from email_ingestion.py

### DIFF
--- a/src/modules/email_ingestion.py
+++ b/src/modules/email_ingestion.py
@@ -23,9 +23,6 @@ from typing import Any, Dict, List, Optional, Tuple
 from ..utils.config import EmailAccountConfig
 from ..utils.sanitization import redact_email, sanitize_for_logging
 from ..utils.security_validators import (
-    DEFAULT_MAX_EMAIL_SIZE,
-    MAX_MIME_PARTS,
-    MAX_SUBJECT_LENGTH,
     calculate_max_email_size,
     create_secure_ssl_context,
 )
@@ -43,10 +40,6 @@ __all__ = [
     "IMAPClient",
     "EmailIngestionManager",
     "EmailData",
-    # Security constants (used in tests)
-    "MAX_SUBJECT_LENGTH",
-    "MAX_MIME_PARTS",
-    "DEFAULT_MAX_EMAIL_SIZE",
 ]
 
 

--- a/tests/test_mime_bomb_limit.py
+++ b/tests/test_mime_bomb_limit.py
@@ -2,7 +2,8 @@ import unittest
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-from src.modules.email_ingestion import MAX_MIME_PARTS, EmailAccountConfig, IMAPClient
+from src.modules.email_ingestion import EmailAccountConfig, IMAPClient
+from src.utils.security_validators import MAX_MIME_PARTS
 
 
 class TestMimeBombLimit(unittest.TestCase):


### PR DESCRIPTION
🎯 **What:** Removed unused security constants (`MAX_SUBJECT_LENGTH`, `MAX_MIME_PARTS`, `DEFAULT_MAX_EMAIL_SIZE`) from `src/modules/email_ingestion.py` imports and its `__all__` list, moving usage strictly to `src.utils.security_validators`.
💡 **Why:** This enforces the intended design where the Facade pattern does not bleed unneeded security constants and prevents unused import clutter, improving code maintainability.
✅ **Verification:** Verified by modifying `tests/test_mime_bomb_limit.py` to import `MAX_MIME_PARTS` from `src.utils.security_validators` and running the full pytest suite (`python3 -m pytest tests/`), ensuring everything passes successfully.
✨ **Result:** A cleaner codebase with proper separation of concerns without impacting existing functionality.

---
*PR created automatically by Jules for task [13412702458023834674](https://jules.google.com/task/13412702458023834674) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->