### PR TITLE
Potential fix for code scanning alert no. 7845: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/abhimehro/email-security-pipeline/security/code-scanning/7845](https://github.com/abhimehro/email-security-pipeline/security/code-scanning/7845)

Add an explicit `permissions` block in `.github/workflows/pytest.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, the best minimal permission is:

- `contents: read`

This preserves current functionality (checkout and test execution) while constraining token scope and satisfying CodeQL. No imports, methods, or additional definitions are needed—just YAML configuration update near the top of the file, after `on:` triggers (or before `jobs:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
