### PR TITLE
🧹 style: fix long lines in setup_wizard.py via black

### DIFF
--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -145,10 +145,18 @@ def _test_connection(email: str, app_password: str, provider_choice: str) -> boo
 def _select_provider() -> str:
     """Prompt user to select an email provider."""
     print(f"\n{Colors.CYAN}Step 1 of 2: Choose your email provider{Colors.RESET}")
-    print(f"  {Colors.colorize('1.', Colors.BOLD)} Gmail {Colors.colorize('(Recommended)', Colors.GREEN)}")
-    print(f"  {Colors.colorize('2.', Colors.BOLD)} Proton Mail {Colors.colorize('(Requires Bridge)', Colors.GREY)}")
-    print(f"  {Colors.colorize('3.', Colors.BOLD)} Outlook {Colors.colorize('(Business Only)', Colors.YELLOW)}")
-    print(f"  {Colors.colorize('4.', Colors.BOLD)} Skip {Colors.colorize('(Manually edit .env)', Colors.GREY)}")
+    print(
+        f"  {Colors.colorize('1.', Colors.BOLD)} Gmail {Colors.colorize('(Recommended)', Colors.GREEN)}"
+    )
+    print(
+        f"  {Colors.colorize('2.', Colors.BOLD)} Proton Mail {Colors.colorize('(Requires Bridge)', Colors.GREY)}"
+    )
+    print(
+        f"  {Colors.colorize('3.', Colors.BOLD)} Outlook {Colors.colorize('(Business Only)', Colors.YELLOW)}"
+    )
+    print(
+        f"  {Colors.colorize('4.', Colors.BOLD)} Skip {Colors.colorize('(Manually edit .env)', Colors.GREY)}"
+    )
 
     while True:
         try:


### PR DESCRIPTION
🎯 **What:** Reformats long terminal print statements in `src/utils/setup_wizard.py` to adhere to standard Python line-length limits (PEP 8/Black).

💡 **Why:** Found during Jules Daily QA Review. The manual string concatenations for the terminal wizard menu exceeded the 88-100 character bounds, causing style linter (`black`) violations. This change improves code readability without altering behavior.

✅ **Verification:** 
- Ran `black src/ tests/`
- Confirmed `flake8` clean for modified file
- Full test suite passed (`pytest`)

✨ **Result:** Clean code formatting, fully healthy repo.

---
*PR created automatically by Jules for task [12603182233626049686](https://jules.google.com/task/12603182233626049686) started by @abhimehro*