### PR TITLE
🧹 [code health] Remove unused function validate_mime_parts_count

### DIFF
--- a/.jules/rm_dead_code_dos.md
+++ b/.jules/rm_dead_code_dos.md
@@ -1,0 +1,3 @@
+## 2025-05-24 - Remove unused `validate_mime_parts_count` function
+**Learning:** Found and removed an unused function `validate_mime_parts_count` from `src/utils/security_validators.py` and its corresponding test class from `tests/test_security_validators_dos.py`.
+**Action:** Removed unused function and test class using Python scripts to prevent dead code and improve code health.

--- a/src/utils/security_validators.py
+++ b/src/utils/security_validators.py
@@ -164,27 +164,6 @@ def validate_subject_length(subject: str) -> str:
     return subject
 
 
-def validate_mime_parts_count(count: int) -> bool:
-    """
-    Check if MIME parts count is within safe limits.
-
-    SECURITY STORY: MIME bomb attacks use deeply nested MIME structures
-    to cause exponential processing time or memory exhaustion. We limit
-    the total number of MIME parts to prevent this.
-
-    Args:
-        count: Number of MIME parts in the email
-
-    Returns:
-        True if count is safe, False if it exceeds limits
-
-    """
-    if count > MAX_MIME_PARTS:
-        logger.error(f"Email has {count} MIME parts, exceeds limit of {MAX_MIME_PARTS}")
-        return False
-    return True
-
-
 def calculate_max_email_size(max_total_attachment_bytes: int) -> int:
     """
     Calculate maximum email size based on attachment limits.

--- a/tests/test_security_validators_dos.py
+++ b/tests/test_security_validators_dos.py
@@ -2,10 +2,8 @@ import unittest
 
 from src.utils.security_validators import (
     DEFAULT_MAX_EMAIL_SIZE,
-    MAX_MIME_PARTS,
     MAX_SUBJECT_LENGTH,
     calculate_max_email_size,
-    validate_mime_parts_count,
     validate_subject_length,
 )
 
@@ -36,21 +34,6 @@ class TestValidateSubjectLength(unittest.TestCase):
         result = validate_subject_length(subject)
         self.assertEqual(len(result), MAX_SUBJECT_LENGTH)
         self.assertEqual(result, "C" * MAX_SUBJECT_LENGTH)
-
-
-class TestValidateMimePartsCount(unittest.TestCase):
-
-    def test_count_of_one_is_safe(self):
-        self.assertTrue(validate_mime_parts_count(1))
-
-    def test_count_at_exact_limit_is_safe(self):
-        self.assertTrue(validate_mime_parts_count(MAX_MIME_PARTS))
-
-    def test_count_one_over_limit_is_rejected(self):
-        self.assertFalse(validate_mime_parts_count(MAX_MIME_PARTS + 1))
-
-    def test_count_of_zero_is_safe(self):
-        self.assertTrue(validate_mime_parts_count(0))
 
 
 class TestCalculateMaxEmailSize(unittest.TestCase):


### PR DESCRIPTION
## 🎯 What
Removed the unused `validate_mime_parts_count` function from `src/utils/security_validators.py` and its corresponding test class from `tests/test_security_validators_dos.py`.

## 💡 Why
No references to this function exist across the project. Removing it reduces dead code, improving codebase maintainability.

## ✅ Verification
1. Confirmed absence of function usages via `grep`.
2. Ran formatting and linting checks (`black`, `flake8`), fixing an unused import.
3. Verified the test suite using `unittest`.

## ✨ Result
Reduced dead code in the `security_validators` module without changing system behavior.

---
*PR created automatically by Jules for task [7174601922635459695](https://jules.google.com/task/7174601922635459695) started by @abhimehro*