### PR TITLE
🎨 Palette: Add actionable empty state for unconfigured accounts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -231,3 +231,7 @@
 ## 2024-05-18 - Visual Hierarchy for Terminal Validation Failures
 **Learning:** Terminal validation errors often blend together when the entire message is colored red. By prepending an uncolored heavy multiplication cross (✖) and separating the red error description from the yellow actionable remediation advice, we establish a much clearer visual hierarchy that reduces cognitive load.
 **Action:** Always format terminal error messages by placing the symbol outside the colorization block (e.g., `"✖ " + Colors.colorize("Error...", Colors.RED)`) to maintain distinct visual structure across different terminal emulators.
+
+## 2026-07-10 - Actionable Empty States
+**Learning:** When displaying an empty state or 'not configured' warning, users often lack context on how to resolve it. Adding a direct, actionable next step reduces friction.
+**Action:** Always pair empty states with a clear call-to-action or instruction.

--- a/src/main.py
+++ b/src/main.py
@@ -413,6 +413,7 @@ class EmailSecurityPipeline:
         print(f"  📧 {Colors.colorize('Monitored Accounts:', Colors.CYAN)}")
         if not self.config.email_accounts:
             print(f"    - {Colors.colorize('⚠ No accounts configured', Colors.YELLOW)}")
+            print(f"      {Colors.colorize('→ Add credentials to your .env file to start processing emails.', Colors.GREY)}")
         else:
             for account in self.config.email_accounts:
                 status = (


### PR DESCRIPTION
💡 What: Added an actionable call-to-action hint when no email accounts are configured in the CLI dashboard.
🎯 Why: Users previously only saw a warning without clear instructions on how to resolve the empty state. This reduces friction and improves the onboarding experience.
📸 Before/After: 
  - Before: `⚠ No accounts configured`
  - After: `⚠ No accounts configured` followed by `→ Add credentials to your .env file to start processing emails.`
♿ Accessibility: N/A - pure terminal output improvement.

---
*PR created automatically by Jules for task [2994171654361151709](https://jules.google.com/task/2994171654361151709) started by @abhimehro*