### PR TITLE
🎨 Palette: Add call-to-action to empty alert configuration

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -464,6 +464,7 @@ class EmailSecurityPipeline:
             print(
                 f"    - {Colors.colorize('⚠ No alert channels configured', Colors.YELLOW)}"
             )
+            print(f"      {Colors.colorize('→ Enable alerts in your .env file to receive notifications.', Colors.GREY)}")
 
         print(f"  ⚙️ {Colors.colorize('System:', Colors.CYAN)}")
         print(f"    - Log Level:  {self.config.system.log_level}")


### PR DESCRIPTION
💡 **What:** Added a clear, actionable instruction (`→ Enable alerts in your .env file to receive notifications.`) to the empty state output when no alert channels are configured.
🎯 **Why:** Previously, the CLI simply printed a warning (`⚠ No alert channels configured`). Adding a concrete call-to-action directly below it reduces user friction by explaining exactly *how* to resolve the warning, aligning with the pattern already used for missing email accounts.
📸 **Before/After:**
*Before:*
```
    - ⚠ No alert channels configured
```
*After:*
```
    - ⚠ No alert channels configured
      → Enable alerts in your .env file to receive notifications.
```
♿ **Accessibility:** Improves CLI UX by preventing dead ends and providing actionable next steps in a muted, non-distracting color (`Colors.GREY`).

---
*PR created automatically by Jules for task [2086029942027399247](https://jules.google.com/task/2086029942027399247) started by @abhimehro*