### PR TITLE
🧪 test: coverage for non-string default credentials

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -40,7 +40,9 @@ class TestValidators(unittest.TestCase):
         ]
         errors = check_default_credentials(self.config)
         self.assertIn(
-            "Gmail account enabled but uses default email: your-email@gmail.com", errors
+            "Gmail account enabled but uses default email: "
+            "your-email@gmail.com",
+            errors,
         )
 
     def test_default_password(self):
@@ -54,7 +56,9 @@ class TestValidators(unittest.TestCase):
             )
         ]
         errors = check_default_credentials(self.config)
-        self.assertIn("Gmail account enabled but uses default password", errors)
+        self.assertIn(
+            "Gmail account enabled but uses default password", errors
+        )
 
     def test_disabled_account_ignored(self):
         self.config.email_accounts = [
@@ -81,7 +85,26 @@ class TestValidators(unittest.TestCase):
             "https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
         )
         errors = check_default_credentials(self.config)
-        self.assertIn("Slack alerts enabled but uses default Webhook URL", errors)
+        self.assertIn(
+            "Slack alerts enabled but uses default Webhook URL", errors
+        )
+
+    def test_non_string_credentials(self):
+        self.config.email_accounts = [
+            Mock(
+                spec=EmailAccountConfig,
+                enabled=True,
+                email=None,
+                app_password=12345,
+                provider="gmail",
+            )
+        ]
+        self.config.alerts.webhook_enabled = True
+        self.config.alerts.webhook_url = None
+        self.config.alerts.slack_enabled = True
+        self.config.alerts.slack_webhook = 12345
+        errors = check_default_credentials(self.config)
+        self.assertEqual(len(errors), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🎯 What
Added test coverage to ensure `check_default_credentials` properly handles non-string values (e.g., `None`, integers) in configuration objects without throwing TypeErrors.

## 📊 Coverage
- `email=None`
- `app_password=<int>`
- `webhook_url=None`
- `slack_webhook=<int>`

## ✨ Result
Validation runs cleanly and correctly reports 0 errors for these edge cases, increasing robustness.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->