### PR TITLE
Fix opencv-python-headless version inconsistency

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -3,7 +3,7 @@
 # so PR validation stays fast and reliable.
 
 numpy>=1.26.0,<2.0.0
-opencv-python-headless>=4.8.0
+opencv-python-headless>=4.10.0
 pre-commit>=3.5.0
 pytest>=8.0.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Fix dependency version inconsistency

Standardize opencv-python-headless version across all dependency files:

- requirements.txt: opencv-python-headless>=4.10.0 (already correct)
- requirements-ci.txt: opencv-python-headless>=4.8.0 → >=4.10.0 (fixed)

This ensures consistency between development and CI environments.