### PR TITLE
fix(security): lowercase URL host/netloc + UI error semantics (salvages #1152)

### DIFF
--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -54,7 +54,7 @@ class AppRunner:
         if "\0" in raw_config_file:
             print(
                 Colors.colorize(
-                    f"Error: Invalid configuration file path '{raw_config_file}'.",
+                    f"✘ Error: Invalid configuration file path '{raw_config_file}'.",
                     Colors.RED,
                 )
             )
@@ -69,7 +69,7 @@ class AppRunner:
         except ValueError:
             print(
                 Colors.colorize(
-                    f"Error: Configuration file path must stay within '{base_dir}'.",
+                    f"✘ Error: Configuration file path must stay within '{base_dir}'.",
                     Colors.RED,
                 )
             )
@@ -251,6 +251,7 @@ class AppRunner:
                         print(
                             Colors.colorize(f"✘ Error creating file: {e}", Colors.RED)
                         )
+                        self._print_fallback_instructions()
                         sys.exit(1)
                 else:
                     self._print_fallback_instructions()
@@ -303,7 +304,7 @@ class AppRunner:
                 print(
                     "\n"
                     + Colors.colorize(
-                        "❌ Configuration Error: Default credentials detected",
+                        "✘ Configuration Error: Default credentials detected",
                         Colors.RED,
                     )
                 )
@@ -319,7 +320,7 @@ class AppRunner:
                     print(f"  • {Colors.colorize(error, Colors.YELLOW)}")
 
                 print(
-                    f"\nPlease edit {Colors.colorize(self.config_file, Colors.BOLD)} with your actual credentials."
+                    f"\n{Colors.colorize('Please edit ', Colors.YELLOW)}{Colors.colorize(self.config_file, Colors.BOLD)}{Colors.colorize(' with your actual credentials.', Colors.YELLOW)}"
                 )
                 sys.exit(1)
 
@@ -375,6 +376,7 @@ class AppRunner:
                 sys.exit(0)
             except Exception as e:
                 print(Colors.colorize(f"✘ Error creating file: {e}", Colors.RED))
+                self._print_fallback_instructions()
                 sys.exit(1)
         else:
             self._print_fallback_instructions()

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -310,7 +310,7 @@ class Config:
                 errors.append("Slack alerts enabled but no webhook URL provided")
             elif not self._is_https_url(self.alerts.slack_webhook):
                 errors.append("Slack webhook URL must use HTTPS")
-            elif urlparse(self.alerts.slack_webhook).netloc != "hooks.slack.com":
+            elif urlparse(self.alerts.slack_webhook).netloc.lower() != "hooks.slack.com":
                 errors.append("Slack webhook URL must be a valid Slack hooks endpoint")
             else:
                 is_safe, err_msg = is_safe_webhook_url(self.alerts.slack_webhook)

--- a/src/utils/security_validators.py
+++ b/src/utils/security_validators.py
@@ -266,7 +266,7 @@ def is_safe_webhook_url(url: str) -> Tuple[bool, str]:
     if parsed.scheme != "https":
         return False, f"URL scheme must be https, got: {parsed.scheme}"
 
-    hostname = parsed.hostname
+    hostname = parsed.hostname.lower() if parsed.hostname else None
     if not hostname:
         return False, "URL must contain a valid hostname"
 

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -439,16 +439,15 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
                         os.chmod(config_path_str, 0o600, **chmod_kwargs)
                     else:
                         print(
-                            f"\n{Colors.colorize('✘ Error:', Colors.RED)} "
-                            f"TOCTOU detected on '{config_path}'."
+                            f"\n{Colors.colorize('✘ Error: TOCTOU detected on ', Colors.RED)}"
+                            f"{Colors.colorize(str(config_path), Colors.BOLD)}"
                         )
                         import sys
 
                         sys.exit(1)
                 except OSError as exc:
                     print(
-                        f"\n{Colors.colorize('✘ Error setting permissions:', Colors.RED)} "
-                        f"{exc}"
+                        f"\n{Colors.colorize('✘ Error setting permissions: ' + str(exc), Colors.RED)}"
                     )
                     import sys
 

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -83,7 +83,8 @@ class CountdownTimer:
                 Colors.colorize(" (Press Ctrl+C to stop)", Colors.GREY), ""
             ).replace(" (Press Ctrl+C to stop)", "")
             # Ensure we print the cancellation message correctly
-            sys.stdout.write(f"\r\033[K{warning} {clean_msg} (Cancelled)\n")
+            colored_msg = Colors.colorize(f"{clean_msg} (Cancelled)", Colors.YELLOW)
+            sys.stdout.write(f"\r\033[K{warning} {colored_msg}\n")
             sys.stdout.flush()
             raise KeyboardInterrupt()
         finally:


### PR DESCRIPTION
## Salvage of #1152

Original PR went `DIRTY` after parallel merges on `main`. This draft reapplies the valuable changes onto current `main`.

### Changes
- **Security:** `.lower()` on `urlparse` netloc/hostname in `config.py` and `security_validators.py` (case-sensitive SSRF bypass prevention)
- **UX:** Consistent `✘` error prefix, fallback instructions on file-create failures, colored credential-edit prompt, countdown cancellation styling

### Verification
```bash
python3 -m py_compile src/app_runner.py src/utils/config.py src/utils/security_validators.py src/utils/setup_wizard.py src/utils/ui.py
python3 -m pytest tests/ -q
```
Local: **641 passed**

### Tier: T1 — security-sensitive salvage

═══ ELIR ═══
**PURPOSE:** Salvage Jules Daily QA URL-parsing hardening and UI color semantics from conflicted #1152.
**SECURITY:** Prevents case-variant hostname/netloc bypass in webhook validation; no auth changes.
**FAILS IF:** `.lower()` omitted on mixed-case HTTPS URLs in Slack/webhook checks.
**VERIFY:** Run pytest; spot-check `is_safe_webhook_url('https://HOOKS.SLACK.COM/...')` returns expected result.
**MAINTAIN:** Do not wholesale-checkout `app_runner.py` from stale branches — adapt UI lines to current `main`.

Refs: #1152 (salvage source)