### PR TITLE
🧹 Remove unused validate_subject_length function

### DIFF
--- a/src/utils/security_validators.py
+++ b/src/utils/security_validators.py
@@ -144,25 +144,6 @@ def create_secure_ssl_context() -> ssl.SSLContext:
     return context
 
 
-def validate_subject_length(subject: str) -> str:
-    """
-    Validate and truncate subject line to prevent DoS attacks.
-
-    SECURITY STORY: Extremely long subject lines can cause memory exhaustion
-    or buffer overflows in downstream systems. We truncate to a safe length.
-
-    Args:
-        subject: Email subject line
-
-    Returns:
-        Truncated subject line if it exceeds MAX_SUBJECT_LENGTH
-
-    """
-    if len(subject) > MAX_SUBJECT_LENGTH:
-        logger.warning(f"Subject exceeds {MAX_SUBJECT_LENGTH} chars, truncating")
-        return subject[:MAX_SUBJECT_LENGTH]
-    return subject
-
 
 def validate_mime_parts_count(count: int) -> bool:
     """

--- a/tests/test_security_validators_dos.py
+++ b/tests/test_security_validators_dos.py
@@ -3,39 +3,14 @@ import unittest
 from src.utils.security_validators import (
     DEFAULT_MAX_EMAIL_SIZE,
     MAX_MIME_PARTS,
-    MAX_SUBJECT_LENGTH,
     calculate_max_email_size,
     validate_mime_parts_count,
-    validate_subject_length,
 )
 
 # calculate_max_email_size is expected to add a fixed 5 MB overhead to any
 # positive attachment limit. Mirror that contract here so the tests clearly
 # document and verify this behavior.
 _OVERHEAD_BYTES = 5 * 1024 * 1024
-
-
-class TestValidateSubjectLength(unittest.TestCase):
-
-    def test_short_subject_returned_unchanged(self):
-        subject = "Hello World"
-        self.assertEqual(validate_subject_length(subject), subject)
-
-    def test_subject_at_exact_limit_returned_unchanged(self):
-        subject = "A" * MAX_SUBJECT_LENGTH
-        self.assertEqual(validate_subject_length(subject), subject)
-
-    def test_subject_one_over_limit_is_truncated(self):
-        subject = "B" * (MAX_SUBJECT_LENGTH + 1)
-        result = validate_subject_length(subject)
-        self.assertEqual(len(result), MAX_SUBJECT_LENGTH)
-        self.assertEqual(result, "B" * MAX_SUBJECT_LENGTH)
-
-    def test_very_long_subject_is_truncated(self):
-        subject = "C" * (MAX_SUBJECT_LENGTH * 10)
-        result = validate_subject_length(subject)
-        self.assertEqual(len(result), MAX_SUBJECT_LENGTH)
-        self.assertEqual(result, "C" * MAX_SUBJECT_LENGTH)
 
 
 class TestValidateMimePartsCount(unittest.TestCase):


### PR DESCRIPTION
🎯 **What:** Removed the unused `validate_subject_length` function from `src/utils/security_validators.py` and its corresponding tests.

💡 **Why:** The function was unused dead code across the project. Subject length validation is handled directly in `src/modules/email_parser.py` using the `MAX_SUBJECT_LENGTH` constant. Removing it improves codebase maintainability and reduces clutter.

✅ **Verification:** Verified by checking project-wide references, executing `git diff` for changes, and running the full `python3 -m pytest` test suite, which passed successfully (590 tests).

✨ **Result:** A cleaner codebase with reduced dead code while maintaining the exact same security functionality.