### PR TITLE
🧪 [testing improvement] Add more boundary cases for validate_subject_length

### DIFF
--- a/tests/test_security_validators_dos.py
+++ b/tests/test_security_validators_dos.py
@@ -29,6 +29,24 @@ class TestValidateSubjectLength(unittest.TestCase):
         self.assertEqual(len(result), MAX_SUBJECT_LENGTH)
         self.assertEqual(result, "B" * MAX_SUBJECT_LENGTH)
 
+    def test_subject_one_under_limit_returned_unchanged(self):
+        subject = "D" * (MAX_SUBJECT_LENGTH - 1)
+        self.assertEqual(validate_subject_length(subject), subject)
+
+    def test_empty_subject_returned_unchanged(self):
+        subject = ""
+        self.assertEqual(validate_subject_length(subject), subject)
+
+    def test_unicode_subject_at_exact_limit_returned_unchanged(self):
+        subject = "é" * MAX_SUBJECT_LENGTH
+        self.assertEqual(validate_subject_length(subject), subject)
+
+    def test_unicode_subject_one_over_limit_is_truncated(self):
+        subject = "🚀" * (MAX_SUBJECT_LENGTH + 1)
+        result = validate_subject_length(subject)
+        self.assertEqual(len(result), MAX_SUBJECT_LENGTH)
+        self.assertEqual(result, "🚀" * MAX_SUBJECT_LENGTH)
+
     def test_very_long_subject_is_truncated(self):
         subject = "C" * (MAX_SUBJECT_LENGTH * 10)
         result = validate_subject_length(subject)


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap in `validate_subject_length` by adding missing edge case tests. Specifically, it tests the boundary conditions one character below the limit and an empty subject. Furthermore, it adds test cases using unicode characters to ensure the truncation logic correctly handles character counts rather than byte sizes for multibyte strings.

📊 **Coverage:**
The following scenarios are now tested:
- Subject length exactly at `MAX_SUBJECT_LENGTH - 1` (one under the limit)
- Empty subject string `""`
- Unicode subject length exactly at `MAX_SUBJECT_LENGTH`
- Unicode subject length exactly at `MAX_SUBJECT_LENGTH + 1` (one over the limit, resulting in proper character truncation)

✨ **Result:** Increased test coverage for `validate_subject_length` and guaranteed reliability of the string truncation logic, regardless of character encoding.

---
*PR created automatically by Jules for task [3986877865207822076](https://jules.google.com/task/3986877865207822076) started by @abhimehro*