### PR TITLE
🎨 Palette: Enhance CLI UX with explicit formatting resets and colorized hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -188,3 +188,7 @@
 ## 2025-02-12 - De-emphasize Secondary Interaction Hints
 **Learning:** Secondary hints like "(Press Ctrl+C to stop)" command too much visual attention when styled with the primary foreground color, competing with the actual status message (e.g. "Waiting" or "Checking for emails").
 **Action:** Always de-emphasize secondary keyboard shortcuts and terminal hints using a muted color (like `Colors.GREY`) to maintain focus on the primary action and reduce visual clutter.
+
+## 2027-04-10 - Explicit sys.stdout.write for Resetting Formatting
+**Learning:** Using `print(Colors.RESET, end="")` to clear terminal formatting after interactive inputs (`input()`, `getpass()`) can sometimes fail or buffer inconsistently in constrained environments or CI logs, leaving the user's terminal permanently styled (e.g., bold).
+**Action:** Always use `sys.stdout.write(Colors.RESET)` followed by `sys.stdout.flush()` instead of `print()` when resetting terminal colors inside interactive input blocks or `finally` handlers to guarantee immediate and reliable unbuffered formatting resets.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -27,7 +27,8 @@ class AppRunner:
             raise
         finally:
             if Colors.ENABLED:
-                print(Colors.RESET, end="", flush=True)
+                sys.stdout.write(Colors.RESET)
+                sys.stdout.flush()
 
         return val
 
@@ -155,7 +156,7 @@ class AppRunner:
     def print_help(self) -> None:
         """Print usage instructions for the CLI."""
         print(Colors.colorize("Usage:", Colors.BOLD))
-        print("  python src/main.py [CONFIG_FILE]\n")
+        print(f"  {Colors.colorize('python src/main.py [CONFIG_FILE]', Colors.CYAN)}\n")
         print(Colors.colorize("Arguments:", Colors.BOLD))
         print(
             "  CONFIG_FILE    Path to the environment configuration file (default: .env)\n"

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -1,6 +1,7 @@
 import getpass
 import os
 import re
+import sys
 from pathlib import Path
 
 # Check if Colors is available in the expected path, otherwise mock it
@@ -64,7 +65,8 @@ def _styled_input(prompt: str) -> str:
         raise
     finally:
         if Colors.ENABLED:
-            print(Colors.RESET, end="", flush=True)
+            sys.stdout.write(Colors.RESET)
+            sys.stdout.flush()
 
     return val
 
@@ -262,7 +264,8 @@ def _prompt_for_password(provider_name: str) -> str:
             raise
         finally:
             if Colors.ENABLED:
-                print(Colors.RESET, end="")
+                sys.stdout.write(Colors.RESET)
+                sys.stdout.flush()
 
     app_secret = _get_input()
     while not app_secret:

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -242,41 +242,60 @@ def test_set_secure_permissions_oserror(mock_app_runner):
         assert excinfo.value.code == 1
         mock_exit.assert_called_once_with(1)
 
-@pytest.mark.parametrize("colors_enabled", [True, False])
-@patch("src.app_runner.Colors.BOLD", "[BOLD]")
-@patch("src.app_runner.Colors.RESET", "[RESET]")
-def test_styled_input_colors(mock_app_runner, colors_enabled):
-    with patch("src.app_runner.Colors.ENABLED", colors_enabled), \
-         patch("builtins.input", return_value=" test_input ") as mock_input, \
+@pytest.fixture
+def mock_io():
+    with patch("builtins.input") as mock_input, \
          patch("builtins.print") as mock_print, \
          patch("src.app_runner.sys.stdout.write") as mock_write, \
          patch("src.app_runner.sys.stdout.flush") as mock_flush:
+        yield mock_input, mock_print, mock_write, mock_flush
 
-        result = mock_app_runner._styled_input("Prompt:")
 
-        assert result == "test_input"
-        mock_input.assert_called_once_with("Prompt:[BOLD]" if colors_enabled else "Prompt:")
-        mock_print.assert_not_called()
-        if colors_enabled:
-            mock_write.assert_called_once_with("[RESET]")
-            mock_flush.assert_called_once()
-        else:
-            mock_write.assert_not_called()
-            mock_flush.assert_not_called()
+@patch("src.app_runner.Colors.ENABLED", True)
+@patch("src.app_runner.Colors.BOLD", "[BOLD]")
+@patch("src.app_runner.Colors.RESET", "[RESET]")
+def test_styled_input_colors_enabled(mock_app_runner, mock_io):
+    mock_input, mock_print, mock_write, mock_flush = mock_io
+    mock_input.return_value = " test_input "
+    mock_flush.reset_mock()
+
+    result = mock_app_runner._styled_input("Prompt:")
+
+    assert result == "test_input"
+    mock_input.assert_called_once_with("Prompt:[BOLD]")
+    mock_print.assert_not_called()
+    mock_write.assert_called_once_with("[RESET]")
+    mock_flush.assert_called_once()
+
+
+@patch("src.app_runner.Colors.ENABLED", False)
+@patch("src.app_runner.Colors.BOLD", "[BOLD]")
+@patch("src.app_runner.Colors.RESET", "[RESET]")
+def test_styled_input_colors_disabled(mock_app_runner, mock_io):
+    mock_input, mock_print, mock_write, mock_flush = mock_io
+    mock_input.return_value = " test_input "
+    mock_flush.reset_mock()
+
+    result = mock_app_runner._styled_input("Prompt:")
+
+    assert result == "test_input"
+    mock_input.assert_called_once_with("Prompt:")
+    mock_print.assert_not_called()
+    mock_write.assert_not_called()
+    mock_flush.assert_not_called()
 
 
 @pytest.mark.parametrize("exception", [EOFError, KeyboardInterrupt])
 @patch("src.app_runner.Colors.ENABLED", True)
 @patch("src.app_runner.Colors.RESET", "[RESET]")
-def test_styled_input_interruptions(mock_app_runner, exception):
-    with patch("builtins.input", side_effect=exception), \
-         patch("builtins.print") as mock_print, \
-         patch("src.app_runner.sys.stdout.write") as mock_write, \
-         patch("src.app_runner.sys.stdout.flush") as mock_flush:
+def test_styled_input_interruptions(mock_app_runner, exception, mock_io):
+    mock_input, mock_print, mock_write, mock_flush = mock_io
+    mock_input.side_effect = exception
+    mock_flush.reset_mock()
 
-        with pytest.raises(KeyboardInterrupt):
-            mock_app_runner._styled_input("Prompt:")
+    with pytest.raises(KeyboardInterrupt):
+        mock_app_runner._styled_input("Prompt:")
 
-        mock_print.assert_called_once_with()
-        mock_write.assert_called_once_with("[RESET]")
-        mock_flush.assert_called_once()
+    mock_print.assert_called_once_with()
+    mock_write.assert_called_once_with("[RESET]")
+    mock_flush.assert_called_once()

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -251,38 +251,30 @@ def mock_io():
         yield mock_input, mock_print, mock_write, mock_flush
 
 
-@patch("src.app_runner.Colors.ENABLED", True)
+@pytest.mark.parametrize("colors_enabled,expected_prompt", [
+    (True, "Prompt:[BOLD]"),
+    (False, "Prompt:"),
+])
 @patch("src.app_runner.Colors.BOLD", "[BOLD]")
 @patch("src.app_runner.Colors.RESET", "[RESET]")
-def test_styled_input_colors_enabled(mock_app_runner, mock_io):
-    mock_input, mock_print, mock_write, mock_flush = mock_io
-    mock_input.return_value = " test_input "
-    mock_flush.reset_mock()
+def test_styled_input_colors(mock_app_runner, mock_io, colors_enabled, expected_prompt):
+    with patch("src.app_runner.Colors.ENABLED", colors_enabled):
+        mock_input, mock_print, mock_write, mock_flush = mock_io
+        mock_input.return_value = " test_input "
+        mock_flush.reset_mock()
 
-    result = mock_app_runner._styled_input("Prompt:")
+        result = mock_app_runner._styled_input("Prompt:")
 
-    assert result == "test_input"
-    mock_input.assert_called_once_with("Prompt:[BOLD]")
-    mock_print.assert_not_called()
-    mock_write.assert_called_once_with("[RESET]")
-    mock_flush.assert_called_once()
+        assert result == "test_input"
+        mock_input.assert_called_once_with(expected_prompt)
+        mock_print.assert_not_called()
 
-
-@patch("src.app_runner.Colors.ENABLED", False)
-@patch("src.app_runner.Colors.BOLD", "[BOLD]")
-@patch("src.app_runner.Colors.RESET", "[RESET]")
-def test_styled_input_colors_disabled(mock_app_runner, mock_io):
-    mock_input, mock_print, mock_write, mock_flush = mock_io
-    mock_input.return_value = " test_input "
-    mock_flush.reset_mock()
-
-    result = mock_app_runner._styled_input("Prompt:")
-
-    assert result == "test_input"
-    mock_input.assert_called_once_with("Prompt:")
-    mock_print.assert_not_called()
-    mock_write.assert_not_called()
-    mock_flush.assert_not_called()
+        if colors_enabled:
+            mock_write.assert_called_once_with("[RESET]")
+            mock_flush.assert_called_once()
+        else:
+            mock_write.assert_not_called()
+            mock_flush.assert_not_called()
 
 
 @pytest.mark.parametrize("exception", [EOFError, KeyboardInterrupt])

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -278,26 +278,11 @@ def test_styled_input_colors_disabled(mock_app_runner):
         mock_flush.assert_not_called()
 
 
+@pytest.mark.parametrize("exception", [EOFError, KeyboardInterrupt])
 @patch("src.app_runner.Colors.ENABLED", True)
 @patch("src.app_runner.Colors.RESET", "[RESET]")
-def test_styled_input_eof_error(mock_app_runner):
-    with patch("builtins.input", side_effect=EOFError), \
-         patch("builtins.print") as mock_print, \
-         patch("src.app_runner.sys.stdout.write") as mock_write, \
-         patch("src.app_runner.sys.stdout.flush") as mock_flush:
-
-        with pytest.raises(KeyboardInterrupt):
-            mock_app_runner._styled_input("Prompt:")
-
-        mock_print.assert_called_once_with()
-        mock_write.assert_called_once_with("[RESET]")
-        mock_flush.assert_called_once()
-
-
-@patch("src.app_runner.Colors.ENABLED", True)
-@patch("src.app_runner.Colors.RESET", "[RESET]")
-def test_styled_input_keyboard_interrupt(mock_app_runner):
-    with patch("builtins.input", side_effect=KeyboardInterrupt), \
+def test_styled_input_interruptions(mock_app_runner, exception):
+    with patch("builtins.input", side_effect=exception), \
          patch("builtins.print") as mock_print, \
          patch("src.app_runner.sys.stdout.write") as mock_write, \
          patch("src.app_runner.sys.stdout.flush") as mock_flush:

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -242,65 +242,69 @@ def test_set_secure_permissions_oserror(mock_app_runner):
         assert excinfo.value.code == 1
         mock_exit.assert_called_once_with(1)
 
-@patch("src.app_runner.sys.stdout.write")
-@patch("src.app_runner.sys.stdout.flush")
 @patch("src.app_runner.Colors.ENABLED", True)
 @patch("src.app_runner.Colors.BOLD", "[BOLD]")
 @patch("src.app_runner.Colors.RESET", "[RESET]")
-@patch("builtins.input", return_value=" test_input ")
-@patch("builtins.print")
-def test_styled_input_colors_enabled(mock_print, mock_input, mock_flush, mock_write, mock_app_runner):
-    result = mock_app_runner._styled_input("Prompt:")
+def test_styled_input_colors_enabled(mock_app_runner):
+    with patch("builtins.input", return_value=" test_input ") as mock_input, \
+         patch("builtins.print") as mock_print, \
+         patch("src.app_runner.sys.stdout.write") as mock_write, \
+         patch("src.app_runner.sys.stdout.flush") as mock_flush:
 
-    assert result == "test_input"
-    mock_input.assert_called_once_with("Prompt:[BOLD]")
-    mock_print.assert_not_called()
-    mock_write.assert_called_once_with("[RESET]")
-    mock_flush.assert_called_once()
+        result = mock_app_runner._styled_input("Prompt:")
+
+        assert result == "test_input"
+        mock_input.assert_called_once_with("Prompt:[BOLD]")
+        mock_print.assert_not_called()
+        mock_write.assert_called_once_with("[RESET]")
+        mock_flush.assert_called_once()
 
 
-@patch("src.app_runner.sys.stdout.write")
-@patch("src.app_runner.sys.stdout.flush")
 @patch("src.app_runner.Colors.ENABLED", False)
 @patch("src.app_runner.Colors.BOLD", "[BOLD]")
 @patch("src.app_runner.Colors.RESET", "[RESET]")
-@patch("builtins.input", return_value=" test_input ")
-@patch("builtins.print")
-def test_styled_input_colors_disabled(mock_print, mock_input, mock_flush, mock_write, mock_app_runner):
-    result = mock_app_runner._styled_input("Prompt:")
+def test_styled_input_colors_disabled(mock_app_runner):
+    with patch("builtins.input", return_value=" test_input ") as mock_input, \
+         patch("builtins.print") as mock_print, \
+         patch("src.app_runner.sys.stdout.write") as mock_write, \
+         patch("src.app_runner.sys.stdout.flush") as mock_flush:
 
-    assert result == "test_input"
-    mock_input.assert_called_once_with("Prompt:")
-    mock_print.assert_not_called()
-    mock_write.assert_not_called()
-    mock_flush.assert_not_called()
+        result = mock_app_runner._styled_input("Prompt:")
+
+        assert result == "test_input"
+        mock_input.assert_called_once_with("Prompt:")
+        mock_print.assert_not_called()
+        mock_write.assert_not_called()
+        mock_flush.assert_not_called()
 
 
-@patch("src.app_runner.sys.stdout.write")
-@patch("src.app_runner.sys.stdout.flush")
 @patch("src.app_runner.Colors.ENABLED", True)
 @patch("src.app_runner.Colors.RESET", "[RESET]")
-@patch("builtins.print")
-def test_styled_input_eof_error(mock_print, mock_flush, mock_write, mock_app_runner):
-    with patch("builtins.input", side_effect=EOFError):
+def test_styled_input_eof_error(mock_app_runner):
+    with patch("builtins.input", side_effect=EOFError), \
+         patch("builtins.print") as mock_print, \
+         patch("src.app_runner.sys.stdout.write") as mock_write, \
+         patch("src.app_runner.sys.stdout.flush") as mock_flush:
+
         with pytest.raises(KeyboardInterrupt):
             mock_app_runner._styled_input("Prompt:")
 
-    mock_print.assert_called_once_with()
-    mock_write.assert_called_once_with("[RESET]")
-    mock_flush.assert_called_once()
+        mock_print.assert_called_once_with()
+        mock_write.assert_called_once_with("[RESET]")
+        mock_flush.assert_called_once()
 
 
-@patch("src.app_runner.sys.stdout.write")
-@patch("src.app_runner.sys.stdout.flush")
 @patch("src.app_runner.Colors.ENABLED", True)
 @patch("src.app_runner.Colors.RESET", "[RESET]")
-@patch("builtins.print")
-def test_styled_input_keyboard_interrupt(mock_print, mock_flush, mock_write, mock_app_runner):
-    with patch("builtins.input", side_effect=KeyboardInterrupt):
+def test_styled_input_keyboard_interrupt(mock_app_runner):
+    with patch("builtins.input", side_effect=KeyboardInterrupt), \
+         patch("builtins.print") as mock_print, \
+         patch("src.app_runner.sys.stdout.write") as mock_write, \
+         patch("src.app_runner.sys.stdout.flush") as mock_flush:
+
         with pytest.raises(KeyboardInterrupt):
             mock_app_runner._styled_input("Prompt:")
 
-    mock_print.assert_called_once_with()
-    mock_write.assert_called_once_with("[RESET]")
-    mock_flush.assert_called_once()
+        mock_print.assert_called_once_with()
+        mock_write.assert_called_once_with("[RESET]")
+        mock_flush.assert_called_once()

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -242,11 +242,12 @@ def test_set_secure_permissions_oserror(mock_app_runner):
         assert excinfo.value.code == 1
         mock_exit.assert_called_once_with(1)
 
-@patch("src.app_runner.Colors.ENABLED", True)
+@pytest.mark.parametrize("colors_enabled", [True, False])
 @patch("src.app_runner.Colors.BOLD", "[BOLD]")
 @patch("src.app_runner.Colors.RESET", "[RESET]")
-def test_styled_input_colors_enabled(mock_app_runner):
-    with patch("builtins.input", return_value=" test_input ") as mock_input, \
+def test_styled_input_colors(mock_app_runner, colors_enabled):
+    with patch("src.app_runner.Colors.ENABLED", colors_enabled), \
+         patch("builtins.input", return_value=" test_input ") as mock_input, \
          patch("builtins.print") as mock_print, \
          patch("src.app_runner.sys.stdout.write") as mock_write, \
          patch("src.app_runner.sys.stdout.flush") as mock_flush:
@@ -254,28 +255,14 @@ def test_styled_input_colors_enabled(mock_app_runner):
         result = mock_app_runner._styled_input("Prompt:")
 
         assert result == "test_input"
-        mock_input.assert_called_once_with("Prompt:[BOLD]")
+        mock_input.assert_called_once_with("Prompt:[BOLD]" if colors_enabled else "Prompt:")
         mock_print.assert_not_called()
-        mock_write.assert_called_once_with("[RESET]")
-        mock_flush.assert_called_once()
-
-
-@patch("src.app_runner.Colors.ENABLED", False)
-@patch("src.app_runner.Colors.BOLD", "[BOLD]")
-@patch("src.app_runner.Colors.RESET", "[RESET]")
-def test_styled_input_colors_disabled(mock_app_runner):
-    with patch("builtins.input", return_value=" test_input ") as mock_input, \
-         patch("builtins.print") as mock_print, \
-         patch("src.app_runner.sys.stdout.write") as mock_write, \
-         patch("src.app_runner.sys.stdout.flush") as mock_flush:
-
-        result = mock_app_runner._styled_input("Prompt:")
-
-        assert result == "test_input"
-        mock_input.assert_called_once_with("Prompt:")
-        mock_print.assert_not_called()
-        mock_write.assert_not_called()
-        mock_flush.assert_not_called()
+        if colors_enabled:
+            mock_write.assert_called_once_with("[RESET]")
+            mock_flush.assert_called_once()
+        else:
+            mock_write.assert_not_called()
+            mock_flush.assert_not_called()
 
 
 @pytest.mark.parametrize("exception", [EOFError, KeyboardInterrupt])

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -242,53 +242,65 @@ def test_set_secure_permissions_oserror(mock_app_runner):
         assert excinfo.value.code == 1
         mock_exit.assert_called_once_with(1)
 
+@patch("src.app_runner.sys.stdout.write")
+@patch("src.app_runner.sys.stdout.flush")
 @patch("src.app_runner.Colors.ENABLED", True)
 @patch("src.app_runner.Colors.BOLD", "[BOLD]")
 @patch("src.app_runner.Colors.RESET", "[RESET]")
 @patch("builtins.input", return_value=" test_input ")
 @patch("builtins.print")
-def test_styled_input_colors_enabled(mock_print, mock_input, mock_app_runner):
+def test_styled_input_colors_enabled(mock_print, mock_input, mock_flush, mock_write, mock_app_runner):
     result = mock_app_runner._styled_input("Prompt:")
 
     assert result == "test_input"
     mock_input.assert_called_once_with("Prompt:[BOLD]")
-    mock_print.assert_called_once_with("[RESET]", end="", flush=True)
+    mock_print.assert_not_called()
+    mock_write.assert_called_once_with("[RESET]")
+    mock_flush.assert_called_once()
 
 
+@patch("src.app_runner.sys.stdout.write")
+@patch("src.app_runner.sys.stdout.flush")
 @patch("src.app_runner.Colors.ENABLED", False)
 @patch("src.app_runner.Colors.BOLD", "[BOLD]")
 @patch("src.app_runner.Colors.RESET", "[RESET]")
 @patch("builtins.input", return_value=" test_input ")
 @patch("builtins.print")
-def test_styled_input_colors_disabled(mock_print, mock_input, mock_app_runner):
+def test_styled_input_colors_disabled(mock_print, mock_input, mock_flush, mock_write, mock_app_runner):
     result = mock_app_runner._styled_input("Prompt:")
 
     assert result == "test_input"
     mock_input.assert_called_once_with("Prompt:")
     mock_print.assert_not_called()
+    mock_write.assert_not_called()
+    mock_flush.assert_not_called()
 
 
+@patch("src.app_runner.sys.stdout.write")
+@patch("src.app_runner.sys.stdout.flush")
 @patch("src.app_runner.Colors.ENABLED", True)
 @patch("src.app_runner.Colors.RESET", "[RESET]")
 @patch("builtins.print")
-def test_styled_input_eof_error(mock_print, mock_app_runner):
+def test_styled_input_eof_error(mock_print, mock_flush, mock_write, mock_app_runner):
     with patch("builtins.input", side_effect=EOFError):
         with pytest.raises(KeyboardInterrupt):
             mock_app_runner._styled_input("Prompt:")
 
-    assert mock_print.call_count == 2
-    mock_print.assert_any_call()
-    mock_print.assert_any_call("[RESET]", end="", flush=True)
+    mock_print.assert_called_once_with()
+    mock_write.assert_called_once_with("[RESET]")
+    mock_flush.assert_called_once()
 
 
+@patch("src.app_runner.sys.stdout.write")
+@patch("src.app_runner.sys.stdout.flush")
 @patch("src.app_runner.Colors.ENABLED", True)
 @patch("src.app_runner.Colors.RESET", "[RESET]")
 @patch("builtins.print")
-def test_styled_input_keyboard_interrupt(mock_print, mock_app_runner):
+def test_styled_input_keyboard_interrupt(mock_print, mock_flush, mock_write, mock_app_runner):
     with patch("builtins.input", side_effect=KeyboardInterrupt):
         with pytest.raises(KeyboardInterrupt):
             mock_app_runner._styled_input("Prompt:")
 
-    assert mock_print.call_count == 2
-    mock_print.assert_any_call()
-    mock_print.assert_any_call("[RESET]", end="", flush=True)
+    mock_print.assert_called_once_with()
+    mock_write.assert_called_once_with("[RESET]")
+    mock_flush.assert_called_once()


### PR DESCRIPTION
💡 **What:** 
- Replaced `print(Colors.RESET, end="")` with `sys.stdout.write(Colors.RESET)` and `sys.stdout.flush()` inside interactive input handling (`_styled_input` and `_get_input`).
- Replaced an unstyled text hint with a colorized usage hint (`Colors.CYAN`) in the `print_help` CLI output.

🎯 **Why:** 
- To prevent terminal formatting (like bolding) from leaking out of interactive prompts and permanently modifying the user's shell state when `print` buffering fails or is interrupted in constrained environments. 
- Using standard `print` without flushing can sometimes leave formatting intact. 
- Colorizing usage commands makes them immediately actionable and visually distinct from surrounding instructional text, improving scannability.

♿ **Accessibility:**
- Ensures screen readers and terminal emulators receive immediate, unbuffered escape codes, preventing them from improperly applying styling to subsequent unstructured CLI output.

---
*PR created automatically by Jules for task [2246955037232095896](https://jules.google.com/task/2246955037232095896) started by @abhimehro*