### PR TITLE
🧹 [Code Health] Move import os to top of file in app_runner.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -96,3 +96,6 @@
 ## 2026-05-30 - Remove re.IGNORECASE penalty in hidden text regex evaluation
 **Learning:** In Python, using `re.IGNORECASE` significantly slows down regex execution. On regexes that don't depend on original casing for correct matching (like HTML tags or simple CSS matches), pre-lowercasing the target string and running a case-sensitive regex is 2-4x faster than using `re.IGNORECASE` on the original string, even accounting for the `.lower()` memory allocation overhead.
 **Action:** When a regex with `re.IGNORECASE` is used on strings and the original casing is not needed for the match context, compile the regex without `re.IGNORECASE` and use `.search(text.lower())`.
+## 2026-06-01 - Code Health Improvement: Centralize Imports
+**Learning:** Local imports (like `import os`) nested inside functions should be avoided as they can result in duplication and hurt code maintainability, unless there is a specific need such as circular dependency resolution.
+**Action:** Always check and push redundant local imports to the top level of the module to align with PEP-8.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -1,5 +1,6 @@
 import signal
 import sys
+import os
 from pathlib import Path
 from typing import List, NoReturn, Optional
 
@@ -146,7 +147,6 @@ class AppRunner:
                 response = self._styled_input(prompt).lower()
                 if response in ("", "y", "yes"):
                     try:
-                        import os
 
                         with open(".env.example", "rb") as src:
                             content = src.read()
@@ -288,7 +288,6 @@ class AppRunner:
 
     def _create_config_from_template(self) -> None:
         """Create the configuration file from .env.example with secure permissions."""
-        import os
 
         with open(".env.example", "rb") as src:
             content = src.read()
@@ -318,7 +317,6 @@ class AppRunner:
 
     def _set_secure_permissions(self, fd: int) -> None:
         """Set restrictive permissions (0o600) on a file descriptor with fallback."""
-        import os
 
         # Prioritize using the file descriptor to prevent TOCTOU vulnerabilities.
         try:


### PR DESCRIPTION
🎯 **What:** Removed local `import os` statements from three methods (`_handle_missing_config_interactive`, `_create_config_from_template`, `_set_secure_permissions`) and moved `import os` to the top of `src/app_runner.py`.\n\n💡 **Why:** Having multiple local imports throughout the file introduces unnecessary code duplication and violates general Python style conventions (PEP 8) where standard library imports should be at the top level of the file unless there is a specific circular dependency or performance reason.\n\n✅ **Verification:** Verified the correct insertion and removal via `grep` and `head`. Executed `flake8 src/app_runner.py` which showed no linting issues and `python3 -m pytest tests/test_app_runner.py` passed.\n\n✨ **Result:** The codebase is cleaner and adheres strictly to top-level import guidelines for improved maintainability.

---
*PR created automatically by Jules for task [5260274702822088197](https://jules.google.com/task/5260274702822088197) started by @abhimehro*