### PR TITLE
🎨 Palette: Improve error styling in CLI output using heavy multiplication cross

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -108,7 +108,7 @@
 **Action:** Wrap the shutdown sequence in a visual loading state (like a spinner) to provide immediate feedback that cleanup is actively progressing, reducing user anxiety.
 
 ## 2025-02-15 - Cancellation Warning UX
-**Learning:** For user-initiated interruptions (like pressing Ctrl+C/KeyboardInterrupt), it's a better UX to use a warning indicator (e.g., ⚠️) and explicit "(Cancelled)" text instead of a failure indicator (e.g., ✘). This clearly differentiates cancellations from actual system errors, reducing user confusion.
+**Learning:** For user-initiated interruptions (like pressing Ctrl+C/KeyboardInterrupt), it's a better UX to use a warning indicator (e.g., ⚠️) and explicit "(Cancelled)" text instead of a failure indicator (e.g., ✖). This clearly differentiates cancellations from actual system errors, reducing user confusion.
 **Action:** Implemented this distinction in `src/utils/ui.py`'s `Spinner.__exit__`.
 
 ## 2025-02-15 - Consistent Input Prompt Styling
@@ -208,18 +208,18 @@
 **Learning:** Error paths and fallback instructions (like template creation failures) are often overlooked during UI polish passes, leading to unstyled output that breaks the overall visual consistency of the CLI.
 **Action:** When auditing CLI applications for UX, explicitly check error handling paths (`except` blocks) and fallback states (`else` branches of interactive prompts) to ensure that error messages are styled with `Colors.RED` and instructions are styled with `Colors.YELLOW`, maintaining visual hierarchy even during failures.
 ## 2025-06-25 - Consistency in Terminal Error Styling
-**Learning:** For CLI status indicators (like loading spinners), applying semantic color (like Red) only to the status symbol (✘) while leaving the final message unstyled breaks the visual hierarchy during error paths.
+**Learning:** For CLI status indicators (like loading spinners), applying semantic color (like Red) only to the status symbol (✖) while leaving the final message unstyled breaks the visual hierarchy during error paths.
 **Action:** Apply consistent semantic coloring to the entire final status message (e.g., Red for errors, Green for success, Yellow for warnings) to ensure plain-text default styling does not undermine the error state visualization.
 
 ## 2027-02-18 - Actionable Error Paths UX Consistency
-**Learning:** Consistently providing actionable instructions across all error/fallback paths, not just non-interactive ones, significantly improves user experience. In CLI tools, omitting these instructions in certain failure branches forces users to guess the next steps. Using consistent visual hierarchy (e.g. `✘` for errors, `Colors.CYAN` for commands) reduces cognitive load.
-**Action:** When auditing CLI fallback flows, extract the remediation output logic into reusable helpers to guarantee that whether a user skips a wizard, encounters a file write error, or runs non-interactively, they always receive the exact same visually-distinct actionable command (like `cp .env.example .env`). Ensure consistent `✘` prefixes on critical file operation errors.
+**Learning:** Consistently providing actionable instructions across all error/fallback paths, not just non-interactive ones, significantly improves user experience. In CLI tools, omitting these instructions in certain failure branches forces users to guess the next steps. Using consistent visual hierarchy (e.g. `✖` for errors, `Colors.CYAN` for commands) reduces cognitive load.
+**Action:** When auditing CLI fallback flows, extract the remediation output logic into reusable helpers to guarantee that whether a user skips a wizard, encounters a file write error, or runs non-interactively, they always receive the exact same visually-distinct actionable command (like `cp .env.example .env`). Ensure consistent `✖` prefixes on critical file operation errors.
 ## 2027-02-18 - Actionable Error Paths UX Consistency
-**Learning:** Consistently providing actionable instructions across all error/fallback paths, not just non-interactive ones, significantly improves user experience. In CLI tools, omitting these instructions in certain failure branches forces users to guess the next steps. Using consistent visual hierarchy (e.g. `✘` for errors, `Colors.CYAN` for commands) reduces cognitive load.
-**Action:** When auditing CLI fallback flows, extract the remediation output logic into reusable helpers to guarantee that whether a user skips a wizard, encounters a file write error, or runs non-interactively, they always receive the exact same visually-distinct actionable command (like `cp .env.example .env`). Ensure consistent `✘` prefixes on critical file operation errors.
+**Learning:** Consistently providing actionable instructions across all error/fallback paths, not just non-interactive ones, significantly improves user experience. In CLI tools, omitting these instructions in certain failure branches forces users to guess the next steps. Using consistent visual hierarchy (e.g. `✖` for errors, `Colors.CYAN` for commands) reduces cognitive load.
+**Action:** When auditing CLI fallback flows, extract the remediation output logic into reusable helpers to guarantee that whether a user skips a wizard, encounters a file write error, or runs non-interactively, they always receive the exact same visually-distinct actionable command (like `cp .env.example .env`). Ensure consistent `✖` prefixes on critical file operation errors.
 ## 2025-06-25 - Enhance Input Validation Error Styling
 **Learning:** In interactive CLI wizards, single-line error messages without actionable remediation advice often leave users stuck, and unstyled instructions blend into the error text.
-**Action:** Always format input validation errors by separating the error description (styled in `Colors.RED` with a `✘` prefix) from the actionable remediation advice (styled in `Colors.YELLOW`). This improves clarity and guides the user toward successful input.
+**Action:** Always format input validation errors by separating the error description (styled in `Colors.RED` with a `✖` prefix) from the actionable remediation advice (styled in `Colors.YELLOW`). This improves clarity and guides the user toward successful input.
 
 ## 2027-02-18 - Consolidate Loading State Text
 **Learning:** In CLI flows, printing a static status message (e.g., `print("Verifying...")`) followed immediately by instantiating a `Spinner` (e.g., `Spinner("Connecting...")`) for the actual async work creates visual stutter and terminal clutter. The user sees two similar messages back-to-back.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -54,7 +54,7 @@ class AppRunner:
         if "\0" in raw_config_file:
             print(
                 Colors.colorize(
-                    f"✘ Error: Invalid configuration file path '{raw_config_file}'.",
+                    f"✖ Error: Invalid configuration file path '{raw_config_file}'.",
                     Colors.RED,
                 )
             )
@@ -69,7 +69,7 @@ class AppRunner:
         except ValueError:
             print(
                 Colors.colorize(
-                    f"✘ Error: Configuration file path must stay within '{base_dir}'.",
+                    f"✖ Error: Configuration file path must stay within '{base_dir}'.",
                     Colors.RED,
                 )
             )
@@ -251,7 +251,7 @@ class AppRunner:
                         sys.exit(0)
                     except Exception as e:
                         print(
-                            Colors.colorize(f"✘ Error creating file: {e}", Colors.RED)
+                            Colors.colorize(f"✖ Error creating file: {e}", Colors.RED)
                         )
                         self._print_fallback_instructions()
                         sys.exit(1)
@@ -275,7 +275,7 @@ class AppRunner:
         # to honor the NoReturn type annotation and make the failure mode explicit.
         print(
             Colors.colorize(
-                f"✘ Configuration file '{self.config_file}' not found",
+                f"✖ Configuration file '{self.config_file}' not found",
                 Colors.RED,
             )
         )
@@ -306,7 +306,7 @@ class AppRunner:
                 print(
                     "\n"
                     + Colors.colorize(
-                        "✘ Configuration Error: Default credentials detected",
+                        "✖ Configuration Error: Default credentials detected",
                         Colors.RED,
                     )
                 )
@@ -377,7 +377,7 @@ class AppRunner:
                 self._create_config_from_template()
                 sys.exit(0)
             except Exception as e:
-                print(Colors.colorize(f"✘ Error creating file: {e}", Colors.RED))
+                print(Colors.colorize(f"✖ Error creating file: {e}", Colors.RED))
                 self._print_fallback_instructions()
                 sys.exit(1)
         else:

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -145,7 +145,7 @@ def _test_connection(email: str, app_password: str, provider_choice: str) -> boo
         # outside, we just print as before.
         error_msg = str(e).replace(app_password, "***") if app_password else str(e)
         print(
-            Colors.colorize(f"✘ Error during connection test: {error_msg}", Colors.RED)
+            Colors.colorize(f"✖ Error during connection test: {error_msg}", Colors.RED)
         )
         if provider_choice == "3":
             print(OUTLOOK_AUTH_ERROR_TIP)
@@ -192,7 +192,7 @@ def _select_provider() -> str:
             if choice in choices_map:
                 return choices_map[choice]
             print(
-                Colors.colorize("✘ Invalid choice. ", Colors.RED)
+                Colors.colorize("✖ Invalid choice. ", Colors.RED)
                 + Colors.colorize("Please enter a number (1-4) or provider name.", Colors.YELLOW)
             )
         except EOFError:
@@ -211,7 +211,7 @@ def _prompt_for_email(provider_name: str) -> str:
         email = _styled_input(prompt)
         if not email:
             print(
-                Colors.colorize("✘ Email is required. ", Colors.RED)
+                Colors.colorize("✖ Email is required. ", Colors.RED)
                 + Colors.colorize("Please provide an email address.", Colors.YELLOW)
             )
             continue
@@ -220,7 +220,7 @@ def _prompt_for_email(provider_name: str) -> str:
             return email
 
         print(
-            Colors.colorize("✘ Invalid email format. ", Colors.RED)
+            Colors.colorize("✖ Invalid email format. ", Colors.RED)
             + Colors.colorize(
                 "Please enter a valid email address (e.g., user@example.com).",
                 Colors.YELLOW,
@@ -287,7 +287,7 @@ def _prompt_for_password(provider_name: str) -> str:
     app_secret = _get_input()
     while not app_secret:
         print(
-            Colors.colorize("✘ Password is required. ", Colors.RED)
+            Colors.colorize("✖ Password is required. ", Colors.RED)
             + Colors.colorize("Please provide a password.", Colors.YELLOW)
         )
         app_secret = _get_input()
@@ -389,7 +389,7 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
     if "\0" in config_file:
         print(
             Colors.colorize(
-                f"✘ Error: Invalid configuration file path '{config_file}'.", Colors.RED
+                f"✖ Error: Invalid configuration file path '{config_file}'.", Colors.RED
             )
         )
         return False
@@ -404,7 +404,7 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
     ):
         print(
             Colors.colorize(
-                f"✘ Error: Unsafe configuration file path '{config_file}'. Use a filename only.",
+                f"✖ Error: Unsafe configuration file path '{config_file}'. Use a filename only.",
                 Colors.RED,
             )
         )
@@ -454,7 +454,7 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
                         os.chmod(config_path_str, 0o600, **chmod_kwargs)
                     else:
                         print(
-                            f"\n{Colors.colorize('✘ Error: TOCTOU detected on ', Colors.RED)}"
+                            f"\n{Colors.colorize('✖ Error: TOCTOU detected on ', Colors.RED)}"
                             f"{Colors.colorize(str(config_path), Colors.BOLD)}"
                         )
                         import sys
@@ -462,7 +462,7 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
                         sys.exit(1)
                 except OSError as exc:
                     print(
-                        f"\n{Colors.colorize('✘ Error setting permissions: ' + str(exc), Colors.RED)}"
+                        f"\n{Colors.colorize('✖ Error setting permissions: ' + str(exc), Colors.RED)}"
                     )
                     import sys
 
@@ -479,7 +479,7 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
         )
         return True
     except Exception as e:
-        print(Colors.colorize(f"✘ Error writing config: {e}", Colors.RED))
+        print(Colors.colorize(f"✖ Error writing config: {e}", Colors.RED))
         return False
 
 
@@ -494,7 +494,7 @@ def run_setup_wizard(
     if not Path(template_file).exists():
         print(
             Colors.colorize(
-                f"✘ Error: Template file '{template_file}' not found.", Colors.RED
+                f"✖ Error: Template file '{template_file}' not found.", Colors.RED
             )
         )
         return False
@@ -533,7 +533,7 @@ def run_setup_wizard(
             with open(template_file, "r") as f:
                 template_content = f.read()
         except Exception as e:
-            print(Colors.colorize(f"✘ Error reading template: {e}", Colors.RED))
+            print(Colors.colorize(f"✖ Error reading template: {e}", Colors.RED))
             return False
 
         # 4. Generate Config

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -212,7 +212,7 @@ class Spinner:
                 if self.fail_msg
                 else clean_msg
             )
-            return "✘", msg
+            return "✖", msg
 
         if self.success_msg:
             return "✔", self.success_msg.replace(
@@ -268,7 +268,7 @@ class Spinner:
         """Map symbols to their respective colors."""
         if symbol == "⚠":
             return Colors.YELLOW
-        if symbol == "✘":
+        if symbol == "✖":
             return Colors.RED
         if symbol == "✔":
             return Colors.GREEN

--- a/tests/test_ui_spinner.py
+++ b/tests/test_ui_spinner.py
@@ -47,7 +47,7 @@ class TestSpinner(unittest.TestCase):
 
         output = mock_stdout.getvalue()
         # Verify cross is present
-        self.assertIn("✘ Testing Failure", output)
+        self.assertIn("✖ Testing Failure", output)
 
     @patch("sys.stdout", new_callable=StringIO)
     def test_spinner_non_tty_basic_output(self, mock_stdout):
@@ -103,7 +103,7 @@ class TestSpinner(unittest.TestCase):
 
         output = mock_stdout.getvalue()
         # Verify failure cross message is present in non-TTY mode
-        self.assertIn("✘ Testing non TTY failure", output)
+        self.assertIn("✖ Testing non TTY failure", output)
         self.assertNotIn("\x1b[", output)
 
     @patch("sys.stdout", new_callable=StringIO)
@@ -130,7 +130,7 @@ class TestSpinner(unittest.TestCase):
 
         output = mock_stdout.getvalue()
         # Verify custom failure message is used
-        self.assertIn("✘ Failed!", output)
+        self.assertIn("✖ Failed!", output)
 
     @patch("sys.stdout", new_callable=StringIO)
     def test_spinner_custom_success_non_tty(self, mock_stdout):
@@ -157,7 +157,7 @@ class TestSpinner(unittest.TestCase):
 
         output = mock_stdout.getvalue()
         # Verify custom failure message is printed in non-TTY mode
-        self.assertIn("✘ Custom Failed!", output)
+        self.assertIn("✖ Custom Failed!", output)
         self.assertNotIn("\x1b[", output)
 
     @patch("sys.stdout")


### PR DESCRIPTION
💡 **What**: Replaced the ballot cross character `✘` with the heavy multiplication cross `✖` across all CLI output and error states in the application, including UI components, setup wizard, and app runner. Also updated `test_ui_spinner.py` and `.jules/palette.md` to reflect this change.

🎯 **Why**: The ballot cross (`✘`) can render inconsistently across different terminal emulators and OS environments (such as macOS), sometimes appearing as an uncontrollable double-width emoji. This breaks terminal alignment and ignores standard ANSI color codes (like `Colors.RED`). The heavy multiplication cross (`✖`) is standard text width and reliably accepts ANSI coloring, providing a much more robust and consistent UX during error states in the CLI.

📸 **Before/After**:
* Before: `✘ Error: Invalid configuration file path...` (Potentially misaligned or uncolored depending on terminal)
* After: `✖ Error: Invalid configuration file path...` (Consistently red and aligned text-width character)

♿ **Accessibility**: Improves terminal readability for users who may have been dealing with text alignment issues or uncolored error icons in constrained terminal setups.

---
*PR created automatically by Jules for task [11008916568612134514](https://jules.google.com/task/11008916568612134514) started by @abhimehro*