### PR TITLE
chore(deps): bump pre-commit-hooks v4.5.0 → v5.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Basic file quality checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -38,6 +38,6 @@ repos:
 
   # Verify requirements.txt format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: requirements-txt-fixer


### PR DESCRIPTION
## Summary

Bump `pre-commit/pre-commit-hooks` from v4.5.0 to v5.0.0 in `.pre-commit-config.yaml` (both entries) to resolve deprecated stage-name warnings emitted by pre-commit.

---

## Type of Change

- [ ] `feat` – new feature
- [ ] `fix` – bug fix
- [ ] `docs` – documentation only
- [x] `chore` – maintenance (deps, config, CI)
- [ ] `test` – test additions or improvements
- [ ] `perf` – performance improvement
- [ ] `refactor` – code restructuring, no behaviour change

---

## What Changed and Why

The v4.5.0 hooks define stages using the deprecated names `commit` and `push`. pre-commit v3.2+ warns about these on every run. v5.0.0 uses the updated stage names (`pre-commit`, `pre-push`), eliminating the warnings. Both hook entries (main hooks + `requirements-txt-fixer`) are updated.

---

## How Was This Tested?

- [x] `python3 -m pytest` passes locally (594 passed)
- [x] `pre-commit run --all-files` passes locally — all 17 hooks pass, no deprecation warnings

---

## Security Implications

- [x] No secrets or credentials are introduced or exposed by this change
- Security notes: No security impact — only bumps a pre-commit hook version.

---

## Checklist

- [x] Branch follows naming convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages are clear and descriptive
- [x] New or modified code includes relevant tests
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Documentation updated if behaviour changed (README, docstrings, etc.)
- [x] No secrets, credentials, or `.env` files are included in this PR

Link to Devin session: https://app.devin.ai/sessions/752bcd4623c547a1b4bf256778a0e61c
Requested by: @abhimehro