### PR TITLE
🧹 Code Health: Refactor _inspect_tar_contents to reduce complexity

### DIFF
--- a/src/modules/media_analyzer.py
+++ b/src/modules/media_analyzer.py
@@ -804,6 +804,47 @@ class MediaAuthenticityAnalyzer:
 
         return score, warnings
 
+
+    def _inspect_tar_member_and_check_traversal(
+        self, tf, member, filename: str, depth: int
+    ) -> Tuple[float, List[str]]:
+        score = 0.0
+        warnings = []
+
+        # SECURITY: Sanitize member name to prevent path traversal and log injection
+        safe_member_name = sanitize_for_logging(
+            sanitize_filename(member.name)
+        )
+        member_lower = safe_member_name.lower()
+
+        # Check for dangerous extensions FIRST
+        if member_lower.endswith(self.DANGEROUS_EXTENSIONS):
+            score += 5.0
+            warnings.append(
+                f"Archive {filename} contains dangerous file: {safe_member_name}"
+            )
+            return score, warnings
+
+        if self._is_path_traversal_attempt(member.name):
+            score += 5.0
+            safe_member_name = sanitize_for_logging(
+                sanitize_filename(member.name)
+            )
+            warnings.append(
+                f"Tar file {filename} contains path traversal attempt: {safe_member_name}"
+            )
+            return score, warnings
+
+        member_score, member_warnings = self._inspect_archive_member(
+            filename,
+            member.name,
+            lambda: self._handle_nested_tar_member(tf, member, filename, depth),
+        )
+        score += member_score
+        warnings.extend(member_warnings)
+
+        return score, warnings
+
     def _inspect_tar_contents(
         self, filename: str, data: bytes, depth: int = 0
     ) -> Tuple[float, List[str]]:
@@ -834,40 +875,10 @@ class MediaAuthenticityAnalyzer:
                 )
 
                 for member in members[: self.MAX_ZIP_FILE_COUNT]:
-                    # SECURITY: Sanitize member name to prevent path traversal and log injection
-                    safe_member_name = sanitize_for_logging(
-                        sanitize_filename(member.name)
-                    )
-                    member_lower = safe_member_name.lower()
-
-                    # Check for dangerous extensions FIRST
-                    if member_lower.endswith(self.DANGEROUS_EXTENSIONS):
-                        score += 5.0
-                        warnings.append(
-                            f"Archive {filename} contains dangerous file: {safe_member_name}"
-                        )
-                        if score >= 5.0:
-                            return score, warnings
-                        continue
-
-                    # THEN check for path traversal attempts
-                    if self._is_path_traversal_attempt(member.name):
-                        score += 5.0
-                        safe_member_name = sanitize_for_logging(
-                            sanitize_filename(member.name)
-                        )
-                        warnings.append(
-                            f"Tar file {filename} contains path traversal attempt: {safe_member_name}"
-                        )
-                        continue
-
-                    # Standard archive member inspection
-                    member_score, member_warnings = self._inspect_archive_member(
-                        filename,
-                        member.name,
-                        lambda: self._handle_nested_tar_member(
+                    member_score, member_warnings = (
+                        self._inspect_tar_member_and_check_traversal(
                             tf, member, filename, depth
-                        ),
+                        )
                     )
                     score += member_score
                     warnings.extend(member_warnings)


### PR DESCRIPTION
🎯 **What:** Extracted the per-member inspection logic inside `_inspect_tar_contents` into a new helper method `_inspect_tar_member_and_check_traversal`.

💡 **Why:** This refactoring reduces the cyclomatic complexity of `_inspect_tar_contents` making it much easier to read and maintain.

✅ **Verification:** Ran `python3 -m pytest tests/` after the refactoring to verify that no functionality was broken. Also ran `flake8` and `black` to ensure no linting or formatting issues were introduced.

✨ **Result:** The codebase is cleaner and the `_inspect_tar_contents` method is now easier to understand and maintain.

---
*PR created automatically by Jules for task [16817251563609294178](https://jules.google.com/task/16817251563609294178) started by @abhimehro*