### PR TITLE
🎨 Palette: Distinguish actionable commands in CLI UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -199,3 +199,7 @@
 ## 2025-06-17 - Prevent ANSI Style Reset Leakage in Nested Colorization
 **Learning:** When using Python string interpolation to nest ANSI color codes (e.g., `f"{bold_color}Question {grey_color}[Y/n]{reset} ?"`) within an outer wrapper, the inner string's `RESET` code will prematurely clear all styles applied by the outer wrapper, causing any subsequent prompt text or user input to lose its intended styling.
 **Action:** When building colored terminal prompts with inline hints, always concatenate consecutive styled segments (e.g., `colorize(Q, BOLD) + colorize(hint, GREY) + colorize("?", BOLD)`) instead of nesting them within an outer f-string to ensure styles remain isolated and user input starts with the correct styling.
+
+## 2027-02-18 - Visually Distinguish Actionable CLI Commands
+**Learning:** When providing next steps or remediation instructions in the CLI, unstyled commands blend into the surrounding text, forcing users to parse where the instruction ends and the command begins.
+**Action:** Always visually distinguish actionable CLI commands (e.g., `python src/main.py`) using a distinct color like `Colors.CYAN` to separate them from standard instructional text. This reduces cognitive load and allows users to instantly identify what they need to execute.

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -523,8 +523,8 @@ def run_setup_wizard(
             return False
 
         print("\n" + Colors.colorize("Next Steps:", Colors.BOLD))
-        print("1. Review .env to ensure settings are correct.")
-        print("2. Run the pipeline!")
+        print(f"1. Review {Colors.colorize(config_file, Colors.BOLD)} to ensure settings are correct.")
+        print(f"2. Run the pipeline: {Colors.colorize('python src/main.py', Colors.CYAN)}")
 
         return True
 


### PR DESCRIPTION
🎨 Palette: Distinguish remediation commands in CLI UX

**What:** The UX enhancement added is visually distinguishing actionable CLI commands in terminal output. Specifically, the "Next Steps" screen at the end of the `setup_wizard.py` execution now provides the exact `python src/main.py` command highlighted in Cyan, instead of just an unstyled "Run the pipeline!" text. The `.env` file name is also now bolded.
**Why:** The user problem it solves is that unstyled commands blend into the surrounding instructional text, forcing users to parse where the instruction ends and the command begins. This reduces cognitive load.
**Accessibility:** Improved visual hierarchy and readability using semantic formatting. Added learning to `.jules/palette.md`.

---
*PR created automatically by Jules for task [7462803287956825573](https://jules.google.com/task/7462803287956825573) started by @abhimehro*