### PR TITLE
🔒 Fix TOCTOU vulnerability in configuration file permission fallbacks

### DIFF
--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -159,10 +159,7 @@ class AppRunner:
                             | getattr(os, "O_NOFOLLOW", 0),
                             0o600,
                         )
-                        try:
-                            os.fchmod(fd, 0o600)
-                        except (AttributeError, OSError, NotImplementedError):
-                            os.chmod(self.config_file, 0o600)
+                        self._set_secure_permissions(fd)
 
                         with os.fdopen(fd, "wb") as dst:
                             dst.write(content)
@@ -332,7 +329,37 @@ class AppRunner:
                 os.chmod(fd, 0o600)
             except (AttributeError, OSError, NotImplementedError, TypeError):
                 # Final fallback to path-based chmod (e.g. Windows)
-                os.chmod(self.config_file, 0o600)
+                # To prevent TOCTOU, verify the file descriptor matches the path
+                try:
+                    stat_fd = os.fstat(fd)
+                    stat_path = (
+                        os.lstat(self.config_file)
+                        if hasattr(os, "lstat")
+                        else os.stat(self.config_file)
+                    )
+
+                    if (
+                        stat_fd.st_ino == stat_path.st_ino
+                        and stat_fd.st_dev == stat_path.st_dev
+                    ):
+                        # Use follow_symlinks=False if supported
+                        kwargs = (
+                            {"follow_symlinks": False}
+                            if os.chmod
+                            in getattr(os, "supports_follow_symlinks", set())
+                            else {}
+                        )
+                        os.chmod(self.config_file, 0o600, **kwargs)
+                    else:
+                        print(f"Error: TOCTOU detected on '{self.config_file}'.")
+                        import sys
+
+                        sys.exit(1)
+                except OSError as e:
+                    print(f"Error setting permissions: {e}")
+                    import sys
+
+                    sys.exit(1)
 
     def start_pipeline(self) -> None:
         """Instantiate and start the main pipeline."""

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -360,7 +360,41 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
                 os.chmod(fd, 0o600)
             except (AttributeError, OSError, NotImplementedError, TypeError):
                 # Final fallback to path-based chmod
-                os.chmod(str(config_path), 0o600)
+                # To prevent TOCTOU, verify the file descriptor matches the path
+                try:
+                    stat_fd = os.fstat(fd)
+                    stat_path = (
+                        os.lstat(str(config_path))
+                        if hasattr(os, "lstat")
+                        else os.stat(str(config_path))
+                    )
+
+                    if (
+                        stat_fd.st_ino == stat_path.st_ino
+                        and stat_fd.st_dev == stat_path.st_dev
+                    ):
+                        # Use follow_symlinks=False if supported
+                        kwargs = (
+                            {"follow_symlinks": False}
+                            if os.chmod
+                            in getattr(os, "supports_follow_symlinks", set())
+                            else {}
+                        )
+                        os.chmod(str(config_path), 0o600, **kwargs)
+                    else:
+                        print(
+                            f"\n{Colors.colorize('Error:', Colors.RED)} TOCTOU detected on '{config_path}'."
+                        )
+                        import sys
+
+                        sys.exit(1)
+                except OSError as e:
+                    print(
+                        f"\n{Colors.colorize('Error setting permissions:', Colors.RED)} {e}"
+                    )
+                    import sys
+
+                    sys.exit(1)
 
         with os.fdopen(fd, "w") as f:
             f.write(new_content)


### PR DESCRIPTION
🎯 **What:** The path-based chmod fallback during configuration file creation could lead to a TOCTOU (Time-Of-Check to Time-Of-Use) vulnerability.

⚠️ **Risk:** An attacker could replace the config file with a symlink pointing to an arbitrary file between the time the file descriptor is opened and the fallback chmod is applied on the path, modifying permissions on arbitrary system files.

🛡️ **Solution:** Implemented stat checks comparing inode and device IDs of the file descriptor against the file path before executing path-based chmod, and utilized follow_symlinks=False where available to ensure permissions are only applied to the intended file.