### PR TITLE
🧪 Add missing empty list tests and fix empty compilation bug

### DIFF
--- a/src/utils/pattern_compiler.py
+++ b/src/utils/pattern_compiler.py
@@ -86,6 +86,8 @@ def compile_patterns(
     """
     if validate_redos:
         check_redos_safety(patterns)
+    if not patterns:
+        return re.compile(r"(?!)", flags)
     parts = [f"(?:{p})" for p in patterns]
     return re.compile("|".join(parts), flags)
 
@@ -119,6 +121,8 @@ def compile_named_group_pattern(
     """
     if validate_redos:
         check_redos_safety(patterns)
+    if not patterns:
+        return re.compile(r"(?!)", flags), {}
     parts: List[str] = []
     group_map: Dict[str, str] = {}
     for i, p in enumerate(patterns):

--- a/tests/test_pattern_compiler.py
+++ b/tests/test_pattern_compiler.py
@@ -26,6 +26,10 @@ from src.utils.pattern_compiler import (
 
 
 class TestCheckRedosSafety:
+    def test_empty_list_passes(self):
+        """An empty list should not raise."""
+        check_redos_safety([])  # must not raise
+
     def test_safe_patterns_pass(self):
         """Common email-analysis patterns should not raise."""
         safe = [
@@ -92,9 +96,9 @@ class TestCompilePatterns:
     def test_empty_list_compiles_to_empty_alternation(self):
         """An empty list should not raise; the resulting pattern matches nothing."""
         pat = compile_patterns([])
-        # re.compile("") matches everything; an empty join also matches ""
-        # The key thing is it must not raise.
         assert isinstance(pat, re.Pattern)
+        assert pat.search("anything") is None
+        assert pat.search("") is None
 
     def test_validate_redos_raises_on_unsafe_pattern(self):
         with pytest.raises(ValueError, match="Potential ReDoS"):
@@ -153,6 +157,15 @@ class TestCompileNamedGroupPattern:
     def test_case_insensitive_by_default(self):
         pat, _ = compile_named_group_pattern([r"\bphishing\b"])
         assert pat.search("PHISHING attempt detected")
+
+
+    def test_empty_list_compiles_to_empty_pattern(self):
+        """An empty list should not raise and produces a pattern that matches nothing."""
+        pat, group_map = compile_named_group_pattern([])
+        assert isinstance(pat, re.Pattern)
+        assert group_map == {}
+        assert pat.search("anything") is None
+        assert pat.search("") is None
 
     def test_validate_redos_raises(self):
         with pytest.raises(ValueError, match="Potential ReDoS"):


### PR DESCRIPTION
🎯 **What:** 
The issue requested an edge case test for handling an empty pattern list in the pattern compiler. While testing, a significant logic bug was discovered: passing an empty list resulted in `re.compile("")`, which silently matches *every* string. The implementation was updated to return `re.compile(r"(?!)")` (an unmatchable regex using negative lookahead) when an empty list is passed, ensuring it safely matches nothing. 

📊 **Coverage:** 
- Added `test_empty_list_passes` to `TestCheckRedosSafety` to ensure empty lists don't trigger the ReDoS safety check.
- Added `test_empty_list_compiles_to_empty_pattern` to `TestCompileNamedGroupPattern` to verify it handles empty lists correctly.
- Updated `test_empty_list_compiles_to_empty_alternation` in `TestCompilePatterns` to assert that the compiled pattern actually matches nothing.

✨ **Result:** 
The pattern compiler is now robust against empty pattern lists, preventing potential false-positive logic errors throughout the application by safely returning a regex that matches nothing.

---
*PR created automatically by Jules for task [9561259088958602337](https://jules.google.com/task/9561259088958602337) started by @abhimehro*