### PR TITLE
Lint Fix: Remove unused sys import

### DIFF
--- a/tests/test_ui_palette.py
+++ b/tests/test_ui_palette.py
@@ -147,7 +147,6 @@ class TestPaletteUI(TestCase):
         from src.main import EmailSecurityPipeline
         from src.utils.config import Config
         from io import StringIO
-        import sys
 
         # Create a mock config
         config = Config()


### PR DESCRIPTION
This PR addresses a flake8 lint issue by removing an unused sys import in test_ui_palette.py.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->