### PR TITLE
🎨 Palette: Add styling to configuration template creation output

### DIFF
--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -225,9 +225,9 @@ class AppRunner:
                         with os.fdopen(fd, "wb") as dst:
                             dst.write(content)
 
-                        print(f"Created '{self.config_file}' from '.env.example'.")
+                        print(Colors.colorize(f"✔ Created '{self.config_file}' from '.env.example'.", Colors.GREEN))
                         print(
-                            "IMPORTANT: Please edit .env with your actual credentials before proceeding."
+                            Colors.colorize("IMPORTANT: Please edit .env with your actual credentials before proceeding.", Colors.YELLOW)
                         )
                         sys.exit(0)
                     except Exception as e:
@@ -365,9 +365,9 @@ class AppRunner:
             with os.fdopen(fd, "wb") as dst:
                 dst.write(content)
 
-            print(f"Created '{self.config_file}' from '.env.example'.")
+            print(Colors.colorize(f"✔ Created '{self.config_file}' from '.env.example'.", Colors.GREEN))
             print(
-                "IMPORTANT: Please edit .env with your actual credentials before proceeding."
+                Colors.colorize("IMPORTANT: Please edit .env with your actual credentials before proceeding.", Colors.YELLOW)
             )
         except Exception:
             os.close(fd)


### PR DESCRIPTION
This PR introduces a small UX improvement by styling the terminal output during fallback configuration creation. 

**💡 What:** The text informing the user that the configuration file was created from `.env.example` and the subsequent warning to edit it with actual credentials are now properly colored using the `Colors.colorize` utility (Green for success, Yellow for warning). 
**🎯 Why:** Error paths and fallback states are often overlooked in CLI styling. By adding color here, we maintain visual hierarchy and guide the user's attention to critical next steps.
**📸 Before/After:**
Before: Unstyled text blended into terminal output.
After: Success message has a `✔` and is green. Important instruction is yellow.

---
*PR created automatically by Jules for task [2814542469131541118](https://jules.google.com/task/2814542469131541118) started by @abhimehro*