### PR TITLE
🎨 Palette: Make terminal color resets robust

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -188,3 +188,6 @@
 ## 2025-02-12 - De-emphasize Secondary Interaction Hints
 **Learning:** Secondary hints like "(Press Ctrl+C to stop)" command too much visual attention when styled with the primary foreground color, competing with the actual status message (e.g. "Waiting" or "Checking for emails").
 **Action:** Always de-emphasize secondary keyboard shortcuts and terminal hints using a muted color (like `Colors.GREY`) to maintain focus on the primary action and reduce visual clutter.
+## 2025-06-14 - Reliable Terminal Color Resets
+**Learning:** Using `print(Colors.RESET, end="")` in Python can buffer output in constrained terminal environments, causing subsequent text to inherit unintended styling (e.g., leaked bold/colors) when the program is interrupted or exits.
+**Action:** When handling interactive inputs and terminal styling, explicitly use `sys.stdout.write(Colors.RESET)` followed immediately by `sys.stdout.flush()` to ensure reliable, immediate color resets, rather than relying on `print` buffering behavior.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -27,7 +27,9 @@ class AppRunner:
             raise
         finally:
             if Colors.ENABLED:
-                print(Colors.RESET, end="", flush=True)
+                import sys
+                sys.stdout.write(Colors.RESET)
+                sys.stdout.flush()
 
         return val
 

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -64,7 +64,9 @@ def _styled_input(prompt: str) -> str:
         raise
     finally:
         if Colors.ENABLED:
-            print(Colors.RESET, end="", flush=True)
+            import sys
+            sys.stdout.write(Colors.RESET)
+            sys.stdout.flush()
 
     return val
 
@@ -262,7 +264,9 @@ def _prompt_for_password(provider_name: str) -> str:
             raise
         finally:
             if Colors.ENABLED:
-                print(Colors.RESET, end="")
+                import sys
+                sys.stdout.write(Colors.RESET)
+                sys.stdout.flush()
 
     app_secret = _get_input()
     while not app_secret:

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -246,49 +246,57 @@ def test_set_secure_permissions_oserror(mock_app_runner):
 @patch("src.app_runner.Colors.BOLD", "[BOLD]")
 @patch("src.app_runner.Colors.RESET", "[RESET]")
 @patch("builtins.input", return_value=" test_input ")
-@patch("builtins.print")
-def test_styled_input_colors_enabled(mock_print, mock_input, mock_app_runner):
+@patch("sys.stdout.write")
+@patch("sys.stdout.flush")
+def test_styled_input_colors_enabled(mock_flush, mock_write, mock_input, mock_app_runner):
     result = mock_app_runner._styled_input("Prompt:")
 
     assert result == "test_input"
     mock_input.assert_called_once_with("Prompt:[BOLD]")
-    mock_print.assert_called_once_with("[RESET]", end="", flush=True)
+    mock_write.assert_called_once_with("[RESET]")
+    mock_flush.assert_called_once()
 
 
 @patch("src.app_runner.Colors.ENABLED", False)
 @patch("src.app_runner.Colors.BOLD", "[BOLD]")
 @patch("src.app_runner.Colors.RESET", "[RESET]")
 @patch("builtins.input", return_value=" test_input ")
-@patch("builtins.print")
-def test_styled_input_colors_disabled(mock_print, mock_input, mock_app_runner):
+@patch("sys.stdout.write")
+@patch("sys.stdout.flush")
+def test_styled_input_colors_disabled(mock_flush, mock_write, mock_input, mock_app_runner):
     result = mock_app_runner._styled_input("Prompt:")
 
     assert result == "test_input"
     mock_input.assert_called_once_with("Prompt:")
-    mock_print.assert_not_called()
+    mock_write.assert_not_called()
+    mock_flush.assert_not_called()
 
 
 @patch("src.app_runner.Colors.ENABLED", True)
 @patch("src.app_runner.Colors.RESET", "[RESET]")
+@patch("sys.stdout.write")
+@patch("sys.stdout.flush")
 @patch("builtins.print")
-def test_styled_input_eof_error(mock_print, mock_app_runner):
+def test_styled_input_eof_error(mock_print, mock_flush, mock_write, mock_app_runner):
     with patch("builtins.input", side_effect=EOFError):
         with pytest.raises(KeyboardInterrupt):
             mock_app_runner._styled_input("Prompt:")
 
-    assert mock_print.call_count == 2
-    mock_print.assert_any_call()
-    mock_print.assert_any_call("[RESET]", end="", flush=True)
+    mock_print.assert_called_once_with()
+    mock_write.assert_called_once_with("[RESET]")
+    mock_flush.assert_called_once()
 
 
 @patch("src.app_runner.Colors.ENABLED", True)
 @patch("src.app_runner.Colors.RESET", "[RESET]")
+@patch("sys.stdout.write")
+@patch("sys.stdout.flush")
 @patch("builtins.print")
-def test_styled_input_keyboard_interrupt(mock_print, mock_app_runner):
+def test_styled_input_keyboard_interrupt(mock_print, mock_flush, mock_write, mock_app_runner):
     with patch("builtins.input", side_effect=KeyboardInterrupt):
         with pytest.raises(KeyboardInterrupt):
             mock_app_runner._styled_input("Prompt:")
 
-    assert mock_print.call_count == 2
-    mock_print.assert_any_call()
-    mock_print.assert_any_call("[RESET]", end="", flush=True)
+    mock_print.assert_called_once_with()
+    mock_write.assert_called_once_with("[RESET]")
+    mock_flush.assert_called_once()


### PR DESCRIPTION
💡 What: Changed the terminal color reset mechanism from `print(Colors.RESET, end='')` to `sys.stdout.write(Colors.RESET)` followed immediately by `sys.stdout.flush()`.
🎯 Why: In constrained terminal environments or CI, relying on `print` buffering can occasionally cause the output color/style (like bold) to bleed into subsequent terminal output when the process is interrupted or finishes. Using explicit writes and flushes ensures a reliable, immediate reset.
📸 Before/After: N/A
♿ Accessibility: Ensures that terminal prompts and subsequent screen reader outputs do not inherit stray ANSI styles that could mess up terminal formatting.

---
*PR created automatically by Jules for task [15332347098722367904](https://jules.google.com/task/15332347098722367904) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->