### PR TITLE
Add test for simple_master_pattern search vs match gate bug

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,17 @@
+# ELIR Handoff
+
+**Purpose:**
+Added a test `test_gate_uses_search_not_match` inside `TestScanTextPatternsTwoPhase` in `tests/test_nlp_scan_text_patterns.py` to prevent regression bugs related to regex match vs search.
+
+**Security:**
+Guards against a "silent failure" threat scenario where the `simple_master_pattern` gate uses `.match()` instead of `.search()`, which would skip pattern detection if threats appear mid-string instead of exactly at the beginning.
+
+**Failure Modes:**
+If the gate mistakenly changes to `.match()`, this test will immediately fail, signaling the regression before deployment.
+
+**Review Checklist:**
+*   Verify the test strings start with neutral words before the keyword (e.g. `However, verify your account right now!`).
+*   Verify `assertGreater` targets the correct key in the `matches` dictionary to assert detection.
+
+**Maintenance:**
+If new keywords are added or patterns are restructured, make sure this `test_gate_uses_search_not_match` explicitly tests an active pattern. Currently, it tests for `verify your account` (`SE` pattern).

--- a/tests/test_nlp_scan_text_patterns.py
+++ b/tests/test_nlp_scan_text_patterns.py
@@ -164,6 +164,19 @@ class TestScanTextPatternsCategories(_BaseNLPScanTest):
 class TestScanTextPatternsTwoPhase(_BaseNLPScanTest):
     """Confirms that the fast simple_master_pattern gate short-circuits correctly."""
 
+
+    def test_gate_uses_search_not_match(self):
+        # SECURITY STORY: The simple_master_pattern gate must use .search(), not .match().
+        # If it used .match(), it would only find keywords at the very beginning of the string,
+        # silently dropping threats buried mid-paragraph.
+        text = "This is a normal sentence. However, verify your account right now!"
+        matches, _, _ = self.analyzer._scan_text_patterns([text])
+        self.assertGreater(
+            len(matches["SE"]),
+            0,
+            "Gate failed to detect mid-string pattern (regression: using match instead of search)"
+        )
+
     def test_neutral_text_bypasses_named_group_scan(self):
         # None of the 20 patterns appear in this text.
         # simple_master_pattern.search() must return None →


### PR DESCRIPTION
Added a test `test_gate_uses_search_not_match` inside `TestScanTextPatternsTwoPhase` in `tests/test_nlp_scan_text_patterns.py` to prevent regression bugs related to regex match vs search. 

Guards against a "silent failure" threat scenario where the `simple_master_pattern` gate uses `.match()` instead of `.search()`, which would skip pattern detection if threats appear mid-string instead of exactly at the beginning. If the gate mistakenly changes to `.match()`, this test will immediately fail, signaling the regression before deployment.

Review Checklist:
*   Verify the test strings start with neutral words before the keyword (e.g. `However, verify your account right now!`).
*   Verify `assertGreater` targets the correct key in the `matches` dictionary to assert detection.

---
*PR created automatically by Jules for task [2943804061498421506](https://jules.google.com/task/2943804061498421506) started by @abhimehro*