### PR TITLE
perf(imap): concurrent folder fetch (salvages #921, v4)

### DIFF
--- a/src/modules/email_ingestion.py
+++ b/src/modules/email_ingestion.py
@@ -372,14 +372,28 @@ class EmailIngestionManager:
         self.logger.info(f"Connected to {success_count}/{len(self.accounts)} accounts")
         return True
 
+    def _create_imap_client(self, account: EmailAccountConfig) -> IMAPClient:
+        """Helper to create a fresh IMAP client matching manager settings."""
+        client = IMAPClient(
+            account,
+            self.rate_limit_delay,
+            self.max_attachment_bytes,
+            self.max_total_attachment_bytes,
+            self.max_attachment_count,
+        )
+        client.max_body_size = self.max_body_size
+        return client
+
     def _process_account(
         self, account: EmailAccountConfig, max_per_folder: int
     ) -> List[EmailData]:
         """
         Fetch and parse all emails for a single account across its configured folders.
 
-        This helper is designed to run in its own thread — each account gets an
-        isolated IMAPClient so that IMAP connections are never shared between threads.
+        Folders are processed concurrently using a ThreadPoolExecutor.
+        A persistent client from `self.clients` is reused for the first folder,
+        while temporary client connections are spun up for additional folders to
+        avoid sharing stateful IMAP connections across threads.
 
         Args:
             account: The email account configuration to process
@@ -390,29 +404,75 @@ class EmailIngestionManager:
 
         """
         emails: List[EmailData] = []
-        client = self.clients.get(account.email)
-        if client is None:
+
+        # Guard against uninitialized client
+        persistent_client = self.clients.get(account.email)
+        if persistent_client is None:
             return emails
 
-        for folder in account.folders:
-            if not client.ensure_connection():
-                self.logger.error(
-                    f"Unable to reconnect to {redact_email(account.email)}; "
-                    f"skipping remaining folders"
-                )
-                break
-
-            self.logger.info(
-                f"Fetching from {redact_email(account.email)}/"
-                f"{sanitize_for_logging(folder)}"
+        # Original fail-fast logic: ensure connection on the persistent client first.
+        # If the server is unreachable or credentials rotated, fail immediately before
+        # spinning up concurrent tasks to avoid hammering the server.
+        if account.folders and not persistent_client.ensure_connection():
+            self.logger.error(
+                f"Unable to reconnect to {redact_email(account.email)}; "
+                f"skipping remaining folders"
             )
+            return emails
 
-            raw_emails = client.fetch_unseen_emails(folder, max_per_folder)
+        max_folder_workers = min(3, len(account.folders))
+        if max_folder_workers < 1:
+            return emails
 
-            for email_id, raw_email in raw_emails:
-                email_data = client.parse_email(email_id, raw_email, folder)
-                if email_data:
-                    emails.append(email_data)
+        def _fetch_from_folder(folder: str, is_first: bool) -> List[EmailData]:
+            folder_emails = []
+
+            if is_first:
+                client = persistent_client
+                cleanup_required = False
+            else:
+                # Need fresh client for parallel fetching to avoid IMAP state clashes
+                client = self._create_imap_client(account)
+                if not client.connect():
+                    self.logger.error(
+                        f"Failed to connect for folder {sanitize_for_logging(folder)} "
+                        f"on {redact_email(account.email)}"
+                    )
+                    return folder_emails
+                cleanup_required = True
+
+            try:
+                self.logger.info(
+                    f"Fetching from {redact_email(account.email)}/"
+                    f"{sanitize_for_logging(folder)}"
+                )
+
+                raw_emails = client.fetch_unseen_emails(folder, max_per_folder)
+
+                for email_id, raw_email in raw_emails:
+                    email_data = client.parse_email(email_id, raw_email, folder)
+                    if email_data:
+                        folder_emails.append(email_data)
+            except Exception as e:
+                self.logger.error(
+                    f"Error fetching from {sanitize_for_logging(folder)}: {e}"
+                )
+            finally:
+                if cleanup_required:
+                    try:
+                        client.disconnect()
+                    except Exception:
+                        pass
+
+            return folder_emails
+
+        with ThreadPoolExecutor(max_workers=max_folder_workers, thread_name_prefix=f"FolderFetch") as executor:
+            futures = []
+            for i, folder in enumerate(account.folders):
+                futures.append(executor.submit(_fetch_from_folder, folder, i == 0))
+
+            for future in as_completed(futures):
+                emails.extend(future.result())
 
         return emails
 

--- a/tests/test_email_ingestion_manager.py
+++ b/tests/test_email_ingestion_manager.py
@@ -152,7 +152,8 @@ class TestEmailIngestionManagerFetch(unittest.TestCase):
         self.assertEqual(result, [mock_email])
         mock_client.fetch_unseen_emails.assert_called_once_with("INBOX", 50)
 
-    def test_connection_failure_skips_remaining_folders(self):
+    @patch("src.modules.email_ingestion.IMAPClient")
+    def test_connection_failure_skips_remaining_folders(self, MockIMAPClient):
         """If reconnection fails, all remaining folders for that account are skipped."""
         account = _make_account("u@x.com", folders=["INBOX", "Spam", "Archive"])
 
@@ -167,6 +168,7 @@ class TestEmailIngestionManagerFetch(unittest.TestCase):
 
         self.assertEqual(result, [])
         mock_client.fetch_unseen_emails.assert_not_called()
+        MockIMAPClient.assert_not_called()
 
     def test_parse_email_returning_none_is_excluded(self):
         """parse_email returning None (malformed/oversized mail) is excluded."""
@@ -185,27 +187,37 @@ class TestEmailIngestionManagerFetch(unittest.TestCase):
 
         self.assertEqual(result, [])
 
-    def test_multiple_folders_aggregated(self):
+    @patch("src.modules.email_ingestion.IMAPClient")
+    def test_multiple_folders_aggregated(self, MockIMAPClient):
         """Emails from multiple folders are combined into a single list."""
         account = _make_account("u@x.com", folders=["INBOX", "Spam"])
         email_inbox = MagicMock()
         email_spam = MagicMock()
 
-        mock_client = MagicMock()
-        mock_client.ensure_connection.return_value = True
-        mock_client.fetch_unseen_emails.side_effect = [
-            [("1", b"raw1")],
-            [("2", b"raw2")],
-        ]
-        mock_client.parse_email.side_effect = [email_inbox, email_spam]
+        # The persistent client for the first folder
+        persistent_client = MagicMock()
+        persistent_client.ensure_connection.return_value = True
+        persistent_client.fetch_unseen_emails.return_value = [("1", b"raw1")]
+        persistent_client.parse_email.return_value = email_inbox
+
+        # The new client instantiated for the second folder
+        temp_client = MagicMock()
+        temp_client.connect.return_value = True
+        temp_client.fetch_unseen_emails.return_value = [("2", b"raw2")]
+        temp_client.parse_email.return_value = email_spam
+
+        MockIMAPClient.return_value = temp_client
 
         manager = EmailIngestionManager([account])
         manager.logger = MagicMock()
-        manager.clients = {"u@x.com": mock_client}
+        manager.clients = {"u@x.com": persistent_client}
 
         result = manager.fetch_all_emails()
 
-        self.assertEqual(result, [email_inbox, email_spam])
+        # Check that both emails were retrieved regardless of order
+        self.assertEqual(len(result), 2)
+        self.assertIn(email_inbox, result)
+        self.assertIn(email_spam, result)
 
 
 class TestEmailIngestionManagerClose(unittest.TestCase):

--- a/tests/test_multi_account.py
+++ b/tests/test_multi_account.py
@@ -162,7 +162,8 @@ class TestMultiAccountProcessing(unittest.TestCase):
         self.assertTrue(mock_client1.fetch_unseen_emails.called)
         self.assertTrue(mock_client2.fetch_unseen_emails.called)
 
-    def test_cross_account_isolation(self):
+    @patch("src.modules.email_ingestion.IMAPClient")
+    def test_cross_account_isolation(self, MockIMAPClient):
         """
         SECURITY STORY: This tests that emails from different accounts remain isolated.
         If account isolation fails, an attacker with access to one account could
@@ -206,21 +207,11 @@ class TestMultiAccountProcessing(unittest.TestCase):
             folder="INBOX",
         )
 
-        # Setup mock clients
-        # Account1 has 2 folders, so fetch_unseen_emails will be called twice
-        # We need to return different emails for each folder
+        # Setup persistent mock clients
         mock_client1 = MagicMock()
         mock_client1.ensure_connection.return_value = True
-        # Return different emails for each folder call
-        mock_client1.fetch_unseen_emails.side_effect = [
-            [("1", b"raw1")],  # First folder (INBOX)
-            [("2", b"raw2")],  # Second folder (Spam)
-        ]
-        # parse_email will be called for each fetched email
-        mock_client1.parse_email.side_effect = [
-            email1,
-            email1,
-        ]  # Return email1 for both
+        mock_client1.fetch_unseen_emails.return_value = [("1", b"raw1")]
+        mock_client1.parse_email.return_value = email1
 
         mock_client2 = MagicMock()
         mock_client2.ensure_connection.return_value = True
@@ -231,6 +222,13 @@ class TestMultiAccountProcessing(unittest.TestCase):
             "user1@example.com": mock_client1,
             "user2@different.com": mock_client2,
         }
+
+        # Setup temporary mock client for concurrent folder
+        temp_client = MagicMock()
+        temp_client.connect.return_value = True
+        temp_client.fetch_unseen_emails.return_value = [("2", b"raw2")]
+        temp_client.parse_email.return_value = email1
+        MockIMAPClient.return_value = temp_client
 
         # Fetch all
         all_emails = manager.fetch_all_emails(max_per_folder=10)


### PR DESCRIPTION
## Purpose
v4 rebuild from `main` for per-folder IMAP concurrency (salvages #940 / #921).

## Verify
```bash
python3 -m py_compile src/modules/email_ingestion.py
python3 -m pytest tests/test_email_ingestion_manager.py tests/test_multi_account.py -q
```

Supersedes: #940