### PR TITLE
fix(security): TOCTOU config permissions (salvages #919, v4)

### DIFF
--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -159,10 +159,7 @@ class AppRunner:
                             | getattr(os, "O_NOFOLLOW", 0),
                             0o600,
                         )
-                        try:
-                            os.fchmod(fd, 0o600)
-                        except (AttributeError, OSError, NotImplementedError):
-                            os.chmod(self.config_file, 0o600)
+                        self._set_secure_permissions(fd)
 
                         with os.fdopen(fd, "wb") as dst:
                             dst.write(content)
@@ -331,8 +328,33 @@ class AppRunner:
                 # Some platforms support os.chmod(fd, mode)
                 os.chmod(fd, 0o600)
             except (AttributeError, OSError, NotImplementedError, TypeError):
-                # Final fallback to path-based chmod (e.g. Windows)
-                os.chmod(self.config_file, 0o600)
+                # Final fallback to path-based chmod (e.g. Windows) with inode check.
+                try:
+                    stat_fd = os.fstat(fd)
+                    stat_path = (
+                        os.lstat(self.config_file)
+                        if hasattr(os, "lstat")
+                        else os.stat(self.config_file)
+                    )
+                    if (
+                        stat_fd.st_ino == stat_path.st_ino
+                        and stat_fd.st_dev == stat_path.st_dev
+                    ):
+                        chmod_kwargs = (
+                            {"follow_symlinks": False}
+                            if os.chmod
+                            in getattr(os, "supports_follow_symlinks", set())
+                            else {}
+                        )
+                        os.chmod(self.config_file, 0o600, **chmod_kwargs)
+                    else:
+                        print(
+                            f"Error: TOCTOU detected on '{self.config_file}'."
+                        )
+                        sys.exit(1)
+                except OSError as exc:
+                    print(f"Error setting permissions: {exc}")
+                    sys.exit(1)
 
     def start_pipeline(self) -> None:
         """Instantiate and start the main pipeline."""

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -367,8 +367,42 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
                 # Some platforms support os.chmod(fd, mode)
                 os.chmod(fd, 0o600)
             except (AttributeError, OSError, NotImplementedError, TypeError):
-                # Final fallback to path-based chmod
-                os.chmod(str(config_path), 0o600)
+                # Final fallback to path-based chmod with inode verification.
+                try:
+                    stat_fd = os.fstat(fd)
+                    config_path_str = str(config_path)
+                    stat_path = (
+                        os.lstat(config_path_str)
+                        if hasattr(os, "lstat")
+                        else os.stat(config_path_str)
+                    )
+                    if (
+                        stat_fd.st_ino == stat_path.st_ino
+                        and stat_fd.st_dev == stat_path.st_dev
+                    ):
+                        chmod_kwargs = (
+                            {"follow_symlinks": False}
+                            if os.chmod
+                            in getattr(os, "supports_follow_symlinks", set())
+                            else {}
+                        )
+                        os.chmod(config_path_str, 0o600, **chmod_kwargs)
+                    else:
+                        print(
+                            f"\n{Colors.colorize('Error:', Colors.RED)} "
+                            f"TOCTOU detected on '{config_path}'."
+                        )
+                        import sys
+
+                        sys.exit(1)
+                except OSError as exc:
+                    print(
+                        f"\n{Colors.colorize('Error setting permissions:', Colors.RED)} "
+                        f"{exc}"
+                    )
+                    import sys
+
+                    sys.exit(1)
 
         with os.fdopen(fd, "w") as f:
             f.write(new_content)


### PR DESCRIPTION
## Purpose
Minimal v4 rebuild from `main` for TOCTOU-safe config file permission handling (salvages conflicted #939).

## Security (T1)
- Uses `_set_secure_permissions` for interactive `.env` creation
- Path-based `chmod` fallback verifies inode/dev match before applying

## Verify
```bash
python3 -m py_compile src/app_runner.py src/utils/setup_wizard.py
python3 -m pytest tests/test_setup_wizard.py -q
```

Supersedes: #939
Autofix-PR: 919
Autofix-Cycle: 4