### PR TITLE
🎨 Palette: De-emphasize secondary terminal hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -185,3 +185,6 @@
 ## 2024-05-30 - Refactor direct ANSI concatenations
 **Learning:** Hardcoded ANSI escape codes (like `f"\n{Colors.CYAN}Text{Colors.RESET}"`) bypass TTY detection mechanisms. This breaks accessibility, clutters log files with raw escape characters, and negatively affects users on non-TTY environments who rely on clean output.
 **Action:** Always use the centralized `Colors.colorize(text, color)` utility function for styling text. It cleanly handles environment checks (TTY/NO_COLOR) and conditionally applies styling without polluting logs or non-interactive stdout streams.
+## 2025-02-12 - De-emphasize Secondary Interaction Hints
+**Learning:** Secondary hints like "(Press Ctrl+C to stop)" command too much visual attention when styled with the primary foreground color, competing with the actual status message (e.g. "Waiting" or "Checking for emails").
+**Action:** Always de-emphasize secondary keyboard shortcuts and terminal hints using a muted color (like `Colors.GREY`) to maintain focus on the primary action and reduce visual clutter.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -12,6 +12,7 @@ from .colors import Colors
 
 CURSOR_HIDE = "\033[?25l"
 CURSOR_SHOW = "\033[?25h"
+CTRL_C_HINT = " (Press Ctrl+C to stop)"
 
 
 class CountdownTimer:
@@ -98,9 +99,8 @@ class CountdownTimer:
         # Only add the interactive hint when we're actually in a TTY.
         # In non-TTY mode, `start()` will just sleep and never render the message.
         if sys.stdout.isatty():
-            hint = Colors.colorize(" (Press Ctrl+C to stop)", Colors.GREY)
-            if hint not in message:
-                message += hint
+            if CTRL_C_HINT not in message:
+                message += Colors.colorize(CTRL_C_HINT, Colors.GREY)
         timer = CountdownTimer(seconds, message)
         timer.start()
 
@@ -144,9 +144,8 @@ class Spinner:
             spin_char = Colors.colorize(next(self.spinner), Colors.CYAN)
             display_msg = self.message
             if sys.stdout.isatty():
-                hint = Colors.colorize(" (Press Ctrl+C to stop)", Colors.GREY)
-                if hint not in display_msg:
-                    display_msg += hint
+                if CTRL_C_HINT not in display_msg:
+                    display_msg += Colors.colorize(CTRL_C_HINT, Colors.GREY)
             sys.stdout.write(f"\r{spin_char} {display_msg}{time_str}   \033[K")
             sys.stdout.flush()
             time.sleep(self.delay)
@@ -159,9 +158,8 @@ class Spinner:
         # We don't mutate self.message, we just format the display string
         display_msg = self.message
         if sys.stdout.isatty():
-            hint = Colors.colorize(" (Press Ctrl+C to stop)", Colors.GREY)
-            if hint not in display_msg:
-                display_msg += hint
+            if CTRL_C_HINT not in display_msg:
+                display_msg += Colors.colorize(CTRL_C_HINT, Colors.GREY)
 
         msg = display_msg if display_msg.endswith("...") else f"{display_msg}..."
 

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -78,7 +78,7 @@ class CountdownTimer:
         except (EOFError, KeyboardInterrupt):
             # Clean up line on interrupt
             warning = Colors.colorize("⚠", Colors.YELLOW)
-            clean_msg = self.message.replace(" (Press Ctrl+C to stop)", "")
+            clean_msg = self.message.replace(Colors.colorize(" (Press Ctrl+C to stop)", Colors.GREY), "").replace(" (Press Ctrl+C to stop)", "")
             # Ensure we print the cancellation message correctly
             sys.stdout.write(f"\r\033[K{warning} {clean_msg} (Cancelled)\n")
             sys.stdout.flush()
@@ -98,7 +98,7 @@ class CountdownTimer:
         # Only add the interactive hint when we're actually in a TTY.
         # In non-TTY mode, `start()` will just sleep and never render the message.
         if sys.stdout.isatty():
-            hint = " (Press Ctrl+C to stop)"
+            hint = Colors.colorize(" (Press Ctrl+C to stop)", Colors.GREY)
             if hint not in message:
                 message += hint
         timer = CountdownTimer(seconds, message)
@@ -144,7 +144,7 @@ class Spinner:
             spin_char = Colors.colorize(next(self.spinner), Colors.CYAN)
             display_msg = self.message
             if sys.stdout.isatty():
-                hint = " (Press Ctrl+C to stop)"
+                hint = Colors.colorize(" (Press Ctrl+C to stop)", Colors.GREY)
                 if hint not in display_msg:
                     display_msg += hint
             sys.stdout.write(f"\r{spin_char} {display_msg}{time_str}   \033[K")
@@ -159,7 +159,7 @@ class Spinner:
         # We don't mutate self.message, we just format the display string
         display_msg = self.message
         if sys.stdout.isatty():
-            hint = " (Press Ctrl+C to stop)"
+            hint = Colors.colorize(" (Press Ctrl+C to stop)", Colors.GREY)
             if hint not in display_msg:
                 display_msg += hint
 
@@ -195,7 +195,7 @@ class Spinner:
 
     def _get_final_message_components(self, exc_type) -> tuple[str, str]:
         """Determine the final symbol and message to display."""
-        clean_msg = self.message.replace(" (Press Ctrl+C to stop)", "")
+        clean_msg = self.message.replace(Colors.colorize(" (Press Ctrl+C to stop)", Colors.GREY), "").replace(" (Press Ctrl+C to stop)", "")
         is_cancelled = exc_type is not None and issubclass(
             exc_type, (EOFError, KeyboardInterrupt)
         )
@@ -206,14 +206,14 @@ class Spinner:
 
         if is_failed:
             msg = (
-                self.fail_msg.replace(" (Press Ctrl+C to stop)", "")
+                self.fail_msg.replace(Colors.colorize(" (Press Ctrl+C to stop)", Colors.GREY), "").replace(" (Press Ctrl+C to stop)", "")
                 if self.fail_msg
                 else clean_msg
             )
             return "✘", msg
 
         if self.success_msg:
-            return "✔", self.success_msg.replace(" (Press Ctrl+C to stop)", "")
+            return "✔", self.success_msg.replace(Colors.colorize(" (Press Ctrl+C to stop)", Colors.GREY), "").replace(" (Press Ctrl+C to stop)", "")
 
         if self.persist:
             return "✔", clean_msg


### PR DESCRIPTION
**What**: Added `Colors.GREY` styling to the secondary terminal cancellation hints `(Press Ctrl+C to stop)` in the CLI UI components (`CountdownTimer` and `Spinner`).
**Why**: To prevent secondary shortcut hints from competing visually with primary status messages like "Waiting" or "Checking for emails", creating a cleaner, more focused terminal experience.
**Accessibility**: Reduces visual noise and improves the scannability of terminal output without removing the helpful shortcut hints.

A new critical learning was added to `.jules/palette.md` to ensure this UX pattern is captured and applied in the future.

---
*PR created automatically by Jules for task [1893277618280985768](https://jules.google.com/task/1893277618280985768) started by @abhimehro*