### PR TITLE
⚡ Bolt: optimize IMAP batch sizes to reduce round-trips

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -67,3 +67,8 @@
 
 **Learning:** Python's `datetime.now()` with `timedelta` objects incur high instantiation and garbage collection overhead, which compounds in hot cache eviction loops like `TTLCache`.
 **Action:** Replace `datetime.now()` and `timedelta` with `time.monotonic()` and float arithmetic. This avoids the object creation overhead and is more resilient to system clock adjustments.
+
+## 2025-10-25 - [Performance Optimization: IMAP Batch Fetching]
+
+**Learning:** When fetching emails via IMAP, doing so in very small batches (e.g., 10) significantly incurs round-trip overhead and unnecessary rate limit sleep times, blocking for `0.5s` per batch. 
+**Action:** Increase the `batch_size` to `50` in `src/modules/imap_connection.py`. This significantly minimizes IMAP round-trips and redundant rate-limit sleeps during email retrieval. Avoid checking metadata/sizes (e.g., `RFC822.SIZE`) for *all* unread emails simultaneously without batching, as this risks exceeding IMAP protocol command length limits. 

--- a/src/modules/imap_connection.py
+++ b/src/modules/imap_connection.py
@@ -262,7 +262,8 @@ class IMAPConnection:
 
             # Process in batches for rate limiting
             emails = []
-            batch_size = 10
+            # Increased to 50 to minimize 0.5s sleep overhead per batch
+            batch_size = 50
 
             for i in range(0, len(email_ids), batch_size):
                 if i > 0:

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -1,4 +1,3 @@
-
 import signal
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
💡 **What:** Increased IMAP email fetching batch size from 10 to 50.
🎯 **Why:** To reduce network round-trips to the IMAP server and significantly minimize the overhead of redundant rate-limiting sleeps when processing unread emails.
📊 **Impact:** Expect a measurable reduction in fetch times for accounts with large numbers of unread emails, effectively improving throughput while staying safely below protocol limits.
🔬 **Measurement:** Execute `python3 -m pytest tests/test_imap_connection.py` or observe email fetching speed during pipeline execution.