### PR TITLE
Draft: Salvage #1278 GhTokenCli EnvParseError test

### DIFF
--- a/tests/test_gh_token_env.py
+++ b/tests/test_gh_token_env.py
@@ -6,7 +6,8 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stderr
+from io import StringIO
 from pathlib import Path
 from typing import Iterator
 
@@ -20,6 +21,7 @@ SECURE_AUTOMATION_SCRIPTS = (
 )
 
 from src.utils.env_file_parser import EnvParseError, parse_env_file
+from src.utils.gh_token_cli import main as cli_main
 
 
 @contextmanager
@@ -72,6 +74,14 @@ class TestGhTokenEnvParser(unittest.TestCase):
             )
             self.assertNotEqual(proc.returncode, 0)
             self.assertFalse(marker.exists())
+
+    def test_cli_main_handles_env_parse_error(self) -> None:
+        with temporary_env_file("INVALID LINE\n") as path:
+            with redirect_stderr(StringIO()) as stderr:
+                ret_code = cli_main([str(path)])
+
+        self.assertEqual(ret_code, 1)
+        self.assertIn("error:", stderr.getvalue())
 
 
 class TestAutomationScripts(unittest.TestCase):


### PR DESCRIPTION
## Summary
Adds the isolated GhTokenCli EnvParseError regression test from #1278.

Closes #1278

---

## Type of Change
- [x] `test` – test additions or improvements

---

## What Changed and Why
### ELIR
- Evidence: Salvages only the GhTokenCli EnvParseError test from #1278.
- Lineage: Supersedes #1278; workflow, pre-commit, and journal changes were excluded.
- Implementation: Calls cli_main with an invalid env file and asserts a failure return with stderr error output.
- Risk: Low; test-only change.

---

## How Was This Tested?
- [x] `python3 -m pytest tests/test_gh_token_env.py -q` passes locally (9 passed, 2 subtests passed).
- [ ] `pre-commit run --all-files` passes locally

---

## Security Implications
- [x] No secrets or credentials are introduced or exposed by this change
- Security notes: Test-only parsing regression coverage.

---

## Checklist
- [ ] Branch follows naming convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages are clear and descriptive
- [x] New or modified code includes relevant tests
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Documentation updated if behaviour changed (README, docstrings, etc.)
- [x] No secrets, credentials, or `.env` files are included in this PR
