### PR TITLE
🎨 Palette: Add keyboard shortcut hint to spinner

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -171,3 +171,7 @@
 ## 2027-02-18 - Semantic Colors for Menu Scannability
 **Learning:** Flat, unstyled terminal menus require users to read every word to understand the distinction between options. By using bolding for numbers and semantic colors for caveats (e.g., Green for Recommended, Yellow for restrictions), users can instantly visually parse the menu hierarchy and recommendations.
 **Action:** Apply semantic coloring and bold text to distinct components (indices, primary text, caveats) of terminal menu options to enhance scannability.
+
+## 2025-05-19 - Add keyboard shortcut hint to spinner
+**Learning:** Terminal spinners blocking output streams without visible keyboard exit hints cause user anxiety and increase perceived lock-ups, especially in interactive CLIs where users don't know if Ctrl+C is safe.
+**Action:** Always append actionable exit hints like '(Press Ctrl+C to stop)' dynamically to long-running terminal elements, but ensure the hint is cleanly stripped from the final success/failure log message to prevent polluting permanent logs with interactive UX instructions.

--- a/email-security-pipeline_project_code.txt
+++ b/email-security-pipeline_project_code.txt
@@ -119,7 +119,7 @@ This is a **dispatcher agent** that routes your request to the appropriate speci
 
 - **Creating new workflows**: Routes to `create` prompt
 - **Updating existing workflows**: Routes to `update` prompt
-- **Debugging workflows**: Routes to `debug` prompt  
+- **Debugging workflows**: Routes to `debug` prompt
 - **Upgrading workflows**: Routes to `upgrade-agentic-workflows` prompt
 - **Creating shared components**: Routes to `create-shared-agentic-workflow` prompt
 
@@ -162,7 +162,7 @@ When you interact with this agent, it will:
 - "I need a workflow to label pull requests"
 - "Design a weekly research automation"
 
-### Update Existing Workflow  
+### Update Existing Workflow
 **Load when**: User wants to modify, improve, or refactor an existing workflow
 
 **Prompt file**: https://github.com/github/gh-aw/blob/v0.45.0/.github/aw/update-agentic-workflow.md
@@ -172,7 +172,7 @@ When you interact with this agent, it will:
 - "Update the PR reviewer to use discussions instead of issues"
 - "Improve the prompt for the weekly-research workflow"
 
-### Debug Workflow  
+### Debug Workflow
 **Load when**: User needs to investigate, audit, debug, or understand a workflow, troubleshoot issues, analyze logs, or fix errors
 
 **Prompt file**: https://github.com/github/gh-aw/blob/v0.45.0/.github/aw/debug-agentic-workflow.md
@@ -39554,8 +39554,8 @@ All identified issues have been addressed, and the codebase is now more robust, 
 <file path="BACKLOG_PHASE_2A_SUMMARY.md" size="11.5 KB" language="markdown">
 # Backlog Burner Phase 2A - Quick Wins Summary
 
-**Date:** 2026-02-15  
-**Phase:** 2A - Quick Wins  
+**Date:** 2026-02-15
+**Phase:** 2A - Quick Wins
 **Status:** ✅ COMPLETE
 
 ## Executive Summary
@@ -39568,13 +39568,13 @@ Phase 2A has been successfully completed per maintainer feedback on issue #194. 
 
 ### 1. Workflow Failure Issues - CLOSED ✅
 
-**Issue #185** - Daily Backlog Burner Failed  
+**Issue #185** - Daily Backlog Burner Failed
 - **Status:** CLOSED (2026-02-14)
 - **Root Cause:** Missing discussion categories in repository
 - **Resolution:** Discussion categories were created; issue no longer relevant
 - **Action Taken:** Verified closure per maintainer feedback
 
-**Issue #186** - Daily Perf Improver Failed  
+**Issue #186** - Daily Perf Improver Failed
 - **Status:** CLOSED (2026-02-14)
 - **Root Cause:** Missing discussion categories in repository
 - **Resolution:** Discussion categories were created; issue no longer relevant
@@ -39582,7 +39582,7 @@ Phase 2A has been successfully completed per maintainer feedback on issue #194. 
 
 ### 2. Performance Research Issue - KEPT OPEN 📋
 
-**Issue #193** - Daily Perf Improver Research and Plan  
+**Issue #193** - Daily Perf Improver Research and Plan
 - **Status:** OPEN (intentional)
 - **Purpose:** Valuable reference document for future optimization work
 - **Content:** Comprehensive performance analysis covering:
@@ -39594,7 +39594,7 @@ Phase 2A has been successfully completed per maintainer feedback on issue #194. 
 
 ### 3. PR #192 Review - READY FOR MERGE ✅
 
-**PR #192** - 🎨 Palette: Add NO_COLOR support and auto-disable colors in non-TTY  
+**PR #192** - 🎨 Palette: Add NO_COLOR support and auto-disable colors in non-TTY
 - **Status:** OPEN, ready for merge
 - **Branch:** `palette-ux-no-color-13799634109474746294`
 - **Commits:** 6 commits, 151 additions, 26 deletions
@@ -39804,12 +39804,12 @@ Per the original plan, Phase 2B focuses on verification and documentation:
 
 ## Sign-Off
 
-**Phase 2A Status:** ✅ COMPLETE  
-**Ready for:** Maintainer review and PR merge  
+**Phase 2A Status:** ✅ COMPLETE
+**Ready for:** Maintainer review and PR merge
 **Next Phase:** 2B (Verification & Documentation)
 
-**Review Conducted By:** @copilot (GitHub Copilot Agent)  
-**Review Date:** 2026-02-15  
+**Review Conducted By:** @copilot (GitHub Copilot Agent)
+**Review Date:** 2026-02-15
 **Review Confidence:** HIGH (all tests passed, code reviewed, security assessed)
 
 ---
@@ -40508,8 +40508,8 @@ This is **professional-grade testing** that future contributors should emulate.
 <file path="COMPREHENSIVE_REVIEW_2025-11-08.md" size="19.2 KB" language="markdown">
 # Email Security Pipeline - Comprehensive Review Report
 
-**Date:** November 8, 2025  
-**Reviewer:** AI Assistant (Warp)  
+**Date:** November 8, 2025
+**Reviewer:** AI Assistant (Warp)
 **Review Type:** Complete system validation and testing
 
 ---
@@ -41183,8 +41183,8 @@ The system is ready to use with Gmail and/or Proton Mail immediately after creat
 
 ---
 
-**Review Completed:** November 8, 2025  
-**Next Review:** After initial deployment or 30 days  
+**Review Completed:** November 8, 2025
+**Next Review:** After initial deployment or 30 days
 **Status:** ✅ **READY FOR PRODUCTION USE**
 
 ---
@@ -41253,7 +41253,7 @@ Close these 20 PRs with a comment linking to the consolidated PR #160:
 **Security (Sentinel) PRs:**
 - #134 - sentinel-fix-alert-config-leak
 - #143 - sentinel-log-sanitization-fix
-- #123 - sentinel/dos-protection  
+- #123 - sentinel/dos-protection
 - #128 - sentinel-dangerous-extensions
 - #137 - sentinel-media-dos-fix
 - #146 - sentinel/zip-inspection
@@ -41830,7 +41830,7 @@ All changes have been merged in priority order while preserving functionality an
 ## Merge Statistics
 - **Total PRs Merged**: 20
 - **Security (Sentinel)**: 9 PRs
-- **Performance (Bolt)**: 4 PRs  
+- **Performance (Bolt)**: 4 PRs
 - **UX (Palette)**: 7 PRs
 
 ## Detailed Breakdown
@@ -42030,7 +42030,7 @@ All changes have been merged in priority order while preserving functionality an
 
 All 20 PRs have been successfully consolidated with zero data loss and intelligent conflict resolution. The codebase now includes:
 - **Stronger security** against multiple attack vectors
-- **Better performance** through parallelization and optimization  
+- **Better performance** through parallelization and optimization
 - **Enhanced UX** with better feedback and error handling
 
 The consolidation followed security-first principles, ensuring that all security fixes were properly integrated while maintaining performance improvements and UX enhancements.
@@ -43474,9 +43474,9 @@ The fix is minimal, focused, and well-documented.
 
 ---
 
-**Fixed by**: GitHub Copilot Agent  
-**Date**: February 16, 2026  
-**Issue**: #232  
+**Fixed by**: GitHub Copilot Agent
+**Date**: February 16, 2026
+**Issue**: #232
 **Branch**: `copilot/debug-daily-backlog-burner`
 
 </file>
@@ -46785,14 +46785,14 @@ You can start monitoring emails with Gmail and Proton Mail immediately. The Outl
 <file path="TROUBLESHOOTING_SUMMARY.md" size="4.7 KB" language="markdown">
 # Email Security Pipeline Troubleshooting Summary
 
-**Date**: April 2, 2026  
+**Date**: April 2, 2026
 **Status**: ✅ .env detection fixed | ⚠️ Email authentication issues remain
 
 ## What We Fixed
 
 ### 1. Docker .env Detection Issue ✅
-**Problem**: Container couldn't find `/app/.env` file  
-**Root Cause**: `docker-compose.yml` was loading environment **variables** via `env_file`, but the Python app needed the actual `.env` **file** to exist  
+**Problem**: Container couldn't find `/app/.env` file
+**Root Cause**: `docker-compose.yml` was loading environment **variables** via `env_file`, but the Python app needed the actual `.env` **file** to exist
 **Solution**: Added `.env` as a read-only volume mount in `docker-compose.yml`
 
 **Changes Made**:
@@ -46811,7 +46811,7 @@ You can start monitoring emails with Gmail and Proton Mail immediately. The Outl
 ## Remaining Issues
 
 ### Issue 1: Gmail Authentication Failure
-**Error**: `[AUTHENTICATIONFAILED] Invalid credentials (Failure)`  
+**Error**: `[AUTHENTICATIONFAILED] Invalid credentials (Failure)`
 **Current Config**:
 - Email: `abhimhrtr@gmail.com`
 - App Password: `enmfnbufsdmrdpnf` (spaces removed)
@@ -46837,7 +46837,7 @@ docker compose down && docker compose up -d
 ```
 
 ### Issue 2: Proton Mail Bridge SSL Failure
-**Error**: `[SSL] record layer failure (_ssl.c:1016)`  
+**Error**: `[SSL] record layer failure (_ssl.c:1016)`
 **Current Config**:
 - Email: `abhimehro@pm.me`
 - Bridge: `host.docker.internal:1143`
@@ -46932,9 +46932,9 @@ docker compose logs -f
 
 ## Summary
 
-**Fixed**: ✅ Docker .env detection and mounting  
-**Fixed**: ✅ Proton Bridge networking (host.docker.internal)  
-**Next**: 🔍 Need to verify/regenerate both Gmail and Proton credentials  
+**Fixed**: ✅ Docker .env detection and mounting
+**Fixed**: ✅ Proton Bridge networking (host.docker.internal)
+**Next**: 🔍 Need to verify/regenerate both Gmail and Proton credentials
 
 The pipeline infrastructure is now working correctly. The remaining issues are authentication-specific and need credential verification/regeneration.
 
@@ -47757,8 +47757,8 @@ If you encounter any issues after applying this fix:
 
 ---
 
-**Fix Author**: GitHub Copilot  
-**Date**: 2026-02-16  
+**Fix Author**: GitHub Copilot
+**Date**: 2026-02-16
 **Issue**: #232 - [agentics] Daily Backlog Burner failed
 
 </file>

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -142,7 +142,12 @@ class Spinner:
             )
             # \r moves cursor to start of line, \033[K clears the line
             spin_char = Colors.colorize(next(self.spinner), Colors.CYAN)
-            sys.stdout.write(f"\r{spin_char} {self.message}{time_str}   \033[K")
+            display_msg = self.message
+            if sys.stdout.isatty():
+                hint = " (Press Ctrl+C to stop)"
+                if hint not in display_msg:
+                    display_msg += hint
+            sys.stdout.write(f"\r{spin_char} {display_msg}{time_str}   \033[K")
             sys.stdout.flush()
             time.sleep(self.delay)
             # Check again to avoid writing after stop
@@ -151,11 +156,14 @@ class Spinner:
 
     def __enter__(self):
         self.start_time = time.time()
+        # We don't mutate self.message, we just format the display string
+        display_msg = self.message
         if sys.stdout.isatty():
             hint = " (Press Ctrl+C to stop)"
-            if hint not in self.message:
-                self.message += hint
-        msg = self.message if self.message.endswith("...") else f"{self.message}..."
+            if hint not in display_msg:
+                display_msg += hint
+
+        msg = display_msg if display_msg.endswith("...") else f"{display_msg}..."
 
         if sys.stdout.isatty():
             self._start_tty_spinner(msg)
@@ -198,13 +206,12 @@ class Spinner:
                     self.thread.join()
                 final_message = ""
 
-                clean_msg = self.message.replace(" (Press Ctrl+C to stop)", "")
                 if exc_type is KeyboardInterrupt:
                     warning = Colors.colorize("⚠", Colors.YELLOW)
-                    final_message = f"{warning} {clean_msg} (Cancelled){time_str}\n"
+                    final_message = f"{warning} {self.message} (Cancelled){time_str}\n"
                 elif exc_type is not None or self.fail_msg:
                     # Failure logic
-                    msg = self.fail_msg if self.fail_msg else clean_msg
+                    msg = self.fail_msg if self.fail_msg else self.message
                     # Use Colors.colorize to ensure we get proper fallback if colors are disabled
                     cross = Colors.colorize("✘", Colors.RED)
                     final_message = f"{cross} {msg}{time_str}\n"
@@ -215,7 +222,7 @@ class Spinner:
                 elif self.persist:
                     # Default persistence
                     check = Colors.colorize("✔", Colors.GREEN)
-                    final_message = f"{check} {clean_msg}{time_str}\n"
+                    final_message = f"{check} {self.message}{time_str}\n"
 
                 sys.stdout.write(f"\r\033[K{final_message}")
                 sys.stdout.flush()
@@ -228,14 +235,13 @@ class Spinner:
             # Colors.ENABLED is computed at import time, so use plain symbols here
             # to avoid leaking escape sequences when stdout is redirected later.
             raw_time_str = f" [{elapsed:.1f}s]" if elapsed >= 1.0 else ""
-            clean_msg = self.message.replace(" (Press Ctrl+C to stop)", "")
             if exc_type is KeyboardInterrupt:
-                sys.stdout.write(f"⚠ {clean_msg} (Cancelled){raw_time_str}\n")
+                sys.stdout.write(f"⚠ {self.message} (Cancelled){raw_time_str}\n")
             elif exc_type is not None or self.fail_msg:
-                msg = self.fail_msg if self.fail_msg else clean_msg
+                msg = self.fail_msg if self.fail_msg else self.message
                 sys.stdout.write(f"✘ {msg}{raw_time_str}\n")
             elif self.success_msg:
                 sys.stdout.write(f"✔ {self.success_msg}{raw_time_str}\n")
             elif self.persist:
-                sys.stdout.write(f"✔ {clean_msg}{raw_time_str}\n")
+                sys.stdout.write(f"✔ {self.message}{raw_time_str}\n")
             sys.stdout.flush()

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -151,6 +151,10 @@ class Spinner:
 
     def __enter__(self):
         self.start_time = time.time()
+        if sys.stdout.isatty():
+            hint = " (Press Ctrl+C to stop)"
+            if hint not in self.message:
+                self.message += hint
         msg = self.message if self.message.endswith("...") else f"{self.message}..."
 
         if sys.stdout.isatty():
@@ -194,13 +198,13 @@ class Spinner:
                     self.thread.join()
                 final_message = ""
 
+                clean_msg = self.message.replace(" (Press Ctrl+C to stop)", "")
                 if exc_type is KeyboardInterrupt:
-                    msg = self.message
                     warning = Colors.colorize("⚠", Colors.YELLOW)
-                    final_message = f"{warning} {msg} (Cancelled){time_str}\n"
+                    final_message = f"{warning} {clean_msg} (Cancelled){time_str}\n"
                 elif exc_type is not None or self.fail_msg:
                     # Failure logic
-                    msg = self.fail_msg if self.fail_msg else self.message
+                    msg = self.fail_msg if self.fail_msg else clean_msg
                     # Use Colors.colorize to ensure we get proper fallback if colors are disabled
                     cross = Colors.colorize("✘", Colors.RED)
                     final_message = f"{cross} {msg}{time_str}\n"
@@ -211,7 +215,7 @@ class Spinner:
                 elif self.persist:
                     # Default persistence
                     check = Colors.colorize("✔", Colors.GREEN)
-                    final_message = f"{check} {self.message}{time_str}\n"
+                    final_message = f"{check} {clean_msg}{time_str}\n"
 
                 sys.stdout.write(f"\r\033[K{final_message}")
                 sys.stdout.flush()
@@ -224,13 +228,14 @@ class Spinner:
             # Colors.ENABLED is computed at import time, so use plain symbols here
             # to avoid leaking escape sequences when stdout is redirected later.
             raw_time_str = f" [{elapsed:.1f}s]" if elapsed >= 1.0 else ""
+            clean_msg = self.message.replace(" (Press Ctrl+C to stop)", "")
             if exc_type is KeyboardInterrupt:
-                sys.stdout.write(f"⚠ {self.message} (Cancelled){raw_time_str}\n")
+                sys.stdout.write(f"⚠ {clean_msg} (Cancelled){raw_time_str}\n")
             elif exc_type is not None or self.fail_msg:
-                msg = self.fail_msg if self.fail_msg else self.message
+                msg = self.fail_msg if self.fail_msg else clean_msg
                 sys.stdout.write(f"✘ {msg}{raw_time_str}\n")
             elif self.success_msg:
                 sys.stdout.write(f"✔ {self.success_msg}{raw_time_str}\n")
             elif self.persist:
-                sys.stdout.write(f"✔ {self.message}{raw_time_str}\n")
+                sys.stdout.write(f"✔ {clean_msg}{raw_time_str}\n")
             sys.stdout.flush()

--- a/tests/test_ui_palette.py
+++ b/tests/test_ui_palette.py
@@ -50,6 +50,22 @@ class TestPaletteUI(TestCase):
             self.assertNotIn("\033[?25l", writes)
             self.assertNotIn("\033[?25h", writes)
 
+    def test_spinner_keyboard_interrupt_hint(self):
+        # Verify the "Press Ctrl+C to stop" hint is added correctly to Spinner.
+        from src.utils.ui import Spinner
+
+        with patch("sys.stdout") as mock_stdout:
+            mock_stdout.isatty.return_value = True
+
+            with patch.object(Spinner, '_start_tty_spinner'):
+                spinner = Spinner("Testing")
+                spinner.__enter__()
+                self.assertIn(" (Press Ctrl+C to stop)", spinner.message)
+
+                spinner_with_hint = Spinner("Testing (Press Ctrl+C to stop)")
+                spinner_with_hint.__enter__()
+                self.assertEqual(spinner_with_hint.message.count("(Press Ctrl+C to stop)"), 1)
+
     def test_spinner_keyboard_interrupt_tty(self):
         """Test graceful cancellation message on KeyboardInterrupt in TTY mode."""
         from src.utils.ui import Spinner

--- a/tests/test_ui_palette.py
+++ b/tests/test_ui_palette.py
@@ -5,6 +5,11 @@ from src.utils.ui import CountdownTimer
 
 
 class TestPaletteUI(TestCase):
+    def _get_writes(self, mock_stdout):
+        return "".join(
+            call.args[0] for call in mock_stdout.write.mock_calls if call.args
+        )
+
     def test_countdown_timer_keyboard_interrupt_hint(self):
         # Verify the "Press Ctrl+C to stop" hint is added correctly.
         with patch("sys.stdout") as mock_stdout:
@@ -30,9 +35,7 @@ class TestPaletteUI(TestCase):
             timer = CountdownTimer(duration=0, message="Test")
             timer.start()
 
-            writes = "".join(
-                call.args[0] for call in mock_stdout.write.mock_calls if call.args
-            )
+            writes = self._get_writes(mock_stdout)
             self.assertIn("\033[?25l", writes)  # CURSOR_HIDE
             self.assertIn("\033[?25h", writes)  # CURSOR_SHOW
 
@@ -44,9 +47,7 @@ class TestPaletteUI(TestCase):
             timer = CountdownTimer(duration=0, message="Test")
             timer.start()
 
-            writes = "".join(
-                call.args[0] for call in mock_stdout.write.mock_calls if call.args
-            )
+            writes = self._get_writes(mock_stdout)
             self.assertNotIn("\033[?25l", writes)
             self.assertNotIn("\033[?25h", writes)
 
@@ -77,9 +78,7 @@ class TestPaletteUI(TestCase):
             spinner.__enter__()
             spinner.__exit__(KeyboardInterrupt, None, None)
 
-            writes = "".join(
-                call.args[0] for call in mock_stdout.write.mock_calls if call.args
-            )
+            writes = self._get_writes(mock_stdout)
             self.assertIn("Test Cancel (Cancelled)", writes)
             self.assertIn("⚠", writes)
 
@@ -105,9 +104,7 @@ class TestPaletteUI(TestCase):
                 with self.assertRaises(KeyboardInterrupt):
                     timer.start()
 
-            writes = "".join(
-                call.args[0] for call in mock_stdout.write.mock_calls if call.args
-            )
+            writes = self._get_writes(mock_stdout)
             self.assertIn("Testing Cancel (Cancelled)", writes)
             self.assertNotIn("(Press Ctrl+C to stop) (Cancelled)", writes)
             self.assertIn("⚠", writes)

--- a/tests/test_ui_palette.py
+++ b/tests/test_ui_palette.py
@@ -57,48 +57,39 @@ class TestPaletteUI(TestCase):
         with patch("sys.stdout") as mock_stdout:
             mock_stdout.isatty.return_value = True
 
-            with patch.object(Spinner, '_start_tty_spinner'):
+            with patch.object(Spinner, '_start_tty_spinner') as mock_start:
                 spinner = Spinner("Testing")
                 spinner.__enter__()
-                self.assertIn(" (Press Ctrl+C to stop)", spinner.message)
+                # Since message is no longer mutated, verify it's passed to _start_tty_spinner correctly
+                mock_start.assert_called_with("Testing (Press Ctrl+C to stop)...")
 
                 spinner_with_hint = Spinner("Testing (Press Ctrl+C to stop)")
                 spinner_with_hint.__enter__()
-                self.assertEqual(spinner_with_hint.message.count("(Press Ctrl+C to stop)"), 1)
+                mock_start.assert_called_with("Testing (Press Ctrl+C to stop)...")
+
+    def _run_spinner_interrupt_test(self, is_tty: bool):
+        from src.utils.ui import Spinner
+
+        with patch("sys.stdout") as mock_stdout:
+            mock_stdout.isatty.return_value = is_tty
+
+            spinner = Spinner(message="Test Cancel")
+            spinner.__enter__()
+            spinner.__exit__(KeyboardInterrupt, None, None)
+
+            writes = "".join(
+                call.args[0] for call in mock_stdout.write.mock_calls if call.args
+            )
+            self.assertIn("Test Cancel (Cancelled)", writes)
+            self.assertIn("⚠", writes)
 
     def test_spinner_keyboard_interrupt_tty(self):
         """Test graceful cancellation message on KeyboardInterrupt in TTY mode."""
-        from src.utils.ui import Spinner
-
-        with patch("sys.stdout") as mock_stdout:
-            mock_stdout.isatty.return_value = True
-
-            spinner = Spinner(message="Test Cancel")
-            spinner.__enter__()
-            spinner.__exit__(KeyboardInterrupt, None, None)
-
-            writes = "".join(
-                call.args[0] for call in mock_stdout.write.mock_calls if call.args
-            )
-            self.assertIn("Test Cancel (Cancelled)", writes)
-            self.assertIn("⚠", writes)
+        self._run_spinner_interrupt_test(True)
 
     def test_spinner_keyboard_interrupt_non_tty(self):
         """Test graceful cancellation message on KeyboardInterrupt in non-TTY mode."""
-        from src.utils.ui import Spinner
-
-        with patch("sys.stdout") as mock_stdout:
-            mock_stdout.isatty.return_value = False
-
-            spinner = Spinner(message="Test Cancel")
-            spinner.__enter__()
-            spinner.__exit__(KeyboardInterrupt, None, None)
-
-            writes = "".join(
-                call.args[0] for call in mock_stdout.write.mock_calls if call.args
-            )
-            self.assertIn("Test Cancel (Cancelled)", writes)
-            self.assertIn("⚠", writes)
+        self._run_spinner_interrupt_test(False)
 
     def test_countdown_keyboard_interrupt_tty(self):
         """Test graceful cancellation message on KeyboardInterrupt in TTY mode for CountdownTimer."""


### PR DESCRIPTION
🎯 **What:** Adds a `(Press Ctrl+C to stop)` keyboard shortcut hint to the CLI `Spinner` during active loading, and smoothly strips it before emitting the final success or cancellation message.

💡 **Why:** Terminal spinners blocking output streams without visible keyboard exit hints cause user anxiety and increase perceived lock-ups. Explicit hints reassure users that graceful exit is possible.

✅ **Verification:** Updated `Spinner` in `src/utils/ui.py` to append the hint conditionally based on `isatty()`. Updated unit tests in `test_ui_palette.py` to verify the hint is present during execution and properly removed on exit. Tested locally with `pytest`.

✨ **Result:** A more user-friendly CLI experience that reduces anxiety during longer network or processing operations without polluting terminal scrollback with interactive instructions.

---
*PR created automatically by Jules for task [10977635495281004864](https://jules.google.com/task/10977635495281004864) started by @abhimehro*