### PR TITLE
⚡ Bolt: optimize IMAP batch sizes to reduce round-trips

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -67,3 +67,8 @@
 
 **Learning:** Python's `datetime.now()` with `timedelta` objects incur high instantiation and garbage collection overhead, which compounds in hot cache eviction loops like `TTLCache`.
 **Action:** Replace `datetime.now()` and `timedelta` with `time.monotonic()` and float arithmetic. This avoids the object creation overhead and is more resilient to system clock adjustments.
+
+## 2025-08-01 - [Performance Optimization: Optimize IMAP batch sizes to reduce round-trips]
+
+**Learning:** During email retrieval, fetching unseen emails via IMAP uses a two-step process to prevent DoS attacks by first checking `RFC822.SIZE`. Checking metadata and fetching emails in extremely small batches (e.g., 10) causes excessive round-trips to the server and redundant rate-limiting sleeps, creating a bottleneck. However, requesting all unread emails simultaneously without batching risks exceeding IMAP protocol command length limits.
+**Action:** Use a `batch_size` of 50 in `src/modules/imap_connection.py`. This significantly reduces overhead from repeated network latency and rate-limit sleeps while safely staying within IMAP command limits.

--- a/src/modules/imap_connection.py
+++ b/src/modules/imap_connection.py
@@ -261,8 +261,10 @@ class IMAPConnection:
             self.logger.info(f"Found {len(email_ids)} unseen emails in {safe_folder}")
 
             # Process in batches for rate limiting
+            # Optimization: Increased batch_size to 50 to reduce IMAP round-trips
+            # and redundant rate-limit sleeps while remaining safely within limits.
             emails = []
-            batch_size = 10
+            batch_size = 50
 
             for i in range(0, len(email_ids), batch_size):
                 if i > 0:


### PR DESCRIPTION
💡 **What:** Increased IMAP email fetching batch size from 10 to 50.
🎯 **Why:** To reduce network round-trips to the IMAP server and significantly minimize the overhead of redundant rate-limiting sleeps when processing unread emails.
📊 **Impact:** Expect a measurable reduction in fetch times for accounts with large numbers of unread emails, effectively improving throughput while staying safely below protocol limits.
🔬 **Measurement:** Execute `python3 -m pytest tests/test_imap_connection.py` or observe email fetching speed during pipeline execution.

---
*PR created automatically by Jules for task [7128005423744389324](https://jules.google.com/task/7128005423744389324) started by @abhimehro*