### PR TITLE
🧹 fix: log BadZipFile exception instead of ignoring it

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -145,3 +145,7 @@
 ## $(date +%Y-%m-%d) - Pre-Compiled Regex Lowercase Optimization
 **Learning:** The `re.IGNORECASE` flag carries a significant performance penalty in Python. Optimizing regex matching by lowercasing the pattern strings ahead of time and compiling with `flags=0`, then evaluating against explicitly lowercased input text (e.g., `text.lower()`), is measurably faster. Automated reviewers may incorrectly flag this optimization as breaking case-insensitivity, failing to trace the data flow (e.g., missing that `subject_lower = subject.lower()` is used).
 **Action:** Always independently verify claims from automated code reviews using `cat` or `grep` to confirm if text normalization (like `.lower()`) is already handled upstream before reverting a valid performance optimization.
+
+## 2025-06-25 - Prevent Ignored Exception Anti-Pattern
+**Learning:** Silently ignoring exceptions using a bare `pass` statement (e.g., `except zipfile.BadZipFile: pass`) masks potential issues and reduces the observability of the system. While it prevents the application from crashing, it makes debugging incredibly difficult when failures inevitably occur.
+**Action:** Replace silent `pass` statements in exception handlers with appropriate logging (e.g., `self.logger.warning(...)`) to ensure operational visibility while still allowing the system to handle the error gracefully without failing outright.

--- a/src/modules/media_analyzer.py
+++ b/src/modules/media_analyzer.py
@@ -631,8 +631,8 @@ class MediaAuthenticityAnalyzer:
                     if score >= 5.0:
                         return score, warnings
 
-        except zipfile.BadZipFile:
-            pass
+        except zipfile.BadZipFile as e:
+            self.logger.warning(f"Bad zip file {filename}: {e}")
         except Exception as e:
             self.logger.warning(f"Error inspecting zip {filename}: {e}")
 


### PR DESCRIPTION
🎯 **What:** Replaced the silent `pass` in the `zipfile.BadZipFile` exception handler with a proper logging statement inside `src/modules/media_analyzer.py`.
💡 **Why:** Silently ignoring errors makes debugging very hard. Logging the `BadZipFile` exception improves system observability while still handling the error gracefully and preventing crashes. This resolves a code health issue where an exception was being swallowed.
✅ **Verification:** Ran the full test suite (`pytest -v`), specifically checking the `media_analyzer` and error handling test cases, and confirmed there are no regressions. Black formatter was run as well.
✨ **Result:** Improved maintainability and debugging capability for the `media_analyzer` module.

```
<<<<<<< SEARCH
        except zipfile.BadZipFile:
            pass
        except Exception as e:
            self.logger.warning(f"Error inspecting zip {filename}: {e}")
=======
        except zipfile.BadZipFile as e:
            self.logger.warning(f"Bad zip file {filename}: {e}")
        except Exception as e:
            self.logger.warning(f"Error inspecting zip {filename}: {e}")
>>>>>>> REPLACE
```

---
*PR created automatically by Jules for task [1783291817581198617](https://jules.google.com/task/1783291817581198617) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->