### PR TITLE
🧹 convert comment to variable docstring in pattern_compiler

### DIFF
--- a/src/utils/pattern_compiler.py
+++ b/src/utils/pattern_compiler.py
@@ -16,8 +16,6 @@ these helpers so that the ReDoS guard and flag defaults are always applied unifo
 import re
 from typing import Dict, List, Tuple
 
-# Known ReDoS signatures — nested or repeated quantifiers on unbounded character
-# classes are the most common source of catastrophic backtracking.
 _REDOS_SIGNATURES: List[str] = [
     r"(\w+)*",
     r"(\d+)+",
@@ -25,6 +23,10 @@ _REDOS_SIGNATURES: List[str] = [
     r"(a+)+",
     r"([a-zA-Z]+)*",
 ]
+"""
+Known ReDoS signatures — nested or repeated quantifiers on unbounded character
+classes are the most common source of catastrophic backtracking.
+"""
 
 
 def check_redos_safety(patterns: List[str]) -> None:


### PR DESCRIPTION
## What
Converted the comment above `_REDOS_SIGNATURES` into a proper string literal docstring immediately following the assignment.

## Why
This addresses a code health issue where the explanatory comment might be interpreted as commented-out code. Using an attribute docstring conforms to standard conventions while preserving the useful context.

## Verification
Checked that there were no regressions in `test_pattern_compiler.py` and that formatting/linting via `black` and `flake8` still pass.