### PR TITLE
🧪 Test IMAP size item parsing edge cases

### DIFF
--- a/tests/test_imap_connection.py
+++ b/tests/test_imap_connection.py
@@ -544,5 +544,39 @@ class TestIMAPDiagnosticsSSLCertificate(unittest.TestCase):
         self.assertIn("SSL check failed", result["error"])
 
 
+class TestIMAPConnectionParseSizeItem(unittest.TestCase):
+    """Tests for IMAPConnection._parse_size_item()."""
+
+    def setUp(self):
+        self.config = _make_config()
+        self.conn = IMAPConnection(self.config)
+        self.conn.logger = MagicMock()
+
+    def test_parse_size_item_valid(self):
+        """Happy path: correctly formats and extracts sequence and size."""
+        result = self.conn._parse_size_item(b"1 (RFC822.SIZE 1024)")
+        self.assertEqual(result, (b"1", 1024))
+
+    def test_parse_size_item_tuple(self):
+        """Valid tuple input (commonly returned by IMAP clients)."""
+        result = self.conn._parse_size_item((b"2 (RFC822.SIZE 2048)", b"other data"))
+        self.assertEqual(result, (b"2", 2048))
+
+    def test_parse_size_item_not_bytes(self):
+        """Non-bytes items (e.g. integer or string) should be rejected gracefully."""
+        self.assertIsNone(self.conn._parse_size_item(123))
+        self.assertIsNone(self.conn._parse_size_item("1 (RFC822.SIZE 1024)"))
+
+    def test_parse_size_item_no_rfc822_size(self):
+        """Valid bytes that lack RFC822.SIZE indicator."""
+        result = self.conn._parse_size_item(b"1 (FLAGS (\\Seen))")
+        self.assertIsNone(result)
+
+    def test_parse_size_item_malformed_size(self):
+        """Malformed RFC822.SIZE response where the size is not an integer."""
+        result = self.conn._parse_size_item(b"1 (RFC822.SIZE invalid)")
+        self.assertIsNone(result)
+        self.conn.logger.warning.assert_called()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for `_parse_size_item` in `IMAPConnection`.

📊 **Coverage:** The new `TestIMAPConnectionParseSizeItem` class covers the happy path, tuple inputs, non-bytes inputs, invalid bytes without the size marker, and malformed strings where the size is not an integer. Also escaped a backslash in a byte string to fix a Python 3.12+ SyntaxWarning.

✨ **Result:** Test coverage improved, confirming graceful error handling for edge cases inside IMAP fetch size parsing.

---
*PR created automatically by Jules for task [3546834549837725049](https://jules.google.com/task/3546834549837725049) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->