### PR TITLE
🧹 Fix ignored exceptions in media_analyzer

### DIFF
--- a/src/modules/media_analyzer.py
+++ b/src/modules/media_analyzer.py
@@ -631,8 +631,8 @@ class MediaAuthenticityAnalyzer:
                     if score >= 5.0:
                         return score, warnings
 
-        except zipfile.BadZipFile:
-            pass
+        except zipfile.BadZipFile as e:
+            self.logger.warning(f"Error inspecting zip {filename}: {e}")
         except Exception as e:
             self.logger.warning(f"Error inspecting zip {filename}: {e}")
 
@@ -861,8 +861,8 @@ class MediaAuthenticityAnalyzer:
                     if score >= 5.0:
                         return score, warnings
 
-        except tarfile.TarError:
-            pass
+        except tarfile.TarError as e:
+            self.logger.warning(f"Error inspecting tar {filename}: {e}")
         except Exception as e:
             self.logger.warning(f"Error inspecting tar {filename}: {e}")
 


### PR DESCRIPTION
🎯 **What:** Replaced swallowed exceptions (`pass`) under `except tarfile.TarError:` and `except zipfile.BadZipFile:` with localized logger warnings.
💡 **Why:** Suppressing specific parsing errors makes debugging difficult when archives fail to process. Logging these errors explicitly improves maintainability and observability while still catching the expected exceptions safely.
✅ **Verification:** Ran the full test suite (`python3 -m pytest -v`), which successfully passed, confirming the change is safe and preserves expected logic.
✨ **Result:** Increased visibility into archive inspection errors without interrupting the analysis flow.

---
*PR created automatically by Jules for task [10666185689725272032](https://jules.google.com/task/10666185689725272032) started by @abhimehro*