### PR TITLE
🧪 [Testing] Cover secure permissions error path

### DIFF
--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -140,3 +140,84 @@ def test_start_pipeline(mock_pipeline_class, mock_app_runner):
 
     mock_pipeline_class.assert_called_once_with(mock_app_runner.config_file)
     mock_pipeline_instance.start.assert_called_once()
+
+
+@patch("os.fchmod")
+def test_set_secure_permissions_primary(mock_fchmod, mock_app_runner):
+    mock_app_runner._set_secure_permissions(123)
+    mock_fchmod.assert_called_once_with(123, 0o600)
+
+@patch("os.chmod")
+@patch("os.fchmod")
+def test_set_secure_permissions_fallback_chmod_fd(mock_fchmod, mock_chmod, mock_app_runner):
+    mock_fchmod.side_effect = AttributeError("fchmod not available")
+    mock_app_runner._set_secure_permissions(123)
+    mock_fchmod.assert_called_once_with(123, 0o600)
+    mock_chmod.assert_called_once_with(123, 0o600)
+
+def test_set_secure_permissions_fallback_chmod_path(mock_app_runner):
+    with patch("os.fchmod") as mock_fchmod, patch("os.fstat") as mock_fstat, patch("os.lstat") as mock_lstat, patch("os.chmod") as mock_chmod:
+        import os
+        mock_fchmod.side_effect = AttributeError("fchmod not available")
+        mock_chmod.side_effect = [TypeError("chmod fd not supported"), None]
+
+        mock_stat_fd = MagicMock()
+        mock_stat_fd.st_ino = 1
+        mock_stat_fd.st_dev = 2
+        mock_fstat.return_value = mock_stat_fd
+
+        mock_stat_path = MagicMock()
+        mock_stat_path.st_ino = 1
+        mock_stat_path.st_dev = 2
+        mock_lstat.return_value = mock_stat_path
+
+        # Mock the follow_symlinks support
+        original_supports = os.supports_follow_symlinks
+        os.supports_follow_symlinks = {os.chmod}
+
+        try:
+            mock_app_runner._set_secure_permissions(123)
+
+            mock_fchmod.assert_called_once_with(123, 0o600)
+            assert mock_chmod.call_count == 2
+            assert mock_chmod.call_args_list[0] == ((123, 0o600), {})
+            assert mock_chmod.call_args_list[1] == ((mock_app_runner.config_file, 0o600), {"follow_symlinks": False})
+        finally:
+            os.supports_follow_symlinks = original_supports
+
+def test_set_secure_permissions_toctou_detected(mock_app_runner):
+    with patch("os.fchmod") as mock_fchmod, patch("os.chmod") as mock_chmod, patch("os.fstat") as mock_fstat, patch("os.lstat") as mock_lstat, patch("src.app_runner.sys.exit") as mock_exit:
+        mock_fchmod.side_effect = AttributeError("fchmod not available")
+        mock_chmod.side_effect = TypeError("chmod fd not supported")
+        mock_exit.side_effect = SystemExit(1)
+
+        mock_stat_fd = MagicMock()
+        mock_stat_fd.st_ino = 1
+        mock_stat_fd.st_dev = 2
+        mock_fstat.return_value = mock_stat_fd
+
+        mock_stat_path = MagicMock()
+        mock_stat_path.st_ino = 3 # Different inode
+        mock_stat_path.st_dev = 2
+        mock_lstat.return_value = mock_stat_path
+
+        import pytest
+        with pytest.raises(SystemExit) as excinfo:
+            mock_app_runner._set_secure_permissions(123)
+
+        assert excinfo.value.code == 1
+        mock_exit.assert_called_once_with(1)
+
+def test_set_secure_permissions_oserror(mock_app_runner):
+    with patch("os.fchmod") as mock_fchmod, patch("os.chmod") as mock_chmod, patch("os.fstat") as mock_fstat, patch("src.app_runner.sys.exit") as mock_exit:
+        mock_fchmod.side_effect = AttributeError("fchmod not available")
+        mock_chmod.side_effect = TypeError("chmod fd not supported")
+        mock_fstat.side_effect = OSError("Permission denied")
+        mock_exit.side_effect = SystemExit(1)
+
+        import pytest
+        with pytest.raises(SystemExit) as excinfo:
+            mock_app_runner._set_secure_permissions(123)
+
+        assert excinfo.value.code == 1
+        mock_exit.assert_called_once_with(1)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed in `_set_secure_permissions` error paths and TOCTOU vulnerabilities.
📊 **Coverage:** Added 5 test cases covering happy path, fallbacks, TOCTOU vulnerability detection, and OSError exceptions during permission configuration.
✨ **Result:** Improved test reliability and ensured secure permission setting error paths are properly handled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->