### PR TITLE
🎨 Palette: Make CLI provider selection more forgiving

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -224,3 +224,7 @@
 ## 2027-02-18 - Consolidate Loading State Text
 **Learning:** In CLI flows, printing a static status message (e.g., `print("Verifying...")`) followed immediately by instantiating a `Spinner` (e.g., `Spinner("Connecting...")`) for the actual async work creates visual stutter and terminal clutter. The user sees two similar messages back-to-back.
 **Action:** Avoid redundant loading messages by consolidating static print statements and immediate subsequent `Spinner` initializations into a single `Spinner` containing the most user-relevant descriptive text.
+
+## 2025-02-18 - Forgiving CLI Text Inputs
+**Learning:** Terminal applications often rely heavily on rigid numeric inputs for menus. When a user naturally attempts to type the contextual option instead (e.g., "gmail" or "quit" instead of "1"), blocking them with an "Invalid Choice" error creates unnecessary friction and hurts the user experience.
+**Action:** When building text-based menus, accept reasonable string synonyms (and explicit exit commands like "q" or "quit") alongside numeric keys to make the UI much more resilient and natural.

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -179,12 +179,20 @@ def _select_provider() -> str:
                 + Colors.colorize("[1-4]", Colors.GREY)
                 + Colors.colorize(": ", Colors.BOLD)
             )
-            choice = _styled_input(prompt)
-            if choice in ("1", "2", "3", "4"):
-                return choice
+            choice = _styled_input(prompt).lower()
+            if choice in ("1", "gmail"):
+                return "1"
+            if choice in ("2", "proton", "proton mail", "protonmail"):
+                return "2"
+            if choice in ("3", "outlook"):
+                return "3"
+            if choice in ("4", "skip"):
+                return "4"
+            if choice in ("q", "quit", "exit"):
+                raise KeyboardInterrupt()
             print(
                 Colors.colorize("✘ Invalid choice. ", Colors.RED)
-                + Colors.colorize("Please enter 1, 2, 3, or 4.", Colors.YELLOW)
+                + Colors.colorize("Please enter a number (1-4) or provider name.", Colors.YELLOW)
             )
         except EOFError:
             return "4"


### PR DESCRIPTION
💡 **What:** Modified the interactive setup wizard's provider selection menu to accept string synonyms (e.g., 'gmail', 'skip', 'proton') and standard exit commands (e.g., 'q', 'quit', 'exit') in addition to the strict numeric keys.

🎯 **Why:** Terminal menus that strictly enforce numeric inputs when contextual options are presented create unnecessary friction. Users naturally attempt to type the name of the option they want. A forgiving UI that gracefully handles these expected variations significantly improves the overall developer and user experience.

♿ **Accessibility:** This provides alternative input paths for users, making the CLI more flexible and forgiving of typing habits. Raising a `KeyboardInterrupt` on 'quit' inputs cleanly exits the application without requiring knowledge of `Ctrl+C`.

---
*PR created automatically by Jules for task [17716202230859707979](https://jules.google.com/task/17716202230859707979) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->