### PR TITLE
⚡ Bolt: [Performance Optimization] Increase IMAP fetch batch size

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -67,3 +67,8 @@
 
 **Learning:** Python's `datetime.now()` with `timedelta` objects incur high instantiation and garbage collection overhead, which compounds in hot cache eviction loops like `TTLCache`.
 **Action:** Replace `datetime.now()` and `timedelta` with `time.monotonic()` and float arithmetic. This avoids the object creation overhead and is more resilient to system clock adjustments.
+
+## 2025-10-25 - [Performance Optimization: IMAP Batch Fetching]
+
+**Learning:** When fetching emails via IMAP, doing so in very small batches (e.g., 10) significantly incurs round-trip overhead and unnecessary rate limit sleep times, blocking for `0.5s` per batch.
+**Action:** Increase the `batch_size` to `50` in `src/modules/imap_connection.py`. This significantly minimizes IMAP round-trips and redundant rate-limit sleeps during email retrieval. Avoid checking metadata/sizes (e.g., `RFC822.SIZE`) for *all* unread emails simultaneously without batching, as this risks exceeding IMAP protocol command length limits.

--- a/src/modules/imap_connection.py
+++ b/src/modules/imap_connection.py
@@ -262,7 +262,8 @@ class IMAPConnection:
 
             # Process in batches for rate limiting
             emails = []
-            batch_size = 10
+            # Increased to 50 to minimize 0.5s sleep overhead per batch
+            batch_size = 50
 
             for i in range(0, len(email_ids), batch_size):
                 if i > 0:

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -1,4 +1,3 @@
-
 import signal
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
💡 **What:** Increased the `batch_size` parameter in `src/modules/imap_connection.py` from 10 to 50.\n\n🎯 **Why:** When fetching emails via IMAP, doing so in very small batches (e.g., 10) significantly incurs round-trip overhead and unnecessary rate limit sleep times, blocking for `0.5s` per batch. This increases processing time exponentially for large inboxes.\n\n📊 **Impact:** Significantly minimizes IMAP round-trips and redundant rate-limit sleeps during email retrieval, speeding up overall execution while avoiding checking metadata/sizes for *all* unread emails simultaneously without batching (which risks exceeding IMAP protocol command length limits).\n\n🔬 **Measurement:** Verify that email ingestion completes faster for folders with >10 unread emails without hitting API rate limits or IMAP protocol limits.

---
*PR created automatically by Jules for task [2139664894080763329](https://jules.google.com/task/2139664894080763329) started by @abhimehro*