### PR TITLE
🎨 Palette: Use semantic Colors.colorize for configuration summary UI

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -403,10 +403,10 @@ class EmailSecurityPipeline:
 
     def _print_configuration_summary(self):
         """Print a summary of the current configuration."""
-        print(f"\n{Colors.BOLD}📊 System Configuration:{Colors.RESET}")
+        print(f"\n{Colors.colorize('📊 System Configuration:', Colors.BOLD)}")
 
         # Accounts
-        print(f"  📧 {Colors.CYAN}Monitored Accounts:{Colors.RESET}")
+        print(f"  📧 {Colors.colorize('Monitored Accounts:', Colors.CYAN)}")
         if not self.config.email_accounts:
             print(f"    - {Colors.colorize('⚠ No accounts configured', Colors.YELLOW)}")
         else:
@@ -419,30 +419,30 @@ class EmailSecurityPipeline:
                 print(f"    - {account.provider.title()}: {account.email} ({status})")
 
         # Analysis
-        print(f"  🔍 {Colors.CYAN}Analysis Layers:{Colors.RESET}")
+        print(f"  🔍 {Colors.colorize('Analysis Layers:', Colors.CYAN)}")
         print(
-            f"    - Spam Detection:   {Colors.GREEN}✔ Active{Colors.RESET} "
+            f"    - Spam Detection:   {Colors.colorize('✔ Active', Colors.GREEN)} "
             f"(Threshold: {self.config.analysis.spam_threshold})"
         )
         print(
-            f"    - NLP Analysis:     {Colors.GREEN}✔ Active{Colors.RESET} "
+            f"    - NLP Analysis:     {Colors.colorize('✔ Active', Colors.GREEN)} "
             f"(Threshold: {self.config.analysis.nlp_threshold})"
         )
 
         media_status = (
-            f"{Colors.GREEN}✔ Active{Colors.RESET}"
+            Colors.colorize("✔ Active", Colors.GREEN)
             if self.config.analysis.check_media_attachments
-            else f"{Colors.GREY}✖ Disabled{Colors.RESET}"
+            else Colors.colorize("✖ Disabled", Colors.GREY)
         )
         deepfake_status = (
-            f"{Colors.GREEN}✔ Enabled{Colors.RESET}"
+            Colors.colorize("✔ Enabled", Colors.GREEN)
             if self.config.analysis.deepfake_detection_enabled
-            else f"{Colors.GREY}✖ Disabled{Colors.RESET}"
+            else Colors.colorize("✖ Disabled", Colors.GREY)
         )
         print(f"    - Media Check:      {media_status} (Deepfake: {deepfake_status})")
 
         # Alerts
-        print(f"  🔔 {Colors.CYAN}Alert Channels:{Colors.RESET}")
+        print(f"  🔔 {Colors.colorize('Alert Channels:', Colors.CYAN)}")
         channels = []
         if self.config.alerts.console:
             channels.append("Console")
@@ -452,13 +452,13 @@ class EmailSecurityPipeline:
             channels.append("Slack")
 
         if channels:
-            print(f"    - {Colors.GREEN}✔ Enabled{Colors.RESET}: {', '.join(channels)}")
+            print(f"    - {Colors.colorize('✔ Enabled', Colors.GREEN)}: {', '.join(channels)}")
         else:
             print(
                 f"    - {Colors.colorize('⚠ No alert channels configured', Colors.YELLOW)}"
             )
 
-        print(f"  ⚙️ {Colors.CYAN}System:{Colors.RESET}")
+        print(f"  ⚙️ {Colors.colorize('System:', Colors.CYAN)}")
         print(f"    - Log Level:  {self.config.system.log_level}")
         print(f"    - Log Format: {self.config.system.log_format}")
         metrics_status = (
@@ -471,7 +471,7 @@ class EmailSecurityPipeline:
 
         # Documentation footer
         print(
-            f"\n📚 {Colors.GREY}For help, see README.md or OUTLOOK_TROUBLESHOOTING.md{Colors.RESET}\n"
+            f"\n📚 {Colors.colorize('For help, see README.md or OUTLOOK_TROUBLESHOOTING.md', Colors.GREY)}\n"
         )
 
 

--- a/tests/test_ui_palette.py
+++ b/tests/test_ui_palette.py
@@ -142,3 +142,35 @@ class TestPaletteUI(TestCase):
                 )
                 self.assertNotIn("(Press Ctrl+C to stop)", writes)
                 self.assertIn("Error", writes)
+
+    def test_main_print_configuration_summary_uses_colorize(self):
+        from src.main import EmailSecurityPipeline
+        from src.utils.config import Config
+        from io import StringIO
+        import sys
+
+        # Create a mock config
+        config = Config()
+        config.system.check_interval = 60
+        pipeline = EmailSecurityPipeline()
+        pipeline.config = config
+
+        # Mock stdout and Colors.colorize to track calls
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            from src.utils.colors import Colors
+            with patch("src.main.Colors.colorize", wraps=Colors.colorize) as mock_colorize:
+                pipeline._print_configuration_summary()
+
+                # Verify that colorize was called for all colored outputs
+                calls = mock_colorize.call_args_list
+                colored_strings = [call[0][0] for call in calls]
+
+                self.assertIn("📊 System Configuration:", colored_strings)
+                self.assertIn("Monitored Accounts:", colored_strings)
+                self.assertIn("Analysis Layers:", colored_strings)
+                self.assertIn("Alert Channels:", colored_strings)
+                self.assertIn("System:", colored_strings)
+
+                # Check actual output for fallback safety (no ANSI code directly interpolated)
+                output = mock_stdout.getvalue()
+                self.assertIn("📊 System Configuration:", output)


### PR DESCRIPTION
💡 What: Refactored the `_print_configuration_summary` UI to use the semantic `Colors.colorize()` function rather than relying on direct string interpolation of raw ANSI color codes (`Colors.BOLD`, `Colors.RESET`, etc.).
🎯 Why: Direct string concatenation of ANSI color codes completely bypasses the centralized environment checks (such as TTY verification or `NO_COLOR` environment variables) making the output garbled when logged to files or displayed in CI systems without proper terminal support. Using the `colorize()` helper resolves this.
♿ Accessibility: Ensures that terminal output smoothly degrades in text-only or screen-reader environments when terminal styling rules prevent color rendering.
✅ Also includes a dedicated test to verify standard usage of `Colors.colorize` in this code path.

---
*PR created automatically by Jules for task [7922445448789202080](https://jules.google.com/task/7922445448789202080) started by @abhimehro*