### PR TITLE
🧹 Refactor _extract_attachment in EmailParser for improved readability

### DIFF
--- a/src/modules/email_parser.py
+++ b/src/modules/email_parser.py
@@ -460,6 +460,70 @@ class EmailParser:
             body_dict[f"{key}_parts"] = parts
             body_dict[f"{key}_len"] = new_len
 
+    def _is_attachment_count_valid(
+        self, attachments: List[Dict[str, Any]], safe_email_id: str
+    ) -> bool:
+        """Check if adding another attachment exceeds the limit."""
+        if len(attachments) >= self.max_attachment_count:
+            self.logger.warning(
+                f"Max attachment count ({self.max_attachment_count}) reached "
+                f"for email {safe_email_id}. Skipping remaining attachments."
+            )
+            return False
+        return True
+
+    def _get_safe_filename(self, part: Message, safe_email_id: str) -> Tuple[str, str]:
+        """Extract and sanitize filename, generating a safe fallback if necessary."""
+        raw_filename = self._decode_header_value(part.get_filename() or "")
+
+        if (
+            not raw_filename.strip()
+            or sanitize_filename(raw_filename) == "unnamed_attachment"
+        ):
+            content_type = part.get_content_type()
+            ext = mimetypes.guess_extension(content_type) or ".bin"
+            raw_filename = f"unnamed_attachment_{uuid.uuid4().hex[:8]}{ext}"
+            self.logger.warning(
+                f"Attachment in email {safe_email_id} has no valid filename. "
+                f"Assigned fallback name: {raw_filename}"
+            )
+
+        filename = sanitize_filename(raw_filename)
+        safe_filename = sanitize_for_logging(filename)
+        return filename, safe_filename
+
+    def _is_total_size_valid(
+        self,
+        current_total_size: int,
+        original_size: int,
+        safe_filename: str,
+        safe_email_id: str,
+    ) -> bool:
+        """Check if adding this attachment exceeds the total size limit."""
+        if self.max_total_attachment_bytes > 0:
+            if (current_total_size + original_size) > self.max_total_attachment_bytes:
+                self.logger.warning(
+                    f"Max total attachment size ({self.max_total_attachment_bytes}) "
+                    f"exceeded for email {safe_email_id}. Skipping attachment {safe_filename}."
+                )
+                return False
+        return True
+
+    def _truncate_payload(
+        self, payload: bytes, original_size: int, safe_filename: str
+    ) -> Tuple[bytes, bool]:
+        """Truncate attachment payload if it exceeds the individual max size limit."""
+        truncated = False
+        if self.max_attachment_bytes > 0 and original_size > self.max_attachment_bytes:
+            self.logger.warning(
+                "Attachment %s exceeds max size (%d bytes); truncating for analysis",
+                safe_filename,
+                original_size,
+            )
+            payload = payload[: self.max_attachment_bytes]
+            truncated = True
+        return payload, truncated
+
     def _extract_attachment(
         self,
         part: Message,
@@ -479,62 +543,22 @@ class EmailParser:
             Attachment dict if valid, None if rejected
 
         """
-        # Check attachment count limit
-        if len(attachments) >= self.max_attachment_count:
-            self.logger.warning(
-                f"Max attachment count ({self.max_attachment_count}) reached "
-                f"for email {safe_email_id}. Skipping remaining attachments."
-            )
+        if not self._is_attachment_count_valid(attachments, safe_email_id):
             return None
 
-        # Get and sanitize filename
-        raw_filename = self._decode_header_value(part.get_filename() or "")
+        filename, safe_filename = self._get_safe_filename(part, safe_email_id)
 
-        # SECURITY FIX: Handle missing filenames to prevent analysis bypass
-        # If no filename is provided, generate a fallback name to ensure
-        # the attachment is analyzed instead of silently dropped.
-        # We also check if sanitize_filename returns 'unnamed_attachment' (which means the original
-        # filename was completely invalid, e.g. purely path traversal like '../../') to apply the proper extension.
-        if (
-            not raw_filename.strip()
-            or sanitize_filename(raw_filename) == "unnamed_attachment"
-        ):
-            content_type = part.get_content_type()
-            # Guess extension from MIME type (e.g. image/jpeg -> .jpg)
-            ext = mimetypes.guess_extension(content_type) or ".bin"
-            # Generate unique fallback name
-            raw_filename = f"unnamed_attachment_{uuid.uuid4().hex[:8]}{ext}"
-
-            self.logger.warning(
-                f"Attachment in email {safe_email_id} has no valid filename. "
-                f"Assigned fallback name: {raw_filename}"
-            )
-        filename = sanitize_filename(raw_filename)
-        safe_filename = sanitize_for_logging(filename)
-
-        # Get attachment data
         payload = part.get_payload(decode=True) or b""
         original_size = len(payload)
 
-        # Check total size limit
-        if self.max_total_attachment_bytes > 0:
-            if (current_total_size + original_size) > self.max_total_attachment_bytes:
-                self.logger.warning(
-                    f"Max total attachment size ({self.max_total_attachment_bytes}) "
-                    f"exceeded for email {safe_email_id}. Skipping attachment {safe_filename}."
-                )
-                return None
+        if not self._is_total_size_valid(
+            current_total_size, original_size, safe_filename, safe_email_id
+        ):
+            return None
 
-        # Check and truncate individual attachment size
-        truncated = False
-        if self.max_attachment_bytes > 0 and original_size > self.max_attachment_bytes:
-            self.logger.warning(
-                "Attachment %s exceeds max size (%d bytes); truncating for analysis",
-                safe_filename,
-                original_size,
-            )
-            payload = payload[: self.max_attachment_bytes]
-            truncated = True
+        payload, truncated = self._truncate_payload(
+            payload, original_size, safe_filename
+        )
 
         return {
             "filename": filename,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored the complex `_extract_attachment` function in `src/modules/email_parser.py` into multiple smaller, cohesive helper methods: `_is_attachment_count_valid`, `_get_safe_filename`, `_is_total_size_valid`, and `_truncate_payload`.

💡 **Why:** How this improves maintainability
The original `_extract_attachment` method was long and handled multiple distinct responsibilities (checking count limits, sanitizing filenames, checking total size limits, and truncating payloads). Extracting these into separate methods significantly improves readability and makes the code easier to test and maintain. It follows the Single Responsibility Principle more closely.

✅ **Verification:** How you confirmed the change is safe
Ran the full test suite via `pytest` to ensure no functionality was broken. Also ran formatters and linters (`black`, `flake8`, `bandit`, and `pre-commit`) to ensure the changes meet code quality and security standards. 

✨ **Result:** The improvement achieved
A much cleaner, more readable `_extract_attachment` method that is easier to comprehend at a glance, while preserving identical behavior and security logic.

---
*PR created automatically by Jules for task [14308772085869991007](https://jules.google.com/task/14308772085869991007) started by @abhimehro*