### PR TITLE
🎨 Palette: Unify error status icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -227,3 +227,7 @@
 ## $(date +%Y-%m-%d) - Silent catch in UI elements
 **Learning:** Silently catching `KeyboardInterrupt` in background threads (like a spinner loop initialization) without raising it or setting a stop event can lead to a state where the thread continues spinning even after the user tries to cancel, or it might consume the interrupt and prevent the main thread from handling it properly. While checking for `sys.stdout.isatty()` or other conditions, it is crucial to ensure that accessibility features (like screen readers) do not inadvertently block main-thread signals by catching and ignoring exceptions.
 **Action:** When adding small delays (e.g., `time.sleep()`) for accessibility or UI timing in methods that start background threads, ensure these delays are moved *into* the background thread itself. This prevents the main thread from blocking and eliminates the need to catch and suppress `KeyboardInterrupt` in the setup phase, allowing the main application to handle cancellation signals robustly.
+
+## 2025-06-26 - Unified error styling symbol
+**Learning:** Having multiple variation of the X symbol (`❌` vs `✘`) for errors creates an inconsistent visual experience in the CLI and causes cognitive dissonance. Consistency in iconography is just as important as consistency in colors.
+**Action:** Always use the same `✘` symbol for error states across the CLI, matching the success `✔` symbol, avoiding more complex or colorful emojis like `❌` which may render inconsistently in some terminals.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -137,7 +137,7 @@ class AppRunner:
             if fd_stat.st_ino != path_stat.st_ino or fd_stat.st_dev != path_stat.st_dev:
                 print(
                     Colors.colorize(
-                        "❌ CRITICAL: TOCTOU detected during permission setting. Aborting.",
+                        "✘ CRITICAL: TOCTOU detected during permission setting. Aborting.",
                         Colors.RED,
                     )
                 )
@@ -150,7 +150,7 @@ class AppRunner:
         except OSError as e:
             print(
                 Colors.colorize(
-                    f"❌ CRITICAL: Failed to set secure permissions: {e}",
+                    f"✘ CRITICAL: Failed to set secure permissions: {e}",
                     Colors.RED,
                 )
             )

--- a/src/main.py
+++ b/src/main.py
@@ -157,7 +157,7 @@ class EmailSecurityPipeline:
             self.logger.info("Received shutdown signal")
             self.stop()
         except ConfigurationError as e:
-            print("\n" + Colors.colorize("❌ Configuration Error:", Colors.RED))
+            print("\n" + Colors.colorize("✘ Configuration Error:", Colors.RED))
             for error in e.args[0]:
                 print(f"  • {Colors.colorize(error, Colors.YELLOW)}")
             print(


### PR DESCRIPTION
💡 **What:** Standardized the CLI error icon by replacing `❌` with `✘` where inconsistencies existed.
🎯 **Why:** To create a unified and consistent visual experience for users when they encounter errors, avoiding cognitive dissonance and ensuring iconography aligns with the success symbol (`✔`).
♿ **Accessibility:** Prevents potential rendering issues with complex emojis in some terminal emulators.

Included a critical learning in `.jules/palette.md` to enforce this pattern.

---
*PR created automatically by Jules for task [18431603439278711918](https://jules.google.com/task/18431603439278711918) started by @abhimehro*