### PR TITLE
🧪 [testing improvement] Add test for alert worker loop exception cleanup

### DIFF
--- a/tests/test_alert_system_async.py
+++ b/tests/test_alert_system_async.py
@@ -111,6 +111,27 @@ class TestAlertWorkerLifecycle(unittest.TestCase):
         system.stop_worker()
 
 
+    def test_run_worker_loop_exception_cleanup(self):
+        """If _alert_worker raises an exception, the loop must be cleaned up properly."""
+        system = AlertSystem(_make_config())
+
+        # We need to simulate being in the worker thread for the identity check
+        system._worker_thread = threading.current_thread()
+
+        async def fake_worker():
+            raise RuntimeError("Simulated crash")
+
+        with patch.object(system, "_alert_worker", side_effect=fake_worker):
+            with self.assertRaises(RuntimeError) as cm:
+                system._run_worker_loop()
+            self.assertIn("Simulated crash", str(cm.exception))
+
+        self.assertIsNone(system._loop)
+        self.assertIsNone(system._alert_queue)
+        self.assertFalse(system._queue_ready.is_set())
+        self.assertIsNone(system._worker_thread)
+
+
 class TestAsyncAlertDispatch(unittest.TestCase):
     """Test that send_alert() enqueues asynchronously when worker is running."""
 


### PR DESCRIPTION
🎯 **What:** Added a missing unit test to `tests/test_alert_system_async.py` for verifying that `_run_worker_loop` inside `alert_system.py` gracefully cleans up its resources (the event loop, queue, and thread references) if the internal `_alert_worker` coroutine crashes.

📊 **Coverage:** The new test `test_run_worker_loop_exception_cleanup` covers the `finally` block of `AlertSystem._run_worker_loop()` and guarantees that the worker thread and queue are properly closed and zombie states are avoided during a crash.

✨ **Result:** Increased testing coverage for the worker thread execution context and added regression protection for `try-finally` lifecycle cleanup logic.

---
*PR created automatically by Jules for task [14201596742982905972](https://jules.google.com/task/14201596742982905972) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->