### PR TITLE
🎨 Palette: Display all threat indicators in console alerts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -164,3 +164,6 @@
 ## 2025-05-18 - Visual Distinction for User Input in CLI
 **Learning:** In interactive CLI wizards, unstyled text for user input can blend into the surrounding informational text or prompts, making it hard to read and lowering the overall visual hierarchy.
 **Action:** Always append `Colors.BOLD` to the end of prompt strings immediately before calling `input()` or `getpass()` to inherit the styling to the user's typing, and use `sys.stdout.write(Colors.RESET)` or `print(Colors.RESET, end="")` immediately after to restore the terminal formatting.
+## 2026-05-19 - Complete Threat Indicator Rendering in CLI
+**Learning:** Threat indicators detected by the analysis engine (`urgency_markers`, `psychological_triggers`, `suspicious_attachments`, `size_anomalies`, `potential_deepfakes`) were present in the `ThreatReport` but visually hidden from the user because the CLI rendering methods (`_print_nlp_details` and `_print_media_details`) did not explicitly handle them.
+**Action:** Explicitly mapping and rendering all list-based properties of a complex data structure (like `ThreatReport`) in the UI ensures that users are fully aware of all detected issues, closing the gap between backend detection capabilities and frontend visibility.

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -524,6 +524,34 @@ class AlertSystem:
                 )
             has_nlp = True
 
+        if nlp_analysis.get("urgency_markers"):
+            self._print_alert_row(
+                Colors.colorize("Urgency Markers:", Colors.BOLD),
+                risk_color,
+                indent=3,
+            )
+            for ind in nlp_analysis["urgency_markers"][
+                : self.MAX_NLP_INDICATORS_DISPLAY
+            ]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.YELLOW)} {ind}", risk_color, indent=5
+                )
+            has_nlp = True
+
+        if nlp_analysis.get("psychological_triggers"):
+            self._print_alert_row(
+                Colors.colorize("Psychological Triggers:", Colors.BOLD),
+                risk_color,
+                indent=3,
+            )
+            for ind in nlp_analysis["psychological_triggers"][
+                : self.MAX_NLP_INDICATORS_DISPLAY
+            ]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.YELLOW)} {ind}", risk_color, indent=5
+                )
+            has_nlp = True
+
         if not has_nlp:
             self._print_alert_row(
                 f"{Colors.colorize('✓', Colors.GREEN)} No social engineering or impersonation detected",
@@ -532,6 +560,7 @@ class AlertSystem:
             )
 
     def _print_media_details(self, media_analysis: Dict, risk_color: str) -> None:
+        has_media_issue = False
         if media_analysis.get("file_type_warnings"):
             self._print_alert_row(
                 Colors.colorize("File Warnings:", Colors.BOLD), risk_color, indent=3
@@ -544,7 +573,51 @@ class AlertSystem:
                     risk_color,
                     indent=5,
                 )
-        else:
+            has_media_issue = True
+
+        if media_analysis.get("suspicious_attachments"):
+            self._print_alert_row(
+                Colors.colorize("Suspicious Attachments:", Colors.BOLD), risk_color, indent=3
+            )
+            for attachment in media_analysis["suspicious_attachments"][
+                : self.MAX_MEDIA_WARNINGS_DISPLAY
+            ]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.RED)} {attachment}",
+                    risk_color,
+                    indent=5,
+                )
+            has_media_issue = True
+
+        if media_analysis.get("size_anomalies"):
+            self._print_alert_row(
+                Colors.colorize("Size Anomalies:", Colors.BOLD), risk_color, indent=3
+            )
+            for anomaly in media_analysis["size_anomalies"][
+                : self.MAX_MEDIA_WARNINGS_DISPLAY
+            ]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.YELLOW)} {anomaly}",
+                    risk_color,
+                    indent=5,
+                )
+            has_media_issue = True
+
+        if media_analysis.get("potential_deepfakes"):
+            self._print_alert_row(
+                Colors.colorize("Potential Deepfakes:", Colors.BOLD), risk_color, indent=3
+            )
+            for deepfake in media_analysis["potential_deepfakes"][
+                : self.MAX_MEDIA_WARNINGS_DISPLAY
+            ]:
+                self._print_alert_row(
+                    f"{Colors.colorize('•', Colors.RED)} {deepfake}",
+                    risk_color,
+                    indent=5,
+                )
+            has_media_issue = True
+
+        if not has_media_issue:
             self._print_alert_row(
                 f"{Colors.colorize('✓', Colors.GREEN)} Attachments appear safe",
                 risk_color,


### PR DESCRIPTION
## 💡 What
This UX enhancement explicitly renders all list-based properties of the `ThreatReport` in the console UI. Specifically, it adds support for displaying `urgency_markers` and `psychological_triggers` under NLP Analysis, and `suspicious_attachments`, `size_anomalies`, and `potential_deepfakes` under Media Analysis.

## 🎯 Why
Previously, these threat indicators were accurately detected by the analysis engine and included in the `ThreatReport`, but they were not mapped in `_print_nlp_details` and `_print_media_details`. This resulted in threats being visually hidden from the user, undermining trust. Furthermore, the system could incorrectly output 'Attachments appear safe' when file type warnings were empty but other critical media issues (like deepfakes) were present. This ensures the user gets comprehensive visual feedback.

## ♿ Accessibility / UX
Ensures that the state of the backend analysis is transparently communicated to the user without silent omissions.

ELIR
PURPOSE: Make all threat indicators visible in the CLI output.
SECURITY: Prevents false sense of security by fixing 'safe' messages when non-file-type threats exist.
FAILS IF: A new list property is added to `ThreatReport` without updating the print methods.
VERIFY: Console output now explicitly lists urgency markers and suspicious attachments.
MAINTAIN: When adding new threat indicators to `ThreatReport`, the corresponding `_print_*_details` method must also be updated.