### PR TITLE
Fix password exposure in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -66,7 +66,18 @@ if [[ ${REPLY} =~ ^[Yy]$ ]]; then
 
 	# Update .env file (using OS-appropriate sed command)
 	${SED_CMD} "s|GMAIL_EMAIL=.*|GMAIL_EMAIL=${gmail_email}|" .env
-	${SED_CMD} "s|GMAIL_APP_PASSWORD=.*|GMAIL_APP_PASSWORD=${gmail_password}|" .env
+	# Create temporary file preserving permissions if possible, or just copy back
+	cp -p .env .env.tmp 2>/dev/null || touch .env.tmp
+	chmod 600 .env.tmp 2>/dev/null || true
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ $line == GMAIL_APP_PASSWORD=* ]]; then
+			echo "GMAIL_APP_PASSWORD=${gmail_password}"
+		else
+			echo "$line"
+		fi
+	done < .env > .env.tmp
+	cat .env.tmp > .env
+	rm -f .env.tmp
 	${SED_CMD} "s|GMAIL_ENABLED=.*|GMAIL_ENABLED=true|" .env
 
 	# Clear password from memory (basic security measure)


### PR DESCRIPTION
Fixes #1236

## Fix password exposure in setup.sh

### Daily QA Findings
* Verified repository health using `python3 -m pytest tests/` which completed successfully (668 passing tests).
* Identified an open issue #1236 regarding a P0 password exposure vulnerability in `setup.sh`.
* Replaced the vulnerable `sed` command in `setup.sh` with a secure Bash `while` loop that reads from and writes to a temporary file preserving permissions, preventing credential leakage in process arguments and potential script injection.

### Bash commands used
* `python3 -m pytest tests/` - Verified test suite
* `git diff HEAD setup.sh` - Verified code modifications

---
*PR created automatically by Jules for task [1678012141131856035](https://jules.google.com/task/1678012141131856035) started by @abhimehro*