### PR TITLE
🧹 Fix: Remove trailing whitespace in config files

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
-      
+
       - name: Install dependencies
         run: pip install bandit bandit-sarif-formatter
 
       - name: Run Bandit Scan
         run: bandit -f sarif -o results.sarif -r . --exit-zero --ini .bandit
-        
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -25,7 +25,7 @@ lint:
     - hadolint@2.14.0
     - isort@8.0.1
     - markdownlint@0.48.0
-    - osv-scanner@2.3.5 
+    - osv-scanner@2.3.5
     - ruff@0.15.15
     - shellcheck@0.11.0
     - shfmt@3.6.0


### PR DESCRIPTION
## Jules Daily QA & Agentic Review

🎯 **What:** Removed trailing whitespaces in `.github/workflows/bandit.yml` and `.trunk/trunk.yaml`.

💡 **Why:** Pre-commit checks detected trailing whitespaces which can sometimes cause strict linters to fail. This is a minor code health fix.

✅ **Verification:** Verified by running `pre-commit run --all-files` which passes.

✨ **Result:** Clean configuration files that pass all pre-commit hooks.

---
*PR created automatically by Jules for task [5651534448111067419](https://jules.google.com/task/5651534448111067419) started by @abhimehro*