### PR TITLE
🛡️ Sentinel: [HIGH] Fix URL Parsing for domain checks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -49,3 +49,8 @@
 **Vulnerability:** A logic flaw in `src/modules/alert_system.py` and `src/utils/config.py` used `parsed.netloc.lower() == "hooks.slack.com"` for webhook redaction and SSRF validation. `netloc` includes explicit ports and user credentials. An attacker could craft a webhook URL like `https://hooks.slack.com:443/services/...` to bypass these checks.
 **Learning:** `urllib.parse.urlparse().netloc` returns the entire authority component (credentials + domain + port). Using it for exact domain matching enables bypasses when ports or user info are added. Furthermore, `netloc` is not reliably lowercased for unknown or uppercase protocols.
 **Prevention:** Always use `(urlparse(url).hostname or "").lower()` when verifying or matching domains for security constraints, as `.hostname` extracts only the domain name component safely without credentials or ports.
+
+## 2025-07-01 - URL Parsing Vulnerability using netloc
+**Vulnerability:** The application used `urlparse(url).netloc` to extract the domain for spam checks and configuration validation.
+**Learning:** `netloc` includes the credentials and port (e.g., `user:pass@domain:port`), which bypasses simple string-matching spam filters. An attacker could craft a URL like `http://domain.com:80@malicious.com` or `http://malicious.com:80` and bypass the filter.
+**Prevention:** Always use `urllib.parse.urlparse(url).hostname` instead of `.netloc` to accurately extract the domain name for validation. Ensure you handle `None` values (e.g., `(parsed.hostname or "").lower()`).

--- a/src/modules/spam_analyzer.py
+++ b/src/modules/spam_analyzer.py
@@ -365,7 +365,7 @@ class SpamAnalyzer:
 
             try:
                 parsed = urlparse(url)
-                domain = parsed.netloc.lower()
+                domain = (parsed.hostname or "").lower()
 
                 current_url_score = 0.0
                 append_count = 0

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -275,7 +275,7 @@ class Config:
             parsed = urlparse(value)
         except ValueError:
             return False
-        return parsed.scheme == "https" and bool(parsed.netloc)
+        return parsed.scheme == "https" and bool(parsed.hostname)
 
     def _validate_email_accounts(self) -> List[str]:
         """Validate email account configurations."""


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** The application used `urlparse(url).netloc` in `src/modules/spam_analyzer.py` and `src/utils/config.py` to extract the domain for spam scoring and URL validation. Because `netloc` returns the entire authority component (credentials + host + port), a URL like `http://domain.com:80@malicious.com` or `http://malicious.com:80` would result in a `netloc` string that does not exactly match simple blocklist entries, effectively bypassing domain-based filters. Furthermore, `netloc` does not reliably guarantee lowercasing for all protocols.

🎯 **Impact:** Attackers could bypass domain-based spam filtering and potentially spoof configuration validations, allowing malicious URLs to evade detection or unauthorized webhook destinations to pass initial basic checks before SSRF validation.

🔧 **Fix:** Replaced `.netloc` with `.hostname` in `src/modules/spam_analyzer.py` and `src/utils/config.py`. `hostname` securely strips out credentials and ports, returning just the domain name. It safely falls back using `(parsed.hostname or "").lower()`.

✅ **Verification:** Ran the full test suite (`python3 -m pytest`) which passed successfully. Confirmed via Code Review. Logged the learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15673537691157317766](https://jules.google.com/task/15673537691157317766) started by @abhimehro*