### PR TITLE
🎨 Palette: Add fallback instructions to permission error paths

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -224,3 +224,6 @@
 ## 2027-02-18 - Consolidate Loading State Text
 **Learning:** In CLI flows, printing a static status message (e.g., `print("Verifying...")`) followed immediately by instantiating a `Spinner` (e.g., `Spinner("Connecting...")`) for the actual async work creates visual stutter and terminal clutter. The user sees two similar messages back-to-back.
 **Action:** Avoid redundant loading messages by consolidating static print statements and immediate subsequent `Spinner` initializations into a single `Spinner` containing the most user-relevant descriptive text.
+## 2027-02-18 - Actionable Error Paths UX Consistency
+**Learning:** Consistently providing actionable instructions across all error/fallback paths, not just non-interactive ones, significantly improves user experience. In CLI tools, omitting these instructions in certain failure branches forces users to guess the next steps. Using consistent visual hierarchy (e.g. `✘` for errors, `Colors.CYAN` for commands) reduces cognitive load.
+**Action:** When auditing CLI fallback flows, extract the remediation output logic into reusable helpers to guarantee that whether a user skips a wizard, encounters a file write error, or runs non-interactively, they always receive the exact same visually-distinct actionable command (like `cp .env.example .env`). Ensure consistent `✘` prefixes on critical file operation errors.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -141,6 +141,7 @@ class AppRunner:
                         Colors.RED,
                     )
                 )
+                self._print_fallback_instructions()
                 sys.exit(1)
 
             # Use follow_symlinks=False to prevent symlink attacks
@@ -153,6 +154,7 @@ class AppRunner:
                     Colors.RED,
                 )
             )
+            self._print_fallback_instructions()
             sys.exit(1)
 
     def print_help(self) -> None:


### PR DESCRIPTION
💡 **What**: Added `self._print_fallback_instructions()` to the `except OSError` and TOCTOU error blocks within the `_set_secure_permissions` method of `src/app_runner.py`.
🎯 **Why**: To ensure users consistently receive actionable remediation steps (like `cp .env.example .env`) during configuration file creation or permission setting failures, rather than just seeing an error and the application exiting. This maintains visual hierarchy and provides clear next steps.
📸 **Before**: Unstyled exit on permission failure.
📸 **After**: Styled error with actionable fallback commands in yellow/cyan.

---
*PR created automatically by Jules for task [5069266881319812848](https://jules.google.com/task/5069266881319812848) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->