### PR TITLE
fix(app_runner): restore _set_secure_permissions for secure config creation

### DIFF
--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -308,6 +308,7 @@ class AppRunner:
         finally:
             os.umask(old_umask)
         try:
+            self._set_secure_permissions(fd)
 
             with os.fdopen(fd, "wb") as dst:
                 dst.write(content)
@@ -319,6 +320,43 @@ class AppRunner:
         except Exception:
             os.close(fd)
             raise
+
+    def _set_secure_permissions(self, fd: int) -> None:
+        """Set restrictive permissions (0o600) on a file descriptor with fallback."""
+        import os
+
+        try:
+            os.fchmod(fd, 0o600)
+            return
+        except (AttributeError, OSError, NotImplementedError):
+            pass
+
+        try:
+            os.chmod(fd, 0o600)
+            return
+        except (AttributeError, OSError, NotImplementedError, TypeError):
+            pass
+
+        try:
+            stat_fd = os.fstat(fd)
+        except OSError:
+            sys.exit(1)
+
+        try:
+            stat_path = os.lstat(self.config_file)
+        except OSError:
+            sys.exit(1)
+
+        if stat_fd.st_ino != stat_path.st_ino or stat_fd.st_dev != stat_path.st_dev:
+            sys.exit(1)
+
+        chmod_kwargs = (
+            {"follow_symlinks": False}
+            if hasattr(os, "supports_follow_symlinks")
+            and os.chmod in os.supports_follow_symlinks
+            else {}
+        )
+        os.chmod(self.config_file, 0o600, **chmod_kwargs)
 
     def start_pipeline(self) -> None:
         """Instantiate and start the main pipeline."""


### PR DESCRIPTION
## Daily QA fix (2026-06-05)

Closes #1033

### Problem
Five `test_app_runner` tests failed: `AppRunner` lacked `_set_secure_permissions`.

### Fix
Restored fd-first `0o600` hardening with TOCTOU-checked path fallback; called from `_create_config_from_template`.

### Verification
```bash
python3 -m pytest tests/test_app_runner.py -q  # 14 passed
python3 -m pytest -q                             # 621 passed
```