### PR TITLE
Draft: Salvage #1279 email size boundary tests

### DIFF
--- a/tests/test_security_validators_dos.py
+++ b/tests/test_security_validators_dos.py
@@ -70,6 +70,16 @@ class TestCalculateMaxEmailSize(unittest.TestCase):
         ten_mb = 10 * 1024 * 1024
         self.assertEqual(calculate_max_email_size(ten_mb), ten_mb + _OVERHEAD_BYTES)
 
+    def test_negative_attachment_limit_returns_default(self):
+        self.assertEqual(calculate_max_email_size(-1024), DEFAULT_MAX_EMAIL_SIZE)
+
+    def test_very_large_attachment_limit_adds_overhead(self):
+        large_limit = 100 * 1024 * 1024 * 1024  # 100 GB
+        self.assertEqual(
+            calculate_max_email_size(large_limit),
+            large_limit + _OVERHEAD_BYTES,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Adds focused boundary tests for calculate_max_email_size negative and very large attachment limits.

Closes #1279

---

## Type of Change
- [x] `test` – test additions or improvements

---

## What Changed and Why
### ELIR
- Evidence: Salvages only the test coverage from #1279 and drops handoff.md.
- Lineage: Supersedes #1279.
- Implementation: Adds default fallback coverage for negative limits and overhead coverage for a 100 GB limit.
- Risk: Low; test-only change.

---

## How Was This Tested?
- [x] `python3 -m pytest tests/test_security_validators_dos.py -q` passes locally (13 passed).
- [ ] `pre-commit run --all-files` passes locally

---

## Security Implications
- [x] No secrets or credentials are introduced or exposed by this change
- Security notes: Test-only boundary coverage.

---

## Checklist
- [ ] Branch follows naming convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages are clear and descriptive
- [x] New or modified code includes relevant tests
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Documentation updated if behaviour changed (README, docstrings, etc.)
- [x] No secrets, credentials, or `.env` files are included in this PR
