### PR TITLE
🎨 Palette: Enhance setup wizard menu with semantic colors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -168,3 +168,6 @@
 ## 2027-02-18 - Missing Rendering Paths for Nested UI
 **Learning:** Hardcoded display logic in CLI views that only checks a subset of available threat dictionary keys creates a disconnect where underlying threats (like potential deepfakes or urgency markers) are detected and sent via webhooks, but remain visually hidden from the CLI user.
 **Action:** Replaced hardcoded key checks in `alert_system.py` with configuration lists that iterate over all possible threat indicators to dynamically display any present threat to the user.
+## 2027-02-18 - Semantic Colors for Menu Scannability
+**Learning:** Flat, unstyled terminal menus require users to read every word to understand the distinction between options. By using bolding for numbers and semantic colors for caveats (e.g., Green for Recommended, Yellow for restrictions), users can instantly visually parse the menu hierarchy and recommendations.
+**Action:** Apply semantic coloring and bold text to distinct components (indices, primary text, caveats) of terminal menu options to enhance scannability.

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -145,10 +145,10 @@ def _test_connection(email: str, app_password: str, provider_choice: str) -> boo
 def _select_provider() -> str:
     """Prompt user to select an email provider."""
     print(f"\n{Colors.CYAN}Step 1 of 2: Choose your email provider{Colors.RESET}")
-    print("  1. Gmail (Recommended)")
-    print("  2. Proton Mail (Requires Bridge)")
-    print("  3. Outlook (Business Only)")
-    print("  4. Skip (Manually edit .env)")
+    print(f"  {Colors.colorize('1.', Colors.BOLD)} Gmail {Colors.colorize('(Recommended)', Colors.GREEN)}")
+    print(f"  {Colors.colorize('2.', Colors.BOLD)} Proton Mail {Colors.colorize('(Requires Bridge)', Colors.GREY)}")
+    print(f"  {Colors.colorize('3.', Colors.BOLD)} Outlook {Colors.colorize('(Business Only)', Colors.YELLOW)}")
+    print(f"  {Colors.colorize('4.', Colors.BOLD)} Skip {Colors.colorize('(Manually edit .env)', Colors.GREY)}")
 
     while True:
         try:


### PR DESCRIPTION
🎯 **What:**
Added bolding to menu indices and semantic colors to caveats (like `(Recommended)` or `(Business Only)`) in the `_select_provider` menu of the setup wizard.

💡 **Why:**
Flat, unstyled terminal menus require users to read every word to understand the distinction between options. Using distinct text styles and colors allows users to instantly parse the menu hierarchy and recommendations, enhancing CLI scanability.

✅ **Verification:**
Tested manually by running the application, and the full test suite (`python3 -m pytest`) passes locally.

✨ **Result:**
The setup wizard menu is now much more visually distinct and easier to read at a glance.