### PR TITLE
🧪 Add tests for zip inspection error handling

### DIFF
--- a/tests/test_media_analyzer_error_handling.py
+++ b/tests/test_media_analyzer_error_handling.py
@@ -46,5 +46,53 @@ class TestMediaAnalyzerBug(unittest.TestCase):
             self.fail(f"Caught unexpected exception: {type(e).__name__}: {e}")
 
 
+
+    def test_inspect_zip_contents_bad_zipfile(self):
+        # Create a mock config
+        config = MagicMock()
+        config.check_media_attachments = True
+        config.deepfake_detection_enabled = False
+
+        analyzer = MediaAuthenticityAnalyzer(config)
+        analyzer.logger = MagicMock()
+
+        # Pass intentionally malformed zip data to trigger zipfile.BadZipFile
+        score, warnings = analyzer._inspect_zip_contents("test.zip", b"not a valid zip")
+
+        # BadZipFile is caught and ignored
+        self.assertEqual(score, 0.0)
+        self.assertEqual(warnings, [])
+        analyzer.logger.warning.assert_not_called()
+
+    def test_inspect_zip_contents_generic_exception(self):
+        # Create a mock config
+        config = MagicMock()
+        config.check_media_attachments = True
+        config.deepfake_detection_enabled = False
+
+        analyzer = MediaAuthenticityAnalyzer(config)
+        analyzer.logger = MagicMock()
+
+        import zipfile
+        import io
+        from unittest.mock import patch
+
+        with patch("src.modules.media_analyzer.zipfile.ZipFile") as mock_zipfile:
+            mock_zipfile.side_effect = Exception("Generic unexpected error")
+
+            score, warnings = analyzer._inspect_zip_contents("test.zip", b"some data")
+
+            # Exception is caught and logged
+            self.assertEqual(score, 0.0)
+            self.assertEqual(warnings, [])
+
+            # Verify the warning was logged
+            analyzer.logger.warning.assert_called_once()
+            args, _ = analyzer.logger.warning.call_args
+            self.assertIn("Error inspecting zip test.zip", args[0])
+            self.assertIn("Generic unexpected error", args[0])
+
+
 if __name__ == "__main__":
+
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added tests to verify how the `_inspect_zip_contents` method in `media_analyzer.py` handles `zipfile.BadZipFile` and generic exceptions.

💡 **Why:** To improve test coverage for edge cases when inspecting malformed zip archives.

✅ **Verification:** Verified by running the new tests (`test_inspect_zip_contents_bad_zipfile` and `test_inspect_zip_contents_generic_exception`) and the full suite using pytest.

✨ **Result:** Test coverage for `_inspect_zip_contents` error handling is now complete.

---
*PR created automatically by Jules for task [2236736762889794829](https://jules.google.com/task/2236736762889794829) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->