### PR TITLE
🧪 test: add test for setup wizard replacing secret

### DIFF
--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -3,7 +3,11 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
-from src.utils.setup_wizard import _is_valid_email, run_setup_wizard
+from src.utils.setup_wizard import (
+    _is_valid_email,
+    run_setup_wizard,
+    _generate_config_content,
+)
 
 
 class TestSetupWizard(unittest.TestCase):
@@ -21,6 +25,25 @@ OUTLOOK_ENABLED=false
 OUTLOOK_EMAIL=test@outlook.com
 OUTLOOK_APP_PASSWORD=password
 """
+
+    def test_generate_config_content_replaces_secret(self):
+        """Test that setup wizard correctly replaces secret using the safe regex replace."""
+        template_content = self.example_content
+
+        # Test replacing with a string that has backslashes or special chars
+        provider_key = "GMAIL"
+        email = "test_new@gmail.com"
+        app_secret = r"new_pass_with_\_backslashes_and_\g<0>_regex_groups"
+
+        updated_content = _generate_config_content(
+            template_content, provider_key, email, app_secret
+        )
+
+        self.assertIn(f"GMAIL_APP_PASSWORD={app_secret}", updated_content)
+        self.assertIn(f"GMAIL_EMAIL={email}", updated_content)
+        self.assertIn("GMAIL_ENABLED=true", updated_content)
+        self.assertIn("PROTON_ENABLED=false", updated_content)
+        self.assertIn("OUTLOOK_ENABLED=false", updated_content)
 
     def test_email_validation_logic(self):
         """Test the email validation helper function directly."""


### PR DESCRIPTION
## 🎯 What
The setup wizard replaces the user's secret safely, which was previously untested. This PR adds a unit test for the `_generate_config_content` method to ensure secrets are correctly substituted into the template.

## 📊 Coverage
The newly added `test_generate_config_content_replaces_secret` covers the regex replacements in `src/utils/setup_wizard.py`.

## ✨ Result
Improved testing and higher reliability of secret replacement logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->