### PR TITLE
Draft: Salvage #1284 setup wizard helper extraction

### DIFF
--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -488,6 +488,39 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
         return False
 
 
+def _print_welcome() -> None:
+    """Print the setup wizard introduction."""
+    print(
+        "\n"
+        + Colors.colorize(
+            "🧙 Welcome to the Email Security Pipeline Setup Wizard! 🧙", Colors.BOLD
+        )
+    )
+    print(
+        Colors.colorize("Let's get your environment configured quickly.", Colors.GREY)
+    )
+    print(Colors.colorize("(Press Ctrl+C at any time to cancel setup)", Colors.GREY))
+
+
+def _read_template(template_file: str) -> str | None:
+    """Read the environment template content."""
+    try:
+        with open(template_file, "r") as f:
+            return f.read()
+    except Exception as e:
+        print("✖ " + Colors.colorize(f"Error reading template: {e}", Colors.RED))
+        return None
+
+
+def _print_next_steps(config_file: str) -> None:
+    """Print post-wizard instructions."""
+    print("\n" + Colors.colorize("Next Steps:", Colors.BOLD))
+    print(
+        f"1. Review {Colors.colorize(config_file, Colors.BOLD)} to ensure settings are correct."
+    )
+    print(f"2. Run the pipeline: {Colors.colorize('python src/main.py', Colors.CYAN)}")
+
+
 def run_setup_wizard(
     config_file: str = ".env", template_file: str = ".env.example"
 ) -> bool:
@@ -502,16 +535,7 @@ def run_setup_wizard(
         )
         return False
 
-    print(
-        "\n"
-        + Colors.colorize(
-            "🧙 Welcome to the Email Security Pipeline Setup Wizard! 🧙", Colors.BOLD
-        )
-    )
-    print(
-        Colors.colorize("Let's get your environment configured quickly.", Colors.GREY)
-    )
-    print(Colors.colorize("(Press Ctrl+C at any time to cancel setup)", Colors.GREY))
+    _print_welcome()
 
     try:
         # 1. Select Provider
@@ -532,11 +556,8 @@ def run_setup_wizard(
             return False
 
         # 3. Read Template
-        try:
-            with open(template_file, "r") as f:
-                template_content = f.read()
-        except Exception as e:
-            print("✖ " + Colors.colorize(f"Error reading template: {e}", Colors.RED))
+        template_content = _read_template(template_file)
+        if template_content is None:
             return False
 
         # 4. Generate Config
@@ -548,13 +569,7 @@ def run_setup_wizard(
         if not _write_config_file(config_file, new_content):
             return False
 
-        print("\n" + Colors.colorize("Next Steps:", Colors.BOLD))
-        print(
-            f"1. Review {Colors.colorize(config_file, Colors.BOLD)} to ensure settings are correct."
-        )
-        print(
-            f"2. Run the pipeline: {Colors.colorize('python src/main.py', Colors.CYAN)}"
-        )
+        _print_next_steps(config_file)
 
         return True
 


### PR DESCRIPTION
## Summary
Extracts focused run_setup_wizard helper functions to reduce the wizard's inline complexity without overlapping palette styling work.

Closes #1284

---

## Type of Change
- [x] `refactor` – code restructuring, no behaviour change

---

## What Changed and Why
### ELIR
- Evidence: Salvages the clean helper extraction from #1284 that is not already on main.
- Lineage: Supersedes #1284; formatting-only and unrelated helper churn was left out.
- Implementation: Added helpers for welcome output, template reading, and next-step output while preserving existing open() semantics.
- Risk: Low; existing wizard tests cover the error and success paths.

---

## How Was This Tested?
- [x] `python3 -m py_compile src/utils/setup_wizard.py && python3 -m pytest tests/test_setup_wizard.py -q` passes locally (15 passed).
- [ ] `pre-commit run --all-files` passes locally

---

## Security Implications
- [x] No secrets or credentials are introduced or exposed by this change
- Security notes: Preserves existing file path validation and write-permission behavior.

---

## Checklist
- [ ] Branch follows naming convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages are clear and descriptive
- [x] New or modified code includes relevant tests
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Documentation updated if behaviour changed (README, docstrings, etc.)
- [x] No secrets, credentials, or `.env` files are included in this PR
