### PR TITLE
🎨 Palette: Separate error messages and instructions visually in setup wizard

### DIFF
--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -180,9 +180,8 @@ def _select_provider() -> str:
             if choice in ("1", "2", "3", "4"):
                 return choice
             print(
-                Colors.colorize(
-                    "Invalid choice. Please enter 1, 2, 3, or 4.", Colors.YELLOW
-                )
+                Colors.colorize("✘ Invalid choice. ", Colors.RED)
+                + Colors.colorize("Please enter 1, 2, 3, or 4.", Colors.YELLOW)
             )
         except EOFError:
             return "4"
@@ -199,15 +198,16 @@ def _prompt_for_email(provider_name: str) -> str:
         )
         email = _styled_input(prompt)
         if not email:
-            print(Colors.colorize("Email is required.", Colors.YELLOW))
+            print(Colors.colorize("✘ Email is required.", Colors.RED))
             continue
 
         if _is_valid_email(email):
             return email
 
         print(
-            Colors.colorize(
-                "Invalid email format. Please enter a valid email address (e.g., user@example.com).",
+            Colors.colorize("✘ Invalid email format. ", Colors.RED)
+            + Colors.colorize(
+                "Please enter a valid email address (e.g., user@example.com).",
                 Colors.YELLOW,
             )
         )
@@ -270,7 +270,7 @@ def _prompt_for_password(provider_name: str) -> str:
 
     app_secret = _get_input()
     while not app_secret:
-        print(Colors.colorize("Password is required.", Colors.YELLOW))
+        print(Colors.colorize("✘ Password is required.", Colors.RED))
         app_secret = _get_input()
 
     return app_secret


### PR DESCRIPTION
💡 **What:** Separated the validation feedback strings in `src/utils/setup_wizard.py` so that the error condition itself (e.g., `✘ Invalid choice.`) is styled in RED, while the actionable remediation advice (e.g., `Please enter 1, 2, 3, or 4.`) remains in YELLOW.
🎯 **Why:** Previously, both the error and the instruction were grouped together and styled with a single color (YELLOW). This blurred the visual hierarchy and diminished the impact of the error state. By separating them, we provide a clearer, more distinct failure indication.
📸 **Before:** Unstyled (yellow) combined text.
📸 **After:** Red `✘ [Error]` followed by Yellow `[Instruction]`.
♿ **Accessibility:** Enhances visual scannability and cognitive accessibility by clearly distinguishing what went wrong from what to do next.

---
*PR created automatically by Jules for task [11768133418739820646](https://jules.google.com/task/11768133418739820646) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->