### PR TITLE
🧹 fix: remove unused unicodedata import (salvages #822)

### DIFF
--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -9,7 +9,6 @@ import re
 import shutil
 import textwrap
 import threading
-
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import Dict, List, Optional


### PR DESCRIPTION
## Salvage of #822

Rebased on `main`.

Salvages: #822