### PR TITLE
🧪 [testing improvement] Cover nested ZIP member error handling

### DIFF
--- a/tests/test_media_analyzer_error_handling.py
+++ b/tests/test_media_analyzer_error_handling.py
@@ -46,5 +46,89 @@ class TestMediaAnalyzerBug(unittest.TestCase):
             self.fail(f"Caught unexpected exception: {type(e).__name__}: {e}")
 
 
+
+    def test_handle_nested_zip_member_value_error(self):
+        # Create a mock config
+        config = MagicMock()
+        config.check_media_attachments = True
+        config.deepfake_detection_enabled = False
+
+        analyzer = MediaAuthenticityAnalyzer(config)
+        analyzer.logger = MagicMock()
+
+        mock_zf = MagicMock(spec=zipfile.ZipFile)
+        mock_info = MagicMock()
+        mock_info.file_size = 100
+        mock_zf.getinfo.return_value = mock_info
+
+        analyzer._read_zip_member_securely = MagicMock(side_effect=ValueError("Nested zip bomb"))
+
+        score, warnings = analyzer._handle_nested_zip_member(mock_zf, "nested.zip", "parent.zip", 0)
+
+        self.assertEqual(score, 5.0)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("Zip bomb detected", warnings[0])
+        self.assertIn("Nested zip bomb", warnings[0])
+
+    def test_handle_nested_zip_member_exception(self):
+        config = MagicMock()
+        config.check_media_attachments = True
+        config.deepfake_detection_enabled = False
+
+        analyzer = MediaAuthenticityAnalyzer(config)
+        analyzer.logger = MagicMock()
+
+        mock_zf = MagicMock(spec=zipfile.ZipFile)
+        mock_info = MagicMock()
+        mock_info.file_size = 100
+        mock_zf.getinfo.return_value = mock_info
+
+        analyzer._read_zip_member_securely = MagicMock(side_effect=Exception("Generic error"))
+
+        score, warnings = analyzer._handle_nested_zip_member(mock_zf, "nested.zip", "parent.zip", 0)
+
+        self.assertEqual(score, 3.0)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("Failed to inspect nested archive", warnings[0])
+        self.assertIn("Generic error", warnings[0])
+        analyzer.logger.warning.assert_called_with("Error inspecting nested archive nested.zip: Generic error")
+
+    def test_handle_nested_zip_member_size_limit(self):
+        config = MagicMock()
+        config.check_media_attachments = True
+        config.deepfake_detection_enabled = False
+
+        analyzer = MediaAuthenticityAnalyzer(config)
+        analyzer.logger = MagicMock()
+
+        mock_zf = MagicMock(spec=zipfile.ZipFile)
+        mock_info = MagicMock()
+        # Set file size greater than MAX_NESTED_ZIP_SIZE (default is usually 10MB or 50MB, let's use a huge number)
+        mock_info.file_size = analyzer.MAX_NESTED_ZIP_SIZE + 1000
+        mock_zf.getinfo.return_value = mock_info
+
+        score, warnings = analyzer._handle_nested_zip_member(mock_zf, "nested.zip", "parent.zip", 0)
+
+        self.assertEqual(score, 0.0)
+        self.assertEqual(len(warnings), 0)
+        analyzer.logger.warning.assert_called_with(f"Skipping nested archive nested.zip (declared size {mock_info.file_size} > limit)")
+
+    def test_handle_nested_zip_member_depth_limit(self):
+        config = MagicMock()
+        config.check_media_attachments = True
+        config.deepfake_detection_enabled = False
+
+        analyzer = MediaAuthenticityAnalyzer(config)
+        analyzer.logger = MagicMock()
+
+        mock_zf = MagicMock(spec=zipfile.ZipFile)
+
+        score, warnings = analyzer._handle_nested_zip_member(mock_zf, "nested.zip", "parent.zip", 2)
+
+        self.assertEqual(score, 0.0)
+        self.assertEqual(len(warnings), 0)
+        # _read_zip_member_securely should not be called because depth >= 2
+        mock_zf.getinfo.assert_not_called()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The `_handle_nested_zip_member` method in `src/modules/media_analyzer.py` had missing test coverage for its error handling logic. This method is responsible for safely extracting and recursing into nested ZIP/TAR archives, applying size limits, depth limits, and catching `ValueError` (zip bombs) and generic exceptions.

📊 **Coverage:** The following scenarios are now tested:
- Simulated `ValueError` (e.g., zip bomb detected) returns a score of 5.0 and appropriate warning.
- Simulated generic `Exception` returns a score of 3.0 and appropriate warning.
- Declared nested file size exceeding `MAX_NESTED_ZIP_SIZE` skips extraction and correctly returns a 0.0 score.
- Recursion `depth >= 2` aborts early and avoids calling further extraction logic.

✨ **Result:** Enhanced test suite reliability by fully exercising the edge cases and failure modes of nested ZIP archive processing.

---
*PR created automatically by Jules for task [1242120434876080047](https://jules.google.com/task/1242120434876080047) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->