### PR TITLE
🎨 Palette: Strip keyboard hint from Spinner on completion

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -175,3 +175,6 @@
 ## 2025-05-19 - Add keyboard shortcut hint to spinner
 **Learning:** Terminal spinners blocking output streams without visible keyboard exit hints cause user anxiety and increase perceived lock-ups, especially in interactive CLIs where users don't know if Ctrl+C is safe.
 **Action:** Always append actionable exit hints like '(Press Ctrl+C to stop)' dynamically to long-running terminal elements, but ensure the hint is cleanly stripped from the final success/failure log message to prevent polluting permanent logs with interactive UX instructions.
+## 2025-06-02 - Strip Interactive Hints from Final UI State
+**Learning:** Terminal spinners that append interactive hints (like `(Press Ctrl+C to stop)`) often leave those hints permanently visible on the screen if they aren't stripped before printing the final success/failure state. This creates messy logs and confusing UX once the action is over.
+**Action:** Always strip interactive instructions from terminal components during their cleanup or `__exit__` phase before printing the final persisted message.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -206,23 +206,26 @@ class Spinner:
                     self.thread.join()
                 final_message = ""
 
+                clean_msg = self.message.replace(" (Press Ctrl+C to stop)", "")
+                
                 if exc_type is KeyboardInterrupt:
                     warning = Colors.colorize("⚠", Colors.YELLOW)
-                    final_message = f"{warning} {self.message} (Cancelled){time_str}\n"
+                    final_message = f"{warning} {clean_msg} (Cancelled){time_str}\n"
                 elif exc_type is not None or self.fail_msg:
                     # Failure logic
-                    msg = self.fail_msg if self.fail_msg else self.message
+                    msg = self.fail_msg.replace(" (Press Ctrl+C to stop)", "") if self.fail_msg else clean_msg
                     # Use Colors.colorize to ensure we get proper fallback if colors are disabled
                     cross = Colors.colorize("✘", Colors.RED)
                     final_message = f"{cross} {msg}{time_str}\n"
                 elif self.success_msg:
                     # Explicit success message always persists
                     check = Colors.colorize("✔", Colors.GREEN)
-                    final_message = f"{check} {self.success_msg}{time_str}\n"
+                    clean_success_msg = self.success_msg.replace(" (Press Ctrl+C to stop)", "")
+                    final_message = f"{check} {clean_success_msg}{time_str}\n"
                 elif self.persist:
                     # Default persistence
                     check = Colors.colorize("✔", Colors.GREEN)
-                    final_message = f"{check} {self.message}{time_str}\n"
+                    final_message = f"{check} {clean_msg}{time_str}\n"
 
                 sys.stdout.write(f"\r\033[K{final_message}")
                 sys.stdout.flush()
@@ -235,13 +238,16 @@ class Spinner:
             # Colors.ENABLED is computed at import time, so use plain symbols here
             # to avoid leaking escape sequences when stdout is redirected later.
             raw_time_str = f" [{elapsed:.1f}s]" if elapsed >= 1.0 else ""
+            clean_msg = self.message.replace(" (Press Ctrl+C to stop)", "")
+            
             if exc_type is KeyboardInterrupt:
-                sys.stdout.write(f"⚠ {self.message} (Cancelled){raw_time_str}\n")
+                sys.stdout.write(f"⚠ {clean_msg} (Cancelled){raw_time_str}\n")
             elif exc_type is not None or self.fail_msg:
-                msg = self.fail_msg if self.fail_msg else self.message
+                msg = self.fail_msg.replace(" (Press Ctrl+C to stop)", "") if self.fail_msg else clean_msg
                 sys.stdout.write(f"✘ {msg}{raw_time_str}\n")
             elif self.success_msg:
-                sys.stdout.write(f"✔ {self.success_msg}{raw_time_str}\n")
+                clean_success_msg = self.success_msg.replace(" (Press Ctrl+C to stop)", "")
+                sys.stdout.write(f"✔ {clean_success_msg}{raw_time_str}\n")
             elif self.persist:
-                sys.stdout.write(f"✔ {self.message}{raw_time_str}\n")
+                sys.stdout.write(f"✔ {clean_msg}{raw_time_str}\n")
             sys.stdout.flush()

--- a/tests/test_ui_palette.py
+++ b/tests/test_ui_palette.py
@@ -108,3 +108,32 @@ class TestPaletteUI(TestCase):
             self.assertIn("Testing Cancel (Cancelled)", writes)
             self.assertNotIn("(Press Ctrl+C to stop) (Cancelled)", writes)
             self.assertIn("⚠", writes)
+
+    def test_spinner_strip_hint_on_exit(self):
+        """Test that the keyboard interrupt hint is cleanly stripped from the final completion message."""
+        from src.utils.ui import Spinner
+        with patch('sys.stdout') as mock_stdout:
+            mock_stdout.isatty.return_value = True
+            
+            with patch.object(Spinner, '_start_tty_spinner'):
+                spinner = Spinner("Loading (Press Ctrl+C to stop)")
+                spinner.__enter__()
+                spinner.success("Done (Press Ctrl+C to stop)")
+                spinner.__exit__(None, None, None)
+                
+                writes = "".join(c.args[0] for c in mock_stdout.write.mock_calls if c.args)
+                self.assertNotIn("(Press Ctrl+C to stop)", writes)
+                self.assertIn("Done", writes)
+
+        with patch('sys.stdout') as mock_stdout:
+            mock_stdout.isatty.return_value = True
+            
+            with patch.object(Spinner, '_start_tty_spinner'):
+                spinner = Spinner("Loading (Press Ctrl+C to stop)")
+                spinner.__enter__()
+                spinner.fail("Error (Press Ctrl+C to stop)")
+                spinner.__exit__(RuntimeError, None, None)
+                
+                writes = "".join(c.args[0] for c in mock_stdout.write.mock_calls if c.args)
+                self.assertNotIn("(Press Ctrl+C to stop)", writes)
+                self.assertIn("Error", writes)


### PR DESCRIPTION
💡 **What:** Strips the interactive terminal hint `(Press Ctrl+C to stop)` from `Spinner` outputs when displaying final state messages (success/fail/cancellation).

🎯 **Why:** Leaves terminal output and persistent logs much cleaner by removing transient interactive UX hints that are no longer relevant once the operation is complete.

📸 **Before/After:** Before, finishing a spinner printed `✔ Loading (Press Ctrl+C to stop) [1.2s]`. After, it prints `✔ Loading [1.2s]`.

♿ **Accessibility:** Improves screen reader experience by not reading out irrelevant and stale instructions after an action completes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->