### PR TITLE
🎨 Palette: Prevent ANSI style leakage in interactive terminal prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -195,3 +195,7 @@
 ## 2025-06-15 - De-emphasize CLI Terminal Hints
 **Learning:** Terminal inputs with explicit options like [Y/n] or [1-4] often compete for visual attention when styled identically to the main question prompt (e.g. bold).
 **Action:** Always wrap trailing hint options in a muted color (like `Colors.GREY`) to clearly separate the primary question from the available inputs and reduce visual clutter.
+
+## 2025-06-17 - Prevent ANSI Style Reset Leakage in Nested Colorization
+**Learning:** When using Python string interpolation to nest ANSI color codes (e.g., `f"{bold_color}Question {grey_color}[Y/n]{reset} ?"`) within an outer wrapper, the inner string's `RESET` code will prematurely clear all styles applied by the outer wrapper, causing any subsequent prompt text or user input to lose its intended styling.
+**Action:** When building colored terminal prompts with inline hints, always concatenate consecutive styled segments (e.g., `colorize(Q, BOLD) + colorize(hint, GREY) + colorize("?", BOLD)`) instead of nesting them within an outer f-string to ensure styles remain isolated and user input starts with the correct styling.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -203,10 +203,7 @@ class AppRunner:
 
             # Fallback to copy only if wizard wasn't run or failed
             if not Path(self.config_file).exists():
-                prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(
-                    f"Create '{self.config_file}' from template without wizard? {Colors.colorize('[Y/n]', Colors.GREY)} ",
-                    Colors.BOLD,
-                )
+                prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(f"Create '{self.config_file}' from template without wizard? ", Colors.BOLD) + Colors.colorize("[Y/n]", Colors.GREY) + Colors.colorize(" ", Colors.BOLD)
                 response = self._styled_input(prompt).lower()
                 if response in ("", "y", "yes"):
                     try:
@@ -322,9 +319,7 @@ class AppRunner:
             )
         )
 
-        prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(
-            f"Run setup wizard? {Colors.colorize('[Y/n]', Colors.GREY)} ", Colors.BOLD
-        )
+        prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize("Run setup wizard? ", Colors.BOLD) + Colors.colorize("[Y/n]", Colors.GREY) + Colors.colorize(" ", Colors.BOLD)
         response = self._styled_input(prompt).lower()
         if response in ("", "y", "yes"):
             if run_setup_wizard(self.config_file):
@@ -334,10 +329,7 @@ class AppRunner:
 
     def _prompt_create_from_template(self) -> None:
         """Prompt the user to create a configuration file from the template."""
-        prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(
-            f"Create '{self.config_file}' from template without wizard? {Colors.colorize('[Y/n]', Colors.GREY)} ",
-            Colors.BOLD,
-        )
+        prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(f"Create '{self.config_file}' from template without wizard? ", Colors.BOLD) + Colors.colorize("[Y/n]", Colors.GREY) + Colors.colorize(" ", Colors.BOLD)
         response = self._styled_input(prompt).lower()
         if response in ("", "y", "yes"):
             try:

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -174,7 +174,7 @@ def _select_provider() -> str:
             prompt = (
                 "\n"
                 + Colors.colorize("? ", Colors.CYAN)
-                + Colors.colorize(f"Select provider {Colors.colorize('[1-4]', Colors.GREY)}: ", Colors.BOLD)
+                + Colors.colorize("Select provider ", Colors.BOLD) + Colors.colorize("[1-4]", Colors.GREY) + Colors.colorize(": ", Colors.BOLD)
             )
             choice = _styled_input(prompt)
             if choice in ("1", "2", "3", "4"):
@@ -311,9 +311,7 @@ def _get_credentials(choice: str, provider_name: str) -> tuple[str, str]:
                 f"  {Colors.colorize('n:', Colors.BOLD)} Proceed anyway {Colors.colorize('(Skip verification)', Colors.YELLOW)}"
             )
 
-            prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(
-                f"Retry? {Colors.colorize('[Y/n]', Colors.GREY)} ", Colors.BOLD
-            )
+            prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize("Retry? ", Colors.BOLD) + Colors.colorize("[Y/n]", Colors.GREY) + Colors.colorize(" ", Colors.BOLD)
             retry = _styled_input(prompt).lower()
             if retry not in ("", "y", "yes"):
                 print(


### PR DESCRIPTION
🎨 Palette: Prevent ANSI style leakage in interactive terminal prompts

When `Colors.colorize` is nested within another `Colors.colorize` call using f-strings, the inner string's ANSI RESET code prematurely clears the styling applied by the outer wrapper. This caused user input following certain prompts (like the `[Y/n]` or `[1-4]` dialogs) to lose their intended BOLD styling. 

This commit refactors these prompts in `app_runner.py` and `setup_wizard.py` to use explicit string concatenation of styled segments rather than nesting, ensuring robust styling is maintained.

Included a journal entry in `.jules/palette.md` detailing this learning.

---
*PR created automatically by Jules for task [6881741036027877775](https://jules.google.com/task/6881741036027877775) started by @abhimehro*