### PR TITLE
🧹 [Refactor] Extract helpers to reduce complexity of _write_config_file

### DIFF
--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -384,16 +384,14 @@ def _generate_config_content(
     return content
 
 
-def _write_config_file(config_file: str, new_content: str) -> bool:
-    """Helper to write the configuration to a file securely."""
+def _validate_config_path(config_file: str) -> Path | None:
+    """Validate the configuration file path securely."""
     if "\0" in config_file:
         print(
             "✖ " + Colors.colorize(f"Error: Invalid configuration file path '{config_file}'.", Colors.RED)
         )
-        return False
+        return None
 
-    # Restrict writes to files in the current working directory by accepting
-    # only a plain filename (no directory components).
     candidate_name = Path(config_file).name
     if (
         not candidate_name
@@ -403,9 +401,62 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
         print(
             "✖ " + Colors.colorize(f"Error: Unsafe configuration file path '{config_file}'. Use a filename only.", Colors.RED)
         )
-        return False
+        return None
 
-    config_path = (Path.cwd() / candidate_name).resolve()
+    return (Path.cwd() / candidate_name).resolve()
+
+
+def _set_file_permissions(fd: int, config_path: Path) -> None:
+    """Set file permissions securely to prevent TOCTOU vulnerabilities."""
+    try:
+        os.fchmod(fd, 0o600)
+    except (AttributeError, OSError, NotImplementedError):
+        try:
+            # Some platforms support os.chmod(fd, mode)
+            os.chmod(fd, 0o600)
+        except (AttributeError, OSError, NotImplementedError, TypeError):
+            # Final fallback to path-based chmod with inode verification.
+            try:
+                stat_fd = os.fstat(fd)
+                config_path_str = str(config_path)
+                stat_path = (
+                    os.lstat(config_path_str)
+                    if hasattr(os, "lstat")
+                    else os.stat(config_path_str)
+                )
+                if (
+                    stat_fd.st_ino == stat_path.st_ino
+                    and stat_fd.st_dev == stat_path.st_dev
+                ):
+                    chmod_kwargs = (
+                        {"follow_symlinks": False}
+                        if os.chmod
+                        in getattr(os, "supports_follow_symlinks", set())
+                        else {}
+                    )
+                    os.chmod(config_path_str, 0o600, **chmod_kwargs)
+                else:
+                    print(
+                        f"\n✖ {Colors.colorize('Error: TOCTOU detected on ', Colors.RED)}"
+                        f"{Colors.colorize(str(config_path), Colors.BOLD)}"
+                    )
+                    import sys
+
+                    sys.exit(1)
+            except OSError as exc:
+                print(
+                    f"\n✖ {Colors.colorize('Error setting permissions: ' + str(exc), Colors.RED)}"
+                )
+                import sys
+
+                sys.exit(1)
+
+
+def _write_config_file(config_file: str, new_content: str) -> bool:
+    """Helper to write the configuration to a file securely."""
+    config_path = _validate_config_path(config_file)
+    if not config_path:
+        return False
 
     try:
         # Create file with restrictive permissions (600)
@@ -420,48 +471,7 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
         # We prioritize using the file descriptor (fchmod or chmod with FD) to prevent TOCTOU
         # vulnerabilities. Path-based chmod is only used as a final fallback on systems
         # that don't support FD-based permission changes (like some older Windows versions).
-        try:
-            os.fchmod(fd, 0o600)
-        except (AttributeError, OSError, NotImplementedError):
-            try:
-                # Some platforms support os.chmod(fd, mode)
-                os.chmod(fd, 0o600)
-            except (AttributeError, OSError, NotImplementedError, TypeError):
-                # Final fallback to path-based chmod with inode verification.
-                try:
-                    stat_fd = os.fstat(fd)
-                    config_path_str = str(config_path)
-                    stat_path = (
-                        os.lstat(config_path_str)
-                        if hasattr(os, "lstat")
-                        else os.stat(config_path_str)
-                    )
-                    if (
-                        stat_fd.st_ino == stat_path.st_ino
-                        and stat_fd.st_dev == stat_path.st_dev
-                    ):
-                        chmod_kwargs = (
-                            {"follow_symlinks": False}
-                            if os.chmod
-                            in getattr(os, "supports_follow_symlinks", set())
-                            else {}
-                        )
-                        os.chmod(config_path_str, 0o600, **chmod_kwargs)
-                    else:
-                        print(
-                            f"\n✖ {Colors.colorize('Error: TOCTOU detected on ', Colors.RED)}"
-                            f"{Colors.colorize(str(config_path), Colors.BOLD)}"
-                        )
-                        import sys
-
-                        sys.exit(1)
-                except OSError as exc:
-                    print(
-                        f"\n✖ {Colors.colorize('Error setting permissions: ' + str(exc), Colors.RED)}"
-                    )
-                    import sys
-
-                    sys.exit(1)
+        _set_file_permissions(fd, config_path)
 
         with os.fdopen(fd, "w") as f:
             f.write(new_content)

--- a/submission.md
+++ b/submission.md
@@ -1,0 +1,4 @@
+🎯 **What:** Extracted configuration path validation and permissions setup logic from `_write_config_file` into separate helper functions (`_validate_config_path` and `_set_file_permissions`).
+💡 **Why:** Reduces the cyclomatic complexity of `_write_config_file` (now Grade A as measured by `radon`), improving readability and separating concerns. Validation and side effects (file system permissioning) are better encapsulated.
+✅ **Verification:** Verified that original file restriction semantics (TOCTOU prevention, 0o600 file permissions) were perfectly preserved. The unit test suite (`pytest`) continues to pass cleanly.
+✨ **Result:** A more maintainable and easily reviewable setup script.


### PR DESCRIPTION
🎯 **What:** Extracted configuration path validation and permissions setup logic from `_write_config_file` into separate helper functions (`_validate_config_path` and `_set_file_permissions`).
💡 **Why:** Reduces the cyclomatic complexity of `_write_config_file` (now Grade A as measured by `radon`), improving readability and separating concerns. Validation and side effects (file system permissioning) are better encapsulated.
✅ **Verification:** Verified that original file restriction semantics (TOCTOU prevention, 0o600 file permissions) were perfectly preserved. The unit test suite (`pytest`) continues to pass cleanly.
✨ **Result:** A more maintainable and easily reviewable setup script.

---
*PR created automatically by Jules for task [5194656249580138762](https://jules.google.com/task/5194656249580138762) started by @abhimehro*