### PR TITLE
🧪 Add test coverage for negative and large attachment limits in calculate_max_email_size

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,6 @@
+══════════ ELIR ══════════
+PURPOSE: Added test cases for `calculate_max_email_size` to cover edge conditions (negative and very large attachment limits).
+SECURITY: Ensures the fallback default logic works for negative limits, and verifies overhead is still applied correctly to extreme inputs without crashing.
+FAILS IF: The implementation of `calculate_max_email_size` is altered to not use `DEFAULT_MAX_EMAIL_SIZE` for negative numbers, or if it stops handling massive limits.
+VERIFY: The tests passed and added coverage. Check CI to ensure regressions aren't introduced.
+MAINTAIN: Keep the test cases aligned with the implementation variables `DEFAULT_MAX_EMAIL_SIZE` and `_OVERHEAD_BYTES`.

--- a/tests/test_security_validators_dos.py
+++ b/tests/test_security_validators_dos.py
@@ -52,6 +52,14 @@ class TestCalculateMaxEmailSize(unittest.TestCase):
         ten_mb = 10 * 1024 * 1024
         self.assertEqual(calculate_max_email_size(ten_mb), ten_mb + _OVERHEAD_BYTES)
 
+    def test_negative_attachment_limit_returns_default(self):
+        self.assertEqual(calculate_max_email_size(-1024), DEFAULT_MAX_EMAIL_SIZE)
+
+    def test_very_large_attachment_limit_adds_overhead(self):
+        large_limit = 100 * 1024 * 1024 * 1024 # 100 GB
+        self.assertEqual(calculate_max_email_size(large_limit), large_limit + _OVERHEAD_BYTES)
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added tests for the public function `calculate_max_email_size` to ensure it correctly handles negative and large attachment limits.

📊 **Coverage:** Added test cases for a negative limit (should return `DEFAULT_MAX_EMAIL_SIZE`) and a 100GB limit (verifying overhead is still applied correctly without overflow).

✨ **Result:** Improved test coverage for `calculate_max_email_size` and enhanced confidence in the email size calculations.

---
*PR created automatically by Jules for task [11887361312235905067](https://jules.google.com/task/11887361312235905067) started by @abhimehro*