### PR TITLE
🧹 Refactor unused `replace_secret` method to lambda in setup_wizard

### DIFF
--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -303,10 +303,11 @@ def _generate_config_content(
     )
 
     # Set app_secret safely
-    def replace_secret(match):
-        return f"{provider_key}_APP_PASSWORD={app_secret}"
-
-    content = re.sub(f"{provider_key}_APP_PASSWORD=.*", replace_secret, content)
+    content = re.sub(
+        f"{provider_key}_APP_PASSWORD=.*",
+        lambda _: f"{provider_key}_APP_PASSWORD={app_secret}",
+        content,
+    )
 
     return content
 


### PR DESCRIPTION
🎯 **What:** Replaced the standalone `replace_secret` function callback used in `re.sub` with a simple lambda expression.

💡 **Why:** Static analysis tools often flag nested callback functions like `replace_secret` as unused methods. By switching to a lambda expression, we eliminate this false-positive linting noise while maintaining the required safety (ignoring `re.sub` regex backreferences inside passwords).

✅ **Verification:** Verified the code changes locally. Handled edge cases with backslashes correctly. `test_setup_wizard.py` runs and the explicit test `test_generate_config_content_replaces_secret` passes.

✨ **Result:** Cleaner code, less linting noise, identical safe behavior.

══════════ ELIR ══════════
PURPOSE: Simplify a configuration variable regex replace from a nested function to a lambda callback.
SECURITY: Lambdas prevent `re.sub` from improperly parsing user-supplied passwords containing special characters (like `\1`) as regex backreferences, which avoids unexpected application errors.
FAILS IF: Python's `re.sub` implementation changes how lambdas return substitution strings (highly unlikely).
VERIFY: The `.env` generated by the setup wizard properly maintains the exact user-typed app password regardless of special characters.
MAINTAIN: Future `re.sub` updates involving dynamic untrusted strings should continue to use a lambda callback pattern instead of direct strings to prevent regex backreference exceptions.