### PR TITLE
🧹 Extract mock email creation in multi-account tests

### DIFF
--- a/refactor_args.py
+++ b/refactor_args.py
@@ -1,0 +1,94 @@
+import re
+
+with open("tests/test_multi_account.py", "r") as f:
+    content = f.read()
+
+# Refactor the function definition
+old_def = r"    def _create_mock_email\(self, msg_id, subject, sender, recipient, account_email\):"
+new_def = "    def _create_mock_email(self, msg_id, **kwargs):"
+content = re.sub(old_def, new_def, content)
+
+old_return = r"""        return EmailData\(
+            message_id=msg_id,
+            subject=subject,
+            sender=sender,
+            recipient=recipient,
+            date=datetime\.now\(\),
+            body_text="Body",
+            body_html="",
+            headers=\{\},
+            attachments=\[\],
+            raw_email=MagicMock\(\),
+            account_email=account_email,
+            folder="INBOX",
+        \)"""
+new_return = """        return EmailData(
+            message_id=msg_id,
+            subject=kwargs.get("subject", ""),
+            sender=kwargs.get("sender", ""),
+            recipient=kwargs.get("recipient", ""),
+            date=datetime.now(),
+            body_text="Body",
+            body_html="",
+            headers={},
+            attachments=[],
+            raw_email=MagicMock(),
+            account_email=kwargs.get("account_email", ""),
+            folder="INBOX",
+        )"""
+content = re.sub(old_return, new_return, content)
+
+# Refactor email1 call site
+old_email1 = r"""        email1 = self\._create_mock_email\(
+            "email-1",
+            "Email from Account 1",
+            "sender1@example\.com",
+            "user1@example\.com",
+            "user1@example\.com",
+        \)"""
+new_email1 = """        email1 = self._create_mock_email(
+            "email-1",
+            subject="Email from Account 1",
+            sender="sender1@example.com",
+            recipient="user1@example.com",
+            account_email="user1@example.com",
+        )"""
+content = re.sub(old_email1, new_email1, content)
+
+# Refactor email2 call site
+old_email2 = r"""        email2 = self\._create_mock_email\(
+            "email-2",
+            "Email from Account 2",
+            "sender2@different\.com",
+            "user2@different\.com",
+            "user2@different\.com",
+        \)"""
+new_email2 = """        email2 = self._create_mock_email(
+            "email-2",
+            subject="Email from Account 2",
+            sender="sender2@different.com",
+            recipient="user2@different.com",
+            account_email="user2@different.com",
+        )"""
+content = re.sub(old_email2, new_email2, content)
+
+# Refactor many_emails call site
+old_many = r"""            self\._create_mock_email\(
+                f"email-\{i\}",
+                f"Email \{i\}",
+                "sender@example\.com",
+                "user1@example\.com",
+                "user1@example\.com",
+            \)"""
+new_many = """            self._create_mock_email(
+                f"email-{i}",
+                subject=f"Email {i}",
+                sender="sender@example.com",
+                recipient="user1@example.com",
+                account_email="user1@example.com",
+            )"""
+content = re.sub(old_many, new_many, content)
+
+
+with open("tests/test_multi_account.py", "w") as f:
+    f.write(content)

--- a/tests/test_multi_account.py
+++ b/tests/test_multi_account.py
@@ -60,6 +60,22 @@ class TestMultiAccountProcessing(unittest.TestCase):
             use_ssl=True,
         )
 
+    def _create_mock_email(self, msg_id, subject, sender, recipient, account_email):
+        return EmailData(
+            message_id=msg_id,
+            subject=subject,
+            sender=sender,
+            recipient=recipient,
+            date=datetime.now(),
+            body_text="Body",
+            body_html="",
+            headers={},
+            attachments=[],
+            raw_email=MagicMock(),
+            account_email=account_email,
+            folder="INBOX",
+        )
+
     def test_multiple_accounts_initialization(self):
         """
         SECURITY STORY: This tests proper initialization of multiple email accounts.
@@ -186,34 +202,20 @@ class TestMultiAccountProcessing(unittest.TestCase):
         )
 
         # Create mock emails tagged with their source account
-        email1 = EmailData(
-            message_id="email-1",
-            subject="Email from Account 1",
-            sender="sender1@example.com",
-            recipient="user1@example.com",
-            date=datetime.now(),
-            body_text="Body 1",
-            body_html="",
-            headers={},
-            attachments=[],
-            raw_email=MagicMock(),
-            account_email="user1@example.com",  # Tagged with account1
-            folder="INBOX",
+        email1 = self._create_mock_email(
+            "email-1",
+            "Email from Account 1",
+            "sender1@example.com",
+            "user1@example.com",
+            "user1@example.com",
         )
 
-        email2 = EmailData(
-            message_id="email-2",
-            subject="Email from Account 2",
-            sender="sender2@different.com",
-            recipient="user2@different.com",
-            date=datetime.now(),
-            body_text="Body 2",
-            body_html="",
-            headers={},
-            attachments=[],
-            raw_email=MagicMock(),
-            account_email="user2@different.com",  # Tagged with account2
-            folder="INBOX",
+        email2 = self._create_mock_email(
+            "email-2",
+            "Email from Account 2",
+            "sender2@different.com",
+            "user2@different.com",
+            "user2@different.com",
         )
 
         # Setup persistent mock clients
@@ -398,19 +400,12 @@ class TestMultiAccountProcessing(unittest.TestCase):
 
         # Create many mock emails for account1
         many_emails = [
-            EmailData(
-                message_id=f"email-{i}",
-                subject=f"Email {i}",
-                sender="sender@example.com",
-                recipient="user1@example.com",
-                date=datetime.now(),
-                body_text="Body",
-                body_html="",
-                headers={},
-                attachments=[],
-                raw_email=MagicMock(),
-                account_email="user1@example.com",
-                folder="INBOX",
+            self._create_mock_email(
+                f"email-{i}",
+                f"Email {i}",
+                "sender@example.com",
+                "user1@example.com",
+                "user1@example.com",
             )
             for i in range(100)  # 100 emails
         ]

--- a/tests/test_multi_account.py
+++ b/tests/test_multi_account.py
@@ -60,19 +60,19 @@ class TestMultiAccountProcessing(unittest.TestCase):
             use_ssl=True,
         )
 
-    def _create_mock_email(self, msg_id, subject, sender, recipient, account_email):
+    def _create_mock_email(self, msg_id, **kwargs):
         return EmailData(
             message_id=msg_id,
-            subject=subject,
-            sender=sender,
-            recipient=recipient,
+            subject=kwargs.get("subject", ""),
+            sender=kwargs.get("sender", ""),
+            recipient=kwargs.get("recipient", ""),
             date=datetime.now(),
             body_text="Body",
             body_html="",
             headers={},
             attachments=[],
             raw_email=MagicMock(),
-            account_email=account_email,
+            account_email=kwargs.get("account_email", ""),
             folder="INBOX",
         )
 
@@ -204,18 +204,18 @@ class TestMultiAccountProcessing(unittest.TestCase):
         # Create mock emails tagged with their source account
         email1 = self._create_mock_email(
             "email-1",
-            "Email from Account 1",
-            "sender1@example.com",
-            "user1@example.com",
-            "user1@example.com",
+            subject="Email from Account 1",
+            sender="sender1@example.com",
+            recipient="user1@example.com",
+            account_email="user1@example.com",
         )
 
         email2 = self._create_mock_email(
             "email-2",
-            "Email from Account 2",
-            "sender2@different.com",
-            "user2@different.com",
-            "user2@different.com",
+            subject="Email from Account 2",
+            sender="sender2@different.com",
+            recipient="user2@different.com",
+            account_email="user2@different.com",
         )
 
         # Setup persistent mock clients
@@ -402,10 +402,10 @@ class TestMultiAccountProcessing(unittest.TestCase):
         many_emails = [
             self._create_mock_email(
                 f"email-{i}",
-                f"Email {i}",
-                "sender@example.com",
-                "user1@example.com",
-                "user1@example.com",
+                subject=f"Email {i}",
+                sender="sender@example.com",
+                recipient="user1@example.com",
+                account_email="user1@example.com",
             )
             for i in range(100)  # 100 emails
         ]


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted repetitive `EmailData` mock creation logic into a shared `_create_mock_email` helper method within `TestMultiAccountProcessing`.

💡 **Why:** How this improves maintainability
The test file had significant code duplication when generating complex `EmailData` mock objects across multiple test functions (`test_cross_account_isolation` and `test_max_emails_per_account_limit`). By centralizing this logic into a helper method, the tests become more concise, easier to read, and less prone to inconsistencies. It also makes updating the `EmailData` structure in tests much simpler in the future.

✅ **Verification:** How you confirmed the change is safe
- Ran `python3 -m pytest tests/` to verify that the full test suite passes without regressions.
- Ran `flake8 tests/test_multi_account.py` to ensure no syntax errors or unused variables were introduced.
- Ran `black tests/test_multi_account.py` to ensure consistent formatting.
- Verified pre-commit hooks passed.

✨ **Result:** The improvement achieved
Reduced duplication and improved the clarity of the test suite, making `test_cross_account_isolation` and `test_max_emails_per_account_limit` much easier to read and maintain.

---
*PR created automatically by Jules for task [7684770888836015682](https://jules.google.com/task/7684770888836015682) started by @abhimehro*