### PR TITLE
🧹 Refactor IMAPConnection.connect() to reduce complexity

### DIFF
--- a/src/modules/imap_connection.py
+++ b/src/modules/imap_connection.py
@@ -63,6 +63,26 @@ class IMAPConnection:
         self.connection: Optional[imaplib.IMAP4_SSL] = None
         self.logger = logging.getLogger(f"IMAPConnection.{config.provider}")
 
+    def _create_imap_client(self, context: ssl.SSLContext) -> imaplib.IMAP4:
+        """
+        Create and return the appropriate IMAP client.
+        """
+        if self.config.use_ssl:
+            return imaplib.IMAP4_SSL(
+                self.config.imap_server,
+                self.config.imap_port,
+                ssl_context=context,
+                timeout=30,  # SECURITY: Prevent indefinite hangs
+            )
+
+        client = imaplib.IMAP4(
+            self.config.imap_server,
+            self.config.imap_port,
+            timeout=30,  # SECURITY: Prevent indefinite hangs
+        )
+        client.starttls(ssl_context=context)
+        return client
+
     def connect(self) -> bool:
         """
         Establish connection to IMAP server with secure TLS.
@@ -84,20 +104,8 @@ class IMAPConnection:
             # Create secure SSL context (TLS 1.2+ enforced)
             context = create_secure_ssl_context()
 
-            if self.config.use_ssl:
-                self.connection = imaplib.IMAP4_SSL(
-                    self.config.imap_server,
-                    self.config.imap_port,
-                    ssl_context=context,
-                    timeout=30,  # SECURITY: Prevent indefinite hangs
-                )
-            else:
-                self.connection = imaplib.IMAP4(
-                    self.config.imap_server,
-                    self.config.imap_port,
-                    timeout=30,  # SECURITY: Prevent indefinite hangs
-                )
-                self.connection.starttls(ssl_context=context)
+            # Initialize client based on SSL configuration
+            self.connection = self._create_imap_client(context)
 
             # Authenticate
             self.connection.login(self.config.email, self.config.app_password)


### PR DESCRIPTION
🎯 **What:** Extracted the logic for creating the IMAP4 client and configuring TLS from the `IMAPConnection.connect()` method into a new `_create_imap_client(self, context)` helper method.

💡 **Why:** The `connect()` method was flagged for being complex as it handled SSL setup, authentication, and error/hint extraction all in a single method. By extracting the client creation, the `connect()` method is easier to read and maintain, while preserving the existing security constraints (e.g. 30-second timeout, TLS configuration).

✅ **Verification:** Verified by checking `git diff`, ensuring the cyclomatic complexity dropped via `radon` (Average complexity is now `A`), and running the full test suite (`python3 -m pytest tests/`), which passed successfully.

✨ **Result:** The code health issue (Complex Function) is resolved. The logic is identical but better encapsulated, improving long-term maintainability.

---
*PR created automatically by Jules for task [16736662407726453117](https://jules.google.com/task/16736662407726453117) started by @abhimehro*