### PR TITLE
🧹 Code Health: Extract permission logic to simplify _write_config_file

### DIFF
--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -171,10 +171,16 @@ def _select_provider() -> str:
     )
 
     choices_map = {
-        "1": "1", "gmail": "1",
-        "2": "2", "proton": "2", "proton mail": "2", "protonmail": "2",
-        "3": "3", "outlook": "3",
-        "4": "4", "skip": "4"
+        "1": "1",
+        "gmail": "1",
+        "2": "2",
+        "proton": "2",
+        "proton mail": "2",
+        "protonmail": "2",
+        "3": "3",
+        "outlook": "3",
+        "4": "4",
+        "skip": "4",
     }
 
     while True:
@@ -193,7 +199,9 @@ def _select_provider() -> str:
                 return choices_map[choice]
             print(
                 Colors.colorize("✘ Invalid choice. ", Colors.RED)
-                + Colors.colorize("Please enter a number (1-4) or provider name.", Colors.YELLOW)
+                + Colors.colorize(
+                    "Please enter a number (1-4) or provider name.", Colors.YELLOW
+                )
             )
         except EOFError:
             return "4"
@@ -384,6 +392,51 @@ def _generate_config_content(
     return content
 
 
+def _apply_secure_permissions(fd: int, config_path: Path) -> None:
+    """Applies restrictive permissions to the config file with fallback mechanisms."""
+    try:
+        os.fchmod(fd, 0o600)
+    except (AttributeError, OSError, NotImplementedError):
+        try:
+            # Some platforms support os.chmod(fd, mode)
+            os.chmod(fd, 0o600)
+        except (AttributeError, OSError, NotImplementedError, TypeError):
+            # Final fallback to path-based chmod with inode verification.
+            try:
+                stat_fd = os.fstat(fd)
+                config_path_str = str(config_path)
+                stat_path = (
+                    os.lstat(config_path_str)
+                    if hasattr(os, "lstat")
+                    else os.stat(config_path_str)
+                )
+                if (
+                    stat_fd.st_ino == stat_path.st_ino
+                    and stat_fd.st_dev == stat_path.st_dev
+                ):
+                    chmod_kwargs = (
+                        {"follow_symlinks": False}
+                        if os.chmod in getattr(os, "supports_follow_symlinks", set())
+                        else {}
+                    )
+                    os.chmod(config_path_str, 0o600, **chmod_kwargs)
+                else:
+                    print(
+                        f"\n{Colors.colorize('✘ Error: TOCTOU detected on ', Colors.RED)}"
+                        f"{Colors.colorize(str(config_path), Colors.BOLD)}"
+                    )
+                    import sys
+
+                    sys.exit(1)
+            except OSError as exc:
+                print(
+                    f"\n{Colors.colorize('✘ Error setting permissions: ' + str(exc), Colors.RED)}"
+                )
+                import sys
+
+                sys.exit(1)
+
+
 def _write_config_file(config_file: str, new_content: str) -> bool:
     """Helper to write the configuration to a file securely."""
     if "\0" in config_file:
@@ -425,48 +478,7 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
         # We prioritize using the file descriptor (fchmod or chmod with FD) to prevent TOCTOU
         # vulnerabilities. Path-based chmod is only used as a final fallback on systems
         # that don't support FD-based permission changes (like some older Windows versions).
-        try:
-            os.fchmod(fd, 0o600)
-        except (AttributeError, OSError, NotImplementedError):
-            try:
-                # Some platforms support os.chmod(fd, mode)
-                os.chmod(fd, 0o600)
-            except (AttributeError, OSError, NotImplementedError, TypeError):
-                # Final fallback to path-based chmod with inode verification.
-                try:
-                    stat_fd = os.fstat(fd)
-                    config_path_str = str(config_path)
-                    stat_path = (
-                        os.lstat(config_path_str)
-                        if hasattr(os, "lstat")
-                        else os.stat(config_path_str)
-                    )
-                    if (
-                        stat_fd.st_ino == stat_path.st_ino
-                        and stat_fd.st_dev == stat_path.st_dev
-                    ):
-                        chmod_kwargs = (
-                            {"follow_symlinks": False}
-                            if os.chmod
-                            in getattr(os, "supports_follow_symlinks", set())
-                            else {}
-                        )
-                        os.chmod(config_path_str, 0o600, **chmod_kwargs)
-                    else:
-                        print(
-                            f"\n{Colors.colorize('✘ Error: TOCTOU detected on ', Colors.RED)}"
-                            f"{Colors.colorize(str(config_path), Colors.BOLD)}"
-                        )
-                        import sys
-
-                        sys.exit(1)
-                except OSError as exc:
-                    print(
-                        f"\n{Colors.colorize('✘ Error setting permissions: ' + str(exc), Colors.RED)}"
-                    )
-                    import sys
-
-                    sys.exit(1)
+        _apply_secure_permissions(fd, config_path)
 
         with os.fdopen(fd, "w") as f:
             f.write(new_content)


### PR DESCRIPTION
🎯 **What:** Extracted the deeply nested `try...except` fallback logic for file permissions out of `_write_config_file` and into a dedicated `_apply_secure_permissions` helper function.
💡 **Why:** `_write_config_file` suffered from the "Complex Function" code health issue. By extracting the complex TOCTOU and fallback mechanisms into a separate helper, the main `_write_config_file` logic is vastly cleaner, more readable, and easier to maintain.
✅ **Verification:** Verified by checking `git diff`, passing `flake8` checks (with black formatting), confirming specific unit tests in `tests/test_setup_wizard.py` still pass, testing the script manually with `test_script.py`, and ensuring the full test suite passes.
✨ **Result:** A significant reduction in cyclomatic complexity within `_write_config_file` while preserving its exact functionality and security safeguards.

---
*PR created automatically by Jules for task [7406053735219711690](https://jules.google.com/task/7406053735219711690) started by @abhimehro*