### PR TITLE
🎨 Palette: Standardize actionable error paths and styling

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -210,3 +210,7 @@
 ## 2025-06-25 - Consistency in Terminal Error Styling
 **Learning:** For CLI status indicators (like loading spinners), applying semantic color (like Red) only to the status symbol (✘) while leaving the final message unstyled breaks the visual hierarchy during error paths.
 **Action:** Apply consistent semantic coloring to the entire final status message (e.g., Red for errors, Green for success, Yellow for warnings) to ensure plain-text default styling does not undermine the error state visualization.
+
+## 2027-02-18 - Actionable Error Paths UX Consistency
+**Learning:** Consistently providing actionable instructions across all error/fallback paths, not just non-interactive ones, significantly improves user experience. In CLI tools, omitting these instructions in certain failure branches forces users to guess the next steps. Using consistent visual hierarchy (e.g. `✘` for errors, `Colors.CYAN` for commands) reduces cognitive load.
+**Action:** When auditing CLI fallback flows, extract the remediation output logic into reusable helpers to guarantee that whether a user skips a wizard, encounters a file write error, or runs non-interactively, they always receive the exact same visually-distinct actionable command (like `cp .env.example .env`). Ensure consistent `✘` prefixes on critical file operation errors.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -28,6 +28,7 @@ class AppRunner:
         finally:
             if Colors.ENABLED:
                 import sys
+
                 sys.stdout.write(Colors.RESET)
                 sys.stdout.flush()
 
@@ -203,7 +204,15 @@ class AppRunner:
 
             # Fallback to copy only if wizard wasn't run or failed
             if not Path(self.config_file).exists():
-                prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(f"Create '{self.config_file}' from template without wizard? ", Colors.BOLD) + Colors.colorize("[Y/n]", Colors.GREY) + Colors.colorize(" ", Colors.BOLD)
+                prompt = (
+                    Colors.colorize("? ", Colors.CYAN)
+                    + Colors.colorize(
+                        f"Create '{self.config_file}' from template without wizard? ",
+                        Colors.BOLD,
+                    )
+                    + Colors.colorize("[Y/n]", Colors.GREY)
+                    + Colors.colorize(" ", Colors.BOLD)
+                )
                 response = self._styled_input(prompt).lower()
                 if response in ("", "y", "yes"):
                     try:
@@ -225,16 +234,26 @@ class AppRunner:
                         with os.fdopen(fd, "wb") as dst:
                             dst.write(content)
 
-                        print(Colors.colorize(f"✔ Created '{self.config_file}' from '.env.example'.", Colors.GREEN))
                         print(
-                            Colors.colorize("IMPORTANT: Please edit .env with your actual credentials before proceeding.", Colors.YELLOW)
+                            Colors.colorize(
+                                f"✔ Created '{self.config_file}' from '.env.example'.",
+                                Colors.GREEN,
+                            )
+                        )
+                        print(
+                            Colors.colorize(
+                                "IMPORTANT: Please edit .env with your actual credentials before proceeding.",
+                                Colors.YELLOW,
+                            )
                         )
                         sys.exit(0)
                     except Exception as e:
-                        print(Colors.colorize(f"Error creating file: {e}", Colors.RED))
+                        print(
+                            Colors.colorize(f"✘ Error creating file: {e}", Colors.RED)
+                        )
                         sys.exit(1)
                 else:
-                    print(Colors.colorize("Please create a .env file based on .env.example", Colors.YELLOW))
+                    self._print_fallback_instructions()
                     sys.exit(1)
         except KeyboardInterrupt:
             warning = Colors.colorize("⚠", Colors.YELLOW)
@@ -257,15 +276,21 @@ class AppRunner:
                 Colors.RED,
             )
         )
+        self._print_fallback_instructions()
+        sys.exit(1)
+
+    def _print_fallback_instructions(self) -> None:
+        """Helper to consistently print fallback instructions and command across error paths."""
         print(
             Colors.colorize(
-                "Please create the configuration file based on .env.example",
-                Colors.YELLOW,
+                "Please create a .env file based on .env.example", Colors.YELLOW
             )
         )
         command = f'cp .env.example "{self.config_file}"'
-        print(Colors.colorize("You can run: ", Colors.YELLOW) + Colors.colorize(command, Colors.CYAN))
-        sys.exit(1)
+        print(
+            Colors.colorize("You can run: ", Colors.YELLOW)
+            + Colors.colorize(command, Colors.CYAN)
+        )
 
     def validate_config(self) -> None:
         """Validate the configuration to ensure default credentials aren't used."""
@@ -319,7 +344,12 @@ class AppRunner:
             )
         )
 
-        prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize("Run setup wizard? ", Colors.BOLD) + Colors.colorize("[Y/n]", Colors.GREY) + Colors.colorize(" ", Colors.BOLD)
+        prompt = (
+            Colors.colorize("? ", Colors.CYAN)
+            + Colors.colorize("Run setup wizard? ", Colors.BOLD)
+            + Colors.colorize("[Y/n]", Colors.GREY)
+            + Colors.colorize(" ", Colors.BOLD)
+        )
         response = self._styled_input(prompt).lower()
         if response in ("", "y", "yes"):
             if run_setup_wizard(self.config_file):
@@ -329,17 +359,25 @@ class AppRunner:
 
     def _prompt_create_from_template(self) -> None:
         """Prompt the user to create a configuration file from the template."""
-        prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize(f"Create '{self.config_file}' from template without wizard? ", Colors.BOLD) + Colors.colorize("[Y/n]", Colors.GREY) + Colors.colorize(" ", Colors.BOLD)
+        prompt = (
+            Colors.colorize("? ", Colors.CYAN)
+            + Colors.colorize(
+                f"Create '{self.config_file}' from template without wizard? ",
+                Colors.BOLD,
+            )
+            + Colors.colorize("[Y/n]", Colors.GREY)
+            + Colors.colorize(" ", Colors.BOLD)
+        )
         response = self._styled_input(prompt).lower()
         if response in ("", "y", "yes"):
             try:
                 self._create_config_from_template()
                 sys.exit(0)
             except Exception as e:
-                print(Colors.colorize(f"Error creating file: {e}", Colors.RED))
+                print(Colors.colorize(f"✘ Error creating file: {e}", Colors.RED))
                 sys.exit(1)
         else:
-            print(Colors.colorize("Please create a .env file based on .env.example", Colors.YELLOW))
+            self._print_fallback_instructions()
             sys.exit(1)
 
     def _create_config_from_template(self) -> None:
@@ -365,9 +403,16 @@ class AppRunner:
             with os.fdopen(fd, "wb") as dst:
                 dst.write(content)
 
-            print(Colors.colorize(f"✔ Created '{self.config_file}' from '.env.example'.", Colors.GREEN))
             print(
-                Colors.colorize("IMPORTANT: Please edit .env with your actual credentials before proceeding.", Colors.YELLOW)
+                Colors.colorize(
+                    f"✔ Created '{self.config_file}' from '.env.example'.", Colors.GREEN
+                )
+            )
+            print(
+                Colors.colorize(
+                    "IMPORTANT: Please edit .env with your actual credentials before proceeding.",
+                    Colors.YELLOW,
+                )
             )
         except Exception:
             os.close(fd)

--- a/src/modules/media_analyzer.py
+++ b/src/modules/media_analyzer.py
@@ -252,7 +252,7 @@ class MediaAuthenticityAnalyzer:
             # and allows exceptions to propagate naturally, avoiding fail-open vulnerabilities.
             results = executor.map(
                 lambda att: self._process_attachment_parallel(att, shared_state),
-                email_data.attachments
+                email_data.attachments,
             )
 
             for meta_results, deepfake_results in results:
@@ -292,7 +292,9 @@ class MediaAuthenticityAnalyzer:
             risk_level=risk_level,
         )
 
-    def _process_attachment_parallel(self, attachment: dict, shared_state: dict) -> tuple:
+    def _process_attachment_parallel(
+        self, attachment: dict, shared_state: dict
+    ) -> tuple:
         """
         Process a single attachment for metadata and deepfake analysis in parallel.
         """
@@ -618,8 +620,10 @@ class MediaAuthenticityAnalyzer:
                 files_to_check = file_list[: self.MAX_ZIP_FILE_COUNT]
 
                 for contained_file in files_to_check:
-                    member_score, member_warnings = self._inspect_zip_member_and_check_traversal(
-                        zf, contained_file, filename, depth
+                    member_score, member_warnings = (
+                        self._inspect_zip_member_and_check_traversal(
+                            zf, contained_file, filename, depth
+                        )
                     )
                     score += member_score
                     warnings.extend(member_warnings)
@@ -652,7 +656,9 @@ class MediaAuthenticityAnalyzer:
         warnings = []
         if contained_file.startswith("/") or ".." in contained_file:
             score += 5.0
-            safe_contained_file = sanitize_for_logging(sanitize_filename(contained_file))
+            safe_contained_file = sanitize_for_logging(
+                sanitize_filename(contained_file)
+            )
             warnings.append(
                 f"Zip file {filename} contains path traversal attempt: {safe_contained_file}"
             )
@@ -660,9 +666,7 @@ class MediaAuthenticityAnalyzer:
         member_score, member_warnings = self._inspect_archive_member(
             filename,
             contained_file,
-            lambda: self._handle_nested_zip_member(
-                zf, contained_file, filename, depth
-            ),
+            lambda: self._handle_nested_zip_member(zf, contained_file, filename, depth),
         )
         score += member_score
         warnings.extend(member_warnings)
@@ -835,7 +839,9 @@ class MediaAuthenticityAnalyzer:
                     # THEN check for path traversal attempts
                     if member.name.startswith("/") or ".." in member.name:
                         score += 5.0
-                        safe_member_name = sanitize_for_logging(sanitize_filename(member.name))
+                        safe_member_name = sanitize_for_logging(
+                            sanitize_filename(member.name)
+                        )
                         warnings.append(
                             f"Tar file {filename} contains path traversal attempt: {safe_member_name}"
                         )

--- a/src/modules/spam_analyzer.py
+++ b/src/modules/spam_analyzer.py
@@ -90,7 +90,9 @@ class SpamAnalyzer:
     # ⚡ BOLT: Removed re.I. We will use .lower() on the text instead.
     # re.IGNORECASE carries a ~50-100% performance penalty during regex execution.
     # We explicitly lower() the keywords to guarantee matching behavior.
-    COMBINED_SPAM_PATTERN = compile_patterns([kw.lower() for kw in SPAM_KEYWORDS], flags=0)
+    COMBINED_SPAM_PATTERN = compile_patterns(
+        [kw.lower() for kw in SPAM_KEYWORDS], flags=0
+    )
 
     LINK_PATTERN = re.compile(r"https?://")
     URL_EXTRACTION_PATTERN = re.compile(r'https?://[^\s<>"]+')
@@ -148,7 +150,9 @@ class SpamAnalyzer:
 
     # Optimization: Pre-compiled regex reduces Python-level iteration compared to an any()-based loop
     # while preserving the original substring-matching behavior (no word boundaries)
-    CORPORATE_TITLES_PATTERN = compile_patterns([kw.lower() for kw in CORPORATE_TITLES], flags=0)
+    CORPORATE_TITLES_PATTERN = compile_patterns(
+        [kw.lower() for kw in CORPORATE_TITLES], flags=0
+    )
 
     def __init__(self, config):
         """
@@ -191,9 +195,7 @@ class SpamAnalyzer:
 
         extracted_urls = self.URL_EXTRACTION_PATTERN.findall(text_lower)
         if html_lower:
-            extracted_urls.extend(
-                self.URL_EXTRACTION_PATTERN.findall(html_lower)
-            )
+            extracted_urls.extend(self.URL_EXTRACTION_PATTERN.findall(html_lower))
         link_count = len(extracted_urls)
 
         # Analyze body content

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -65,6 +65,7 @@ def _styled_input(prompt: str) -> str:
     finally:
         if Colors.ENABLED:
             import sys
+
             sys.stdout.write(Colors.RESET)
             sys.stdout.flush()
 
@@ -174,7 +175,9 @@ def _select_provider() -> str:
             prompt = (
                 "\n"
                 + Colors.colorize("? ", Colors.CYAN)
-                + Colors.colorize("Select provider ", Colors.BOLD) + Colors.colorize("[1-4]", Colors.GREY) + Colors.colorize(": ", Colors.BOLD)
+                + Colors.colorize("Select provider ", Colors.BOLD)
+                + Colors.colorize("[1-4]", Colors.GREY)
+                + Colors.colorize(": ", Colors.BOLD)
             )
             choice = _styled_input(prompt)
             if choice in ("1", "2", "3", "4"):
@@ -265,6 +268,7 @@ def _prompt_for_password(provider_name: str) -> str:
         finally:
             if Colors.ENABLED:
                 import sys
+
                 sys.stdout.write(Colors.RESET)
                 sys.stdout.flush()
 
@@ -311,7 +315,12 @@ def _get_credentials(choice: str, provider_name: str) -> tuple[str, str]:
                 f"  {Colors.colorize('n:', Colors.BOLD)} Proceed anyway {Colors.colorize('(Skip verification)', Colors.YELLOW)}"
             )
 
-            prompt = Colors.colorize("? ", Colors.CYAN) + Colors.colorize("Retry? ", Colors.BOLD) + Colors.colorize("[Y/n]", Colors.GREY) + Colors.colorize(" ", Colors.BOLD)
+            prompt = (
+                Colors.colorize("? ", Colors.CYAN)
+                + Colors.colorize("Retry? ", Colors.BOLD)
+                + Colors.colorize("[Y/n]", Colors.GREY)
+                + Colors.colorize(" ", Colors.BOLD)
+            )
             retry = _styled_input(prompt).lower()
             if retry not in ("", "y", "yes"):
                 print(
@@ -456,7 +465,7 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
         )
         return True
     except Exception as e:
-        print(Colors.colorize(f"Error writing config: {e}", Colors.RED))
+        print(Colors.colorize(f"✘ Error writing config: {e}", Colors.RED))
         return False
 
 
@@ -510,7 +519,7 @@ def run_setup_wizard(
             with open(template_file, "r") as f:
                 template_content = f.read()
         except Exception as e:
-            print(Colors.colorize(f"Error reading template: {e}", Colors.RED))
+            print(Colors.colorize(f"✘ Error reading template: {e}", Colors.RED))
             return False
 
         # 4. Generate Config
@@ -523,8 +532,12 @@ def run_setup_wizard(
             return False
 
         print("\n" + Colors.colorize("Next Steps:", Colors.BOLD))
-        print(f"1. Review {Colors.colorize(config_file, Colors.BOLD)} to ensure settings are correct.")
-        print(f"2. Run the pipeline: {Colors.colorize('python src/main.py', Colors.CYAN)}")
+        print(
+            f"1. Review {Colors.colorize(config_file, Colors.BOLD)} to ensure settings are correct."
+        )
+        print(
+            f"2. Run the pipeline: {Colors.colorize('python src/main.py', Colors.CYAN)}"
+        )
 
         return True
 


### PR DESCRIPTION
💡 **What:** 
- Extracted a reusable `_print_fallback_instructions()` helper in `app_runner.py`.
- Updated all interactive cancellation and non-interactive missing-config paths to use the new helper, which prints a consistent, actionable command (`cp .env.example .env`) styled in `Colors.CYAN`.
- Standardized the visual hierarchy of critical file operation errors (like "Error creating file" or "Error reading template") by prepending the distinct `✘` symbol to the `Colors.RED` messages across `app_runner.py` and `setup_wizard.py`.

🎯 **Why:** 
Previously, users encountering failures outside the happy path received inconsistent and sometimes non-actionable error messages (e.g., just "Please create a .env file..."). By ensuring that every failure branch points the user to the exact shell command needed to fix the state, we significantly reduce cognitive load. Additionally, using standard `✘` indicators prevents error states from looking like plain text, ensuring they grab the user's attention.

📸 **Before/After:**
*(Conceptual Before)*
```text
Please create a .env file based on .env.example
```
*(After)*
```text
Please create a .env file based on .env.example
You can run: cp .env.example .env
```

---
*PR created automatically by Jules for task [18106210604059502946](https://jules.google.com/task/18106210604059502946) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->