### PR TITLE
🧹 [code health] Remove unused annotations import in env_file_parser.py

### DIFF
--- a/src/utils/env_file_parser.py
+++ b/src/utils/env_file_parser.py
@@ -4,8 +4,6 @@ SECURITY: Never use shell ``source`` on env files (CWE-78). This module only
 extracts validated KEY=VALUE assignments.
 """
 
-from __future__ import annotations
-
 import re
 from pathlib import Path
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` line from `src/utils/env_file_parser.py`.

💡 **Why:** The `annotations` feature was imported but not required in this file (or the codebase supports PEP 563 behavior natively depending on the Python version), resulting in an unused import code health issue. Removing it cleans up the file and reduces clutter without impacting functionality.

✅ **Verification:** 
- Examined `src/utils/env_file_parser.py` and confirmed no explicit stringized annotations usage required it here.
- Ran the test suite using `python3 -m pytest tests/` which completed successfully with 677 passed tests, confirming no regressions.

✨ **Result:** A cleaner Python module compliant with standard code health practices.

---
*PR created automatically by Jules for task [17441769268256496403](https://jules.google.com/task/17441769268256496403) started by @abhimehro*