### PR TITLE
🎨 Palette: Apply consistent color styling to spinner error and cancellation messages

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -207,3 +207,6 @@
 ## 2027-02-18 - Styling consistency in error paths
 **Learning:** Error paths and fallback instructions (like template creation failures) are often overlooked during UI polish passes, leading to unstyled output that breaks the overall visual consistency of the CLI.
 **Action:** When auditing CLI applications for UX, explicitly check error handling paths (`except` blocks) and fallback states (`else` branches of interactive prompts) to ensure that error messages are styled with `Colors.RED` and instructions are styled with `Colors.YELLOW`, maintaining visual hierarchy even during failures.
+## 2025-06-25 - Consistency in Terminal Error Styling
+**Learning:** For CLI status indicators (like loading spinners), applying semantic color (like Red) only to the status symbol (✘) while leaving the final message unstyled breaks the visual hierarchy during error paths.
+**Action:** Apply consistent semantic coloring to the entire final status message (e.g., Red for errors, Green for success, Yellow for warnings) to ensure plain-text default styling does not undermine the error state visualization.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -249,7 +249,10 @@ class Spinner:
             color = self._get_color_for_symbol(symbol)
             colored_symbol = Colors.colorize(symbol, color)
 
-            sys.stdout.write(f"\r\033[K{colored_symbol} {msg}{time_str}\n")
+            # Apply the same semantic color to the message for visual consistency
+            colored_msg = Colors.colorize(msg, color)
+
+            sys.stdout.write(f"\r\033[K{colored_symbol} {colored_msg}{time_str}\n")
             sys.stdout.flush()
             sys.stdout.write(CURSOR_SHOW)
             sys.stdout.flush()


### PR DESCRIPTION
### 💡 What:
Updated the terminal `Spinner` utility to apply consistent semantic styling to its completion messages. Now, when a spinner resolves in a failure or cancellation, the entire output message (not just the symbol) inherits the appropriate color (e.g., Red for errors, Yellow for cancellation).

### 🎯 Why:
To improve the UX and visual hierarchy of the CLI. Previously, error messages were rendered in plain default terminal text with only the leading symbol colored red, making the error output blend into surrounding informational logs.

### ♿ Accessibility:
Maintains clear visual mapping of states (Success, Warning, Error) by extending the existing colorization logic to the entire final message.

### Maintenance Notes:
Logged this critical learning to `.jules/palette.md` to ensure future UI components color the entire visual grouping consistently.

---
*PR created automatically by Jules for task [13039679337393717358](https://jules.google.com/task/13039679337393717358) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->