### PR TITLE
🎨 Palette: De-emphasize input options in terminal prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -191,3 +191,7 @@
 ## 2025-06-14 - Reliable Terminal Color Resets
 **Learning:** Using `print(Colors.RESET, end="")` in Python can buffer output in constrained terminal environments, causing subsequent text to inherit unintended styling (e.g., leaked bold/colors) when the program is interrupted or exits.
 **Action:** When handling interactive inputs and terminal styling, explicitly use `sys.stdout.write(Colors.RESET)` followed immediately by `sys.stdout.flush()` to ensure reliable, immediate color resets, rather than relying on `print` buffering behavior.
+
+## 2025-06-15 - De-emphasize CLI Terminal Hints
+**Learning:** Terminal inputs with explicit options like [Y/n] or [1-4] often compete for visual attention when styled identically to the main question prompt (e.g. bold).
+**Action:** Always wrap trailing hint options in a muted color (like `Colors.GREY`) to clearly separate the primary question from the available inputs and reduce visual clutter.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -204,7 +204,7 @@ class AppRunner:
             # Fallback to copy only if wizard wasn't run or failed
             if not Path(self.config_file).exists():
                 prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(
-                    f"Create '{self.config_file}' from template without wizard? [Y/n] ",
+                    f"Create '{self.config_file}' from template without wizard? {Colors.colorize('[Y/n]', Colors.GREY)} ",
                     Colors.BOLD,
                 )
                 response = self._styled_input(prompt).lower()
@@ -323,7 +323,7 @@ class AppRunner:
         )
 
         prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(
-            "Run setup wizard? [Y/n] ", Colors.BOLD
+            f"Run setup wizard? {Colors.colorize('[Y/n]', Colors.GREY)} ", Colors.BOLD
         )
         response = self._styled_input(prompt).lower()
         if response in ("", "y", "yes"):
@@ -335,7 +335,7 @@ class AppRunner:
     def _prompt_create_from_template(self) -> None:
         """Prompt the user to create a configuration file from the template."""
         prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(
-            f"Create '{self.config_file}' from template without wizard? [Y/n] ",
+            f"Create '{self.config_file}' from template without wizard? {Colors.colorize('[Y/n]', Colors.GREY)} ",
             Colors.BOLD,
         )
         response = self._styled_input(prompt).lower()

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -174,7 +174,7 @@ def _select_provider() -> str:
             prompt = (
                 "\n"
                 + Colors.colorize("? ", Colors.CYAN)
-                + Colors.colorize("Select provider [1-4]: ", Colors.BOLD)
+                + Colors.colorize(f"Select provider {Colors.colorize('[1-4]', Colors.GREY)}: ", Colors.BOLD)
             )
             choice = _styled_input(prompt)
             if choice in ("1", "2", "3", "4"):
@@ -312,7 +312,7 @@ def _get_credentials(choice: str, provider_name: str) -> tuple[str, str]:
             )
 
             prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(
-                "Retry? [Y/n] ", Colors.BOLD
+                f"Retry? {Colors.colorize('[Y/n]', Colors.GREY)} ", Colors.BOLD
             )
             retry = _styled_input(prompt).lower()
             if retry not in ("", "y", "yes"):


### PR DESCRIPTION
🎨 Palette: De-emphasize input options in terminal prompts

💡 **What:** Replaced the `Colors.BOLD` styling with `Colors.GREY` for explicit input options like `[Y/n]` and `[1-4]` in terminal prompts.
🎯 **Why:** To visually separate the available options from the primary question, reducing visual clutter and making the prompt easier to parse quickly.
♿ **Accessibility:** Reduces visual noise for sighted users navigating the CLI.

---
*PR created automatically by Jules for task [6145481756779616909](https://jules.google.com/task/6145481756779616909) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->