### PR TITLE
🎨 Palette: Style CLI help and error fallback paths

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -203,3 +203,7 @@
 ## 2027-02-18 - Visually Distinguish Actionable CLI Commands
 **Learning:** When providing next steps or remediation instructions in the CLI, unstyled commands blend into the surrounding text, forcing users to parse where the instruction ends and the command begins.
 **Action:** Always visually distinguish actionable CLI commands (e.g., `python src/main.py`) using a distinct color like `Colors.CYAN` to separate them from standard instructional text. This reduces cognitive load and allows users to instantly identify what they need to execute.
+
+## 2027-02-18 - Styling consistency in error paths
+**Learning:** Error paths and fallback instructions (like template creation failures) are often overlooked during UI polish passes, leading to unstyled output that breaks the overall visual consistency of the CLI.
+**Action:** When auditing CLI applications for UX, explicitly check error handling paths (`except` blocks) and fallback states (`else` branches of interactive prompts) to ensure that error messages are styled with `Colors.RED` and instructions are styled with `Colors.YELLOW`, maintaining visual hierarchy even during failures.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -157,7 +157,7 @@ class AppRunner:
     def print_help(self) -> None:
         """Print usage instructions for the CLI."""
         print(Colors.colorize("Usage:", Colors.BOLD))
-        print("  python src/main.py [CONFIG_FILE]\n")
+        print(f"  {Colors.colorize('python src/main.py [CONFIG_FILE]', Colors.CYAN)}\n")
         print(Colors.colorize("Arguments:", Colors.BOLD))
         print(
             "  CONFIG_FILE    Path to the environment configuration file (default: .env)\n"
@@ -231,10 +231,10 @@ class AppRunner:
                         )
                         sys.exit(0)
                     except Exception as e:
-                        print(f"Error creating file: {e}")
+                        print(Colors.colorize(f"Error creating file: {e}", Colors.RED))
                         sys.exit(1)
                 else:
-                    print("Please create a .env file based on .env.example")
+                    print(Colors.colorize("Please create a .env file based on .env.example", Colors.YELLOW))
                     sys.exit(1)
         except KeyboardInterrupt:
             warning = Colors.colorize("⚠", Colors.YELLOW)
@@ -336,10 +336,10 @@ class AppRunner:
                 self._create_config_from_template()
                 sys.exit(0)
             except Exception as e:
-                print(f"Error creating file: {e}")
+                print(Colors.colorize(f"Error creating file: {e}", Colors.RED))
                 sys.exit(1)
         else:
-            print("Please create a .env file based on .env.example")
+            print(Colors.colorize("Please create a .env file based on .env.example", Colors.YELLOW))
             sys.exit(1)
 
     def _create_config_from_template(self) -> None:


### PR DESCRIPTION
**UX Enhancements:**

1.  **Visual Distinction in Help Text:** The actionable execution command `python src/main.py [CONFIG_FILE]` inside `app_runner.py`'s `print_help()` is now styled with `Colors.CYAN`. This separates the command from the descriptive text, making it much easier for the user to scan and copy.
2.  **Semantic Fallback and Error Paths:** During interactive setup, if a user decides *not* to run the wizard or create the config file from the template, the system falls back to manual instructions. These paths (both the `except Exception as e` failure block and the `else` rejection branch) now properly utilize `Colors.RED` and `Colors.YELLOW` respectively. Previously, they were outputting unstyled text, breaking the application's overall color semantics.
3.  **Documentation:** Added an entry to `.jules/palette.md` noting the importance of auditing `except` and `else` blocks in CLI tools for styling consistency.

---
*PR created automatically by Jules for task [5068412269411085496](https://jules.google.com/task/5068412269411085496) started by @abhimehro*