### PR TITLE
🧪 Add truncation edge cases for sanitize_for_logging

### DIFF
--- a/src/utils/sanitization.py
+++ b/src/utils/sanitization.py
@@ -92,6 +92,8 @@ def sanitize_for_logging(text: str, max_length: int = 255) -> str:
     text = text.translate(_TRANSLATOR)
 
     # 5. Truncate if necessary to prevent log flooding
+    if max_length <= 0:
+        return "..."
     if len(text) > max_length:
         text = text[:max_length] + "..."
 

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -88,5 +88,25 @@ class TestSanitization(unittest.TestCase):
         self.assertTrue(len(sanitized) <= 13)  # 10 + 3 dots
 
 
+
+    def test_truncation_edge_cases(self):
+        """Test string truncation boundary and edge cases."""
+        text = "1234567890"
+
+        # Exact length
+        self.assertEqual(sanitize_for_logging(text, max_length=10), "1234567890")
+
+        # One char over
+        self.assertEqual(sanitize_for_logging(text + "1", max_length=10), "1234567890...")
+
+        # One char under
+        self.assertEqual(sanitize_for_logging(text[:-1], max_length=10), "123456789")
+
+        # Zero max_length
+        self.assertEqual(sanitize_for_logging(text, max_length=0), "...")
+
+        # Negative max_length
+        self.assertEqual(sanitize_for_logging(text, max_length=-1), "...")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Identified and addressed a missing test case covering edge conditions for the `max_length` truncation parameter in `sanitize_for_logging`.
📊 **Coverage:** A new test method `test_truncation_edge_cases` has been added, effectively covering exact length truncation boundaries, off-by-one tests, a zero length, and negative limit configurations. To prevent the negative index from erroneously behaving like reverse python slicing, a guard clause was introduced ensuring correct truncations for boundaries <= 0.
✨ **Result:** Test coverage improved across limit boundaries, making string sanitization predictable and eliminating unexpected behavior on edge cases and invalid `max_length` states. Full test suite is successfully passing with zero regressions.

---
*PR created automatically by Jules for task [18328497455334738494](https://jules.google.com/task/18328497455334738494) started by @abhimehro*