### PR TITLE
🧹 Remove unused 're' import in imap_connection.py

### DIFF
--- a/src/modules/imap_connection.py
+++ b/src/modules/imap_connection.py
@@ -13,7 +13,6 @@ SECURITY STORY: IMAP connections are security-critical because:
 
 import imaplib
 import logging
-import re
 import socket
 import ssl
 import time


### PR DESCRIPTION
🎯 **What:** Removed unused `import re` in `src/modules/imap_connection.py:16`.

💡 **Why:** This code health improvement reduces clutter and namespace pollution, improving maintainability.

✅ **Verification:** Verified via `grep` that `re` is never explicitly called in `imap_connection.py` (it uses `self.__class__._AUTH_KEYWORD_PATTERN.search` loaded from `compile_patterns`). Ran the full `pytest tests/` suite successfully.

✨ **Result:** A cleaner import list with no change in functionality.

---
*PR created automatically by Jules for task [6362467656030372986](https://jules.google.com/task/6362467656030372986) started by @abhimehro*