### PR TITLE
🧪 Add test for print_help in AppRunner

### DIFF
--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -1,3 +1,4 @@
+import io
 import signal
 from unittest.mock import MagicMock, patch
 
@@ -307,3 +308,14 @@ def test_styled_input_keyboard_interrupt(
     mock_print.assert_called_once_with()
     mock_write.assert_called_once_with("[RESET]")
     mock_flush.assert_called_once()
+
+@patch("sys.stdout", new_callable=io.StringIO)
+def test_print_help(mock_stdout, mock_app_runner):
+    mock_app_runner.print_help()
+    output = mock_stdout.getvalue()
+    assert "Usage:" in output
+    assert "python src/main.py [CONFIG_FILE]" in output
+    assert "Arguments:" in output
+    assert "CONFIG_FILE    Path to the environment configuration file (default: .env)" in output
+    assert "Options:" in output
+    assert "-h, --help     Show this help message and exit" in output


### PR DESCRIPTION
🎯 **What:** The `print_help` function in `AppRunner` was previously untested. This PR adds a test case to cover this function.
📊 **Coverage:** Captures `sys.stdout` and verifies that the `Usage`, `Arguments`, and `Options` help text blocks are printed correctly.
✨ **Result:** Increased test coverage for `tests/test_app_runner.py` and the `AppRunner` class, ensuring the CLI help command works correctly without regressions.

---
*PR created automatically by Jules for task [12163534762063994017](https://jules.google.com/task/12163534762063994017) started by @abhimehro*