### PR TITLE
🧹 [Code Health] Remove unused concurrent.futures import in media_analyzer

### DIFF
--- a/src/modules/media_analyzer.py
+++ b/src/modules/media_analyzer.py
@@ -3,7 +3,6 @@ Layer 3: Media Authenticity Verification
 Analyzes attachments for synthetic content and deepfakes.
 """
 
-import concurrent.futures
 import io
 import logging
 import os
@@ -257,7 +256,7 @@ class MediaAuthenticityAnalyzer:
         potential_deepfakes = []
 
         # Optimization: Use ThreadPoolExecutor to process attachments concurrently.
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor() as executor:
             # We use a mutable list to track if the threshold has been crossed globally.
             # Because of the GIL, list operations are thread-safe enough for this heuristic check.
             shared_state = {"stop_deepfake": False}


### PR DESCRIPTION
🎯 **What:** Removed the redundant `import concurrent.futures` from `src/modules/media_analyzer.py` and updated the usage to the explicitly imported `ThreadPoolExecutor`.

💡 **Why:** `ThreadPoolExecutor` is already explicitly imported from `concurrent.futures` on line 13. Removing the unused module-level import cleans up the file header, improves readability, and avoids linter warnings about unused imports without changing any runtime behavior.

✅ **Verification:**
- Ran `git diff` to confirm only the intended import removal and `ThreadPoolExecutor` update occurred.
- Ran `python3 -m pytest tests/` to confirm all 677 unit tests continue to pass.
- Code review passed without issues.

✨ **Result:** A cleaner import block with no redundant dependencies in the module header.

---
*PR created automatically by Jules for task [3436126504468261649](https://jules.google.com/task/3436126504468261649) started by @abhimehro*