### PR TITLE
🧪 [Add test coverage for video frame advance error path]

### DIFF
--- a/tests/test_media_analyzer_advance_frame.py
+++ b/tests/test_media_analyzer_advance_frame.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.modules.media_analyzer import MediaAuthenticityAnalyzer
+
+class TestMediaAnalyzerAdvanceFrame(unittest.TestCase):
+    def setUp(self):
+        config = MagicMock()
+        self.analyzer = MediaAuthenticityAnalyzer(config)
+
+    def test_advance_small_jump(self):
+        cap = MagicMock()
+        cap.grab.side_effect = [True] * 10
+        result = self.analyzer._advance_to_frame(cap, current_frame=0, target_frame=10)
+        self.assertEqual(result, 10)
+        self.assertEqual(cap.grab.call_count, 10)
+        cap.set.assert_not_called()
+
+    def test_advance_large_jump(self):
+        cap = MagicMock()
+        result = self.analyzer._advance_to_frame(cap, current_frame=0, target_frame=40)
+        self.assertEqual(result, 40)
+        cap.set.assert_called_once()
+        cap.grab.assert_not_called()
+
+    def test_advance_error_path_grab_fails(self):
+        cap = MagicMock()
+        # Fails on 6th grab
+        cap.grab.side_effect = [True, True, True, True, True, False]
+        result = self.analyzer._advance_to_frame(cap, current_frame=0, target_frame=10)
+        # loop runs until current_frame reaches 5 and then break
+        self.assertEqual(result, 5)
+        self.assertEqual(cap.grab.call_count, 6)
+        cap.set.assert_not_called()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The `_advance_to_frame` method in `media_analyzer.py` lacked test coverage, specifically for the error path where video `cap.grab()` fails (returns False).

💡 **Why:** Adding these tests ensures that if OpenCV behavior changes or malformed videos are parsed, our frame reading logic behaves deterministically and fails gracefully without entering an infinite loop.

✅ **Verification:** Added `test_media_analyzer_advance_frame.py` with 3 test cases: small jumps (grab), large jumps (set), and grab failures. The full test suite and pre-commit checks pass.

✨ **Result:** Enhanced unit test coverage and confidence when refactoring video-related capabilities in the media analyzer.

══════════ ELIR ══════════
PURPOSE: Added test coverage for `_advance_to_frame` to handle early loop termination when `cap.grab()` returns `False`.
SECURITY: Better reliability against malformed files.
FAILS IF: OpenCV `cv2` mock behavior is not aligned with actual OpenCV versions if we ever change libraries.
VERIFY: `tests/test_media_analyzer_advance_frame.py` has three well-defined cases using `unittest.mock`.
MAINTAIN: Update side_effects in the test if video reading strategies change.

---
*PR created automatically by Jules for task [15191813666807345389](https://jules.google.com/task/15191813666807345389) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->