### PR TITLE
Fix missing whitespace filenames in email parser

### DIFF
--- a/src/modules/email_parser.py
+++ b/src/modules/email_parser.py
@@ -493,7 +493,9 @@ class EmailParser:
         # SECURITY FIX: Handle missing filenames to prevent analysis bypass
         # If no filename is provided, generate a fallback name to ensure
         # the attachment is analyzed instead of silently dropped.
-        if not raw_filename:
+        # We also check if sanitize_filename returns 'unnamed_attachment' (which means the original
+        # filename was completely invalid, e.g. purely path traversal like '../../') to apply the proper extension.
+        if not raw_filename.strip() or sanitize_filename(raw_filename) == "unnamed_attachment":
             content_type = part.get_content_type()
             # Guess extension from MIME type (e.g. image/jpeg -> .jpg)
             ext = mimetypes.guess_extension(content_type) or ".bin"
@@ -501,7 +503,7 @@ class EmailParser:
             raw_filename = f"unnamed_attachment_{uuid.uuid4().hex[:8]}{ext}"
 
             self.logger.warning(
-                f"Attachment in email {safe_email_id} has no filename. "
+                f"Attachment in email {safe_email_id} has no valid filename. "
                 f"Assigned fallback name: {raw_filename}"
             )
         filename = sanitize_filename(raw_filename)


### PR DESCRIPTION
This PR addresses an issue where attachments with filenames containing only whitespace or malicious paths (e.g. `../../../`) bypass the missing filename check. By checking `if not raw_filename.strip() or sanitize_filename(raw_filename) == 'unnamed_attachment'`, we ensure these edge cases are caught and assigned a properly generated fallback name with the correct guessed extension.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->