### PR TITLE
🧪 [Testing Improvement] Test TAR inspection error handling

### DIFF
--- a/tests/test_media_analyzer_error_handling.py
+++ b/tests/test_media_analyzer_error_handling.py
@@ -1,6 +1,7 @@
 import unittest
 import zipfile
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+import tarfile
 
 from src.modules.media_analyzer import MediaAuthenticityAnalyzer
 
@@ -44,6 +45,34 @@ class TestMediaAnalyzerBug(unittest.TestCase):
             self.fail(f"Caught NameError: {e} - Fix failed!")
         except Exception as e:
             self.fail(f"Caught unexpected exception: {type(e).__name__}: {e}")
+
+
+
+    def test_inspect_tar_contents_error_handling(self):
+        # Create a mock config
+        config = MagicMock()
+        config.check_media_attachments = True
+        config.deepfake_detection_enabled = False
+
+        analyzer = MediaAuthenticityAnalyzer(config)
+        analyzer.logger = MagicMock()
+
+        # 1. Test TarError (should be passed and not log a warning)
+        score, warnings = analyzer._inspect_tar_contents("test.tar", b"not a tar file")
+        self.assertEqual(score, 0.0)
+        self.assertEqual(warnings, [])
+        analyzer.logger.warning.assert_not_called()
+
+        # 2. Test generic Exception (should log a warning)
+        with patch('tarfile.open', side_effect=Exception("Generic Error")):
+            score, warnings = analyzer._inspect_tar_contents("test.tar", b"some data")
+
+        self.assertEqual(score, 0.0)
+        self.assertEqual(warnings, [])
+        analyzer.logger.warning.assert_called_once()
+        args, _ = analyzer.logger.warning.call_args
+        self.assertIn("Error inspecting tar test.tar", args[0])
+        self.assertIn("Generic Error", args[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** The `_inspect_tar_contents` method in `src/modules/media_analyzer.py` handles exceptions (e.g., `TarError` and generic `Exception`), but these error paths lacked test coverage.

📊 **Coverage:** Added testing for both the `TarError` catch block (where the error is intentionally suppressed and `logger.warning` is not invoked) and the generic `Exception` catch block (where a warning should be logged). Both paths now assert that `(0.0, [])` is correctly returned as the default when `tarfile.open` fails.

✨ **Result:** Test coverage improved for edge cases and exceptions related to unreadable or malformed `.tar` archives in the media analyzer.

✅ **Verification:** Verified by injecting errors with a `patch` on `tarfile.open` and ensuring the module silently recovers.

---
*PR created automatically by Jules for task [8062494611808455103](https://jules.google.com/task/8062494611808455103) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->