### PR TITLE
🧪 Add comprehensive schema validation test for Metrics.get_summary

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -198,5 +198,50 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(self.metrics.processing_time_ms[-1], 1499.0)
 
 
+    def test_get_summary_format(self):
+        """Test that get_summary returns the expected dictionary format."""
+        # Add some data to ensure processing_time_stats is populated
+        self.metrics.record_email_processed()
+        self.metrics.record_threat("spam", "low")
+        self.metrics.record_processing_time(150.0)
+        self.metrics.record_error("timeout")
+
+        summary = self.metrics.get_summary()
+
+        # Check top-level keys
+        expected_keys = {
+            "uptime_seconds",
+            "emails_processed",
+            "threats_detected",
+            "processing_time_stats",
+            "errors",
+            "sample_count"
+        }
+        self.assertEqual(set(summary.keys()), expected_keys)
+
+        # Check types
+        self.assertIsInstance(summary["uptime_seconds"], float)
+        self.assertIsInstance(summary["emails_processed"], int)
+        self.assertIsInstance(summary["threats_detected"], dict)
+        self.assertIsInstance(summary["processing_time_stats"], dict)
+        self.assertIsInstance(summary["errors"], dict)
+        self.assertIsInstance(summary["sample_count"], int)
+
+        # Check nested stats keys
+        expected_stats_keys = {
+            "avg_ms",
+            "min_ms",
+            "max_ms",
+            "p50_ms",
+            "p95_ms",
+            "p99_ms"
+        }
+        self.assertEqual(set(summary["processing_time_stats"].keys()), expected_stats_keys)
+
+        # Check nested stats types
+        for key in expected_stats_keys:
+            self.assertIsInstance(summary["processing_time_stats"][key], float)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added a comprehensive schema validation test for `Metrics.get_summary` in `tests/test_metrics.py`. Although code coverage for `src/utils/metrics.py` was already 100%, the explicit schema and types of the dictionary returned by `get_summary` were not being strictly validated in a single comprehensive test.

📊 **Coverage:** The new `test_get_summary_format` method fully covers the dictionary keys and checks the exact type returned for all expected keys, including nested `processing_time_stats` dictionary values.

✨ **Result:** Increased test reliability by ensuring future changes to `get_summary` that affect the returned dictionary schema or types will properly fail the test suite, fulfilling the issue's goal.

---
*PR created automatically by Jules for task [15994741566906739487](https://jules.google.com/task/15994741566906739487) started by @abhimehro*