### PR TITLE
🧪 Add missing error test in email_ingestion close_all_connections

### DIFF
--- a/tests/test_email_ingestion_manager.py
+++ b/tests/test_email_ingestion_manager.py
@@ -288,6 +288,25 @@ class TestEmailIngestionManagerClose(unittest.TestCase):
             m.disconnect.assert_called_once()
         self.assertEqual(manager.clients, {})
 
+    def test_disconnect_exception_is_logged(self):
+        """Single client raising an exception on disconnect() doesn't crash."""
+        m1 = MagicMock()
+        m1.disconnect.side_effect = Exception("test exception")
+
+        manager = EmailIngestionManager([])
+        manager.logger = MagicMock()
+        manager.clients = {"a@x.com": m1}
+
+        # Should not crash
+        manager.close_all_connections()
+
+        m1.disconnect.assert_called_once()
+        self.assertEqual(manager.clients, {})
+        manager.logger.warning.assert_called_once()
+        self.assertIn(
+            "Error closing connection", manager.logger.warning.call_args[0][0]
+        )
+
     def test_one_disconnect_raises_others_still_called(self):
         """When one client raises on disconnect(), the others are still disconnected.
 


### PR DESCRIPTION
* 🎯 **What:** The testing gap in `email_ingestion.py` was that there was no test specifically mocking a single client's `disconnect()` throwing an exception and validating that it didn't crash.
* 📊 **Coverage:** The exception block of `close_all_connections()` is now thoroughly tested.
* ✨ **Result:** `test_disconnect_exception_is_logged` was added which explicitly verifies that exceptions raised by `client.disconnect()` are correctly caught, handled gracefully, logged via `logger.warning`, and that the `self.clients` dictionary still gets successfully cleared avoiding potential resource leaks or crashing.

---
*PR created automatically by Jules for task [3492492898257046242](https://jules.google.com/task/3492492898257046242) started by @abhimehro*