### PR TITLE
fix(setup): ABHI-1365 remove shell-variable password exposure in setup.sh

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           # SECURITY: kebab-case inputs required by first-interaction@v3;
           # underscore names are ignored → empty issue/pr messages → action fails.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: "Message that will be displayed on users' first issue"
-          pr-message: "Message that will be displayed on users' first pull request"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: "Message that will be displayed on users' first issue"
+          pr_message: "Message that will be displayed on users' first pull request"

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           # SECURITY: kebab-case inputs required by first-interaction@v3;
           # underscore names are ignored → empty issue/pr messages → action fails.
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          issue_message: "Message that will be displayed on users' first issue"
-          pr_message: "Message that will be displayed on users' first pull request"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: "Message that will be displayed on users' first issue"
+          pr-message: "Message that will be displayed on users' first pull request"

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -96,7 +96,7 @@ vim .env
 # Edit .env file
 nano .env
 
-# Or use setup script
+# Or use the interactive setup script (supports Gmail, Proton Mail, and Outlook)
 ./setup.sh
 ```
 

--- a/setup.sh
+++ b/setup.sh
@@ -56,7 +56,17 @@ if [[ ${configure} == "true" ]]; then
 			exit 1
 		fi
 
-		if ! python3 -m src.utils.setup_wizard; then
+		set +e
+		python3 -m src.utils.setup_wizard
+		exit_code=$?
+		set -e
+
+		if [[ ${exit_code} -eq 0 ]]; then
+			true
+		elif [[ ${exit_code} -eq 2 ]]; then
+			cp .env.example .env
+			print_success "Created .env from template"
+		else
 			echo -e "${RED}Credential setup failed or was cancelled.${NC}"
 			exit 1
 		fi

--- a/setup.sh
+++ b/setup.sh
@@ -4,13 +4,6 @@
 
 set -e # Exit on error
 
-# Check if running on macOS or Linux
-if [[ ${OSTYPE} == "darwin"* ]]; then
-	SED_CMD="sed -i ''"
-else
-	SED_CMD="sed -i"
-fi
-
 echo "===================================="
 echo "Email Security Pipeline Setup"
 echo "===================================="
@@ -31,60 +24,46 @@ print_success() {
 	echo -e "${GREEN}✓${NC} $1"
 }
 
-# Check if .env exists
+# Check if .env exists and whether the user wants to overwrite it.
+configure=false
 if [[ -f .env ]]; then
 	echo -e "${YELLOW}Warning: .env file already exists${NC}"
-	read -p "Do you want to overwrite it? (y/N): " -n 1 -r
+	read -rp "Do you want to overwrite it? (y/N): " -n 1
 	echo
 	if [[ ! ${REPLY} =~ ^[Yy]$ ]]; then
 		echo "Keeping existing .env file"
 	else
-		cp .env.example .env
-		print_success "Created new .env from template"
+		configure=true
 	fi
 else
-	cp .env.example .env
-	print_success "Created .env from template"
+	configure=true
 fi
 
-echo ""
-echo "===================================="
-echo "Configuration"
-echo "===================================="
-echo ""
-echo "You need to configure your email credentials in the .env file."
-echo ""
-read -p "Would you like to configure Gmail credentials now? (y/N): " -n 1 -r
-echo
-
-GMAIL_CONFIGURED=false
-
-if [[ ${REPLY} =~ ^[Yy]$ ]]; then
-	read -p "Enter your Gmail address: " gmail_email
-	read -sp "Enter your Gmail app password (hidden): " gmail_password
+if [[ ${configure} == "true" ]]; then
 	echo ""
+	echo "===================================="
+	echo "Configuration"
+	echo "===================================="
+	echo ""
+	echo "You need to configure your email credentials in the .env file."
+	echo ""
+	read -rp "Would you like to configure email credentials now? (y/N): " -n 1
+	echo
 
-	# Update .env file (using OS-appropriate sed command)
-	${SED_CMD} "s|GMAIL_EMAIL=.*|GMAIL_EMAIL=${gmail_email}|" .env
-	# Create temporary file preserving permissions if possible, or just copy back
-	cp -p .env .env.tmp 2>/dev/null || touch .env.tmp
-	chmod 600 .env.tmp 2>/dev/null || true
-	while IFS= read -r line || [[ -n "$line" ]]; do
-		if [[ $line == GMAIL_APP_PASSWORD=* ]]; then
-			echo "GMAIL_APP_PASSWORD=${gmail_password}"
-		else
-			echo "$line"
+	if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+		if ! command -v python3 &>/dev/null; then
+			echo -e "${RED}Error: Python 3 is required for credential setup${NC}"
+			exit 1
 		fi
-	done < .env > .env.tmp
-	cat .env.tmp > .env
-	rm -f .env.tmp
-	${SED_CMD} "s|GMAIL_ENABLED=.*|GMAIL_ENABLED=true|" .env
 
-	# Clear password from memory (basic security measure)
-	gmail_password=""
-
-	print_success "Gmail credentials configured!"
-	GMAIL_CONFIGURED=true
+		if ! python3 src/utils/setup_wizard.py; then
+			echo -e "${RED}Credential setup failed or was cancelled.${NC}"
+			exit 1
+		fi
+	else
+		cp .env.example .env
+		print_success "Created .env from template"
+	fi
 fi
 
 echo ""
@@ -96,7 +75,7 @@ echo "Choose your deployment method:"
 echo "1) Docker (recommended)"
 echo "2) Local Python (Virtual Environment)"
 echo ""
-read -p "Enter choice (1 or 2): " -n 1 -r
+read -rp "Enter choice (1 or 2): " -n 1
 echo
 echo ""
 
@@ -167,7 +146,7 @@ elif [[ ${REPLY} == "2" ]]; then
 		echo "Connectivity Check"
 		echo "===================================="
 		echo ""
-		read -p "Run connection test now? (y/N): " -n 1 -r
+		read -rp "Run connection test now? (y/N): " -n 1
 		echo
 		if [[ ${REPLY} =~ ^[Yy]$ ]]; then
 			./venv/bin/python scripts/check_mail_connectivity.py

--- a/setup.sh
+++ b/setup.sh
@@ -56,7 +56,7 @@ if [[ ${configure} == "true" ]]; then
 			exit 1
 		fi
 
-		if ! python3 src/utils/setup_wizard.py; then
+		if ! python3 -m src.utils.setup_wizard; then
 			echo -e "${RED}Credential setup failed or was cancelled.${NC}"
 			exit 1
 		fi

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -1,6 +1,7 @@
 import getpass
 import os
 import re
+import sys
 from pathlib import Path
 
 # Check if Colors is available in the expected path, otherwise mock it
@@ -145,7 +146,8 @@ def _test_connection(email: str, app_password: str, provider_choice: str) -> boo
         # outside, we just print as before.
         error_msg = str(e).replace(app_password, "***") if app_password else str(e)
         print(
-            "✖ " + Colors.colorize(f"Error during connection test: {error_msg}", Colors.RED)
+            "✖ "
+            + Colors.colorize(f"Error during connection test: {error_msg}", Colors.RED)
         )
         if provider_choice == "3":
             print(OUTLOOK_AUTH_ERROR_TIP)
@@ -171,10 +173,16 @@ def _select_provider() -> str:
     )
 
     choices_map = {
-        "1": "1", "gmail": "1",
-        "2": "2", "proton": "2", "proton mail": "2", "protonmail": "2",
-        "3": "3", "outlook": "3",
-        "4": "4", "skip": "4"
+        "1": "1",
+        "gmail": "1",
+        "2": "2",
+        "proton": "2",
+        "proton mail": "2",
+        "protonmail": "2",
+        "3": "3",
+        "outlook": "3",
+        "4": "4",
+        "skip": "4",
     }
 
     while True:
@@ -192,8 +200,11 @@ def _select_provider() -> str:
             if choice in choices_map:
                 return choices_map[choice]
             print(
-                "✖ " + Colors.colorize("Invalid choice. ", Colors.RED)
-                + Colors.colorize("Please enter a number (1-4) or provider name.", Colors.YELLOW)
+                "✖ "
+                + Colors.colorize("Invalid choice. ", Colors.RED)
+                + Colors.colorize(
+                    "Please enter a number (1-4) or provider name.", Colors.YELLOW
+                )
             )
         except EOFError:
             return "4"
@@ -211,7 +222,8 @@ def _prompt_for_email(provider_name: str) -> str:
         email = _styled_input(prompt)
         if not email:
             print(
-                "✖ " + Colors.colorize("Email is required. ", Colors.RED)
+                "✖ "
+                + Colors.colorize("Email is required. ", Colors.RED)
                 + Colors.colorize("Please provide an email address.", Colors.YELLOW)
             )
             continue
@@ -220,7 +232,8 @@ def _prompt_for_email(provider_name: str) -> str:
             return email
 
         print(
-            "✖ " + Colors.colorize("Invalid email format. ", Colors.RED)
+            "✖ "
+            + Colors.colorize("Invalid email format. ", Colors.RED)
             + Colors.colorize(
                 "Please enter a valid email address (e.g., user@example.com).",
                 Colors.YELLOW,
@@ -287,7 +300,8 @@ def _prompt_for_password(provider_name: str) -> str:
     app_secret = _get_input()
     while not app_secret:
         print(
-            "✖ " + Colors.colorize("Password is required. ", Colors.RED)
+            "✖ "
+            + Colors.colorize("Password is required. ", Colors.RED)
             + Colors.colorize("Please provide a password.", Colors.YELLOW)
         )
         app_secret = _get_input()
@@ -388,7 +402,10 @@ def _validate_config_path(config_file: str) -> Path | None:
     """Validate the configuration file path securely."""
     if "\0" in config_file:
         print(
-            "✖ " + Colors.colorize(f"Error: Invalid configuration file path '{config_file}'.", Colors.RED)
+            "✖ "
+            + Colors.colorize(
+                f"Error: Invalid configuration file path '{config_file}'.", Colors.RED
+            )
         )
         return None
 
@@ -399,7 +416,11 @@ def _validate_config_path(config_file: str) -> Path | None:
         or candidate_name != config_file
     ):
         print(
-            "✖ " + Colors.colorize(f"Error: Unsafe configuration file path '{config_file}'. Use a filename only.", Colors.RED)
+            "✖ "
+            + Colors.colorize(
+                f"Error: Unsafe configuration file path '{config_file}'. Use a filename only.",
+                Colors.RED,
+            )
         )
         return None
 
@@ -430,21 +451,26 @@ def _set_file_permissions(fd: int, config_path: Path) -> None:
                 ):
                     chmod_kwargs = (
                         {"follow_symlinks": False}
-                        if os.chmod
-                        in getattr(os, "supports_follow_symlinks", set())
+                        if os.chmod in getattr(os, "supports_follow_symlinks", set())
                         else {}
                     )
                     os.chmod(config_path_str, 0o600, **chmod_kwargs)
                 else:
                     print(
-                        f"\n✖ " + Colors.colorize("Error: TOCTOU detected on " + str(config_path), Colors.RED)
+                        f"\n✖ "
+                        + Colors.colorize(
+                            "Error: TOCTOU detected on " + str(config_path), Colors.RED
+                        )
                     )
                     import sys
 
                     sys.exit(1)
             except OSError as exc:
                 print(
-                    f"\n✖ " + Colors.colorize("Error setting permissions: " + str(exc), Colors.RED)
+                    f"\n✖ "
+                    + Colors.colorize(
+                        "Error setting permissions: " + str(exc), Colors.RED
+                    )
                 )
                 import sys
 
@@ -530,7 +556,10 @@ def run_setup_wizard(
 
     if not Path(template_file).exists():
         print(
-            "✖ " + Colors.colorize(f"Error: Template file '{template_file}' not found.", Colors.RED)
+            "✖ "
+            + Colors.colorize(
+                f"Error: Template file '{template_file}' not found.", Colors.RED
+            )
         )
         return False
 
@@ -579,3 +608,27 @@ def run_setup_wizard(
         )
         print(f"\n\n{warning} {message}")
         return False
+
+
+def main() -> int:
+    """CLI entry point for setup.sh and other automation."""
+    if not sys.stdin.isatty():
+        print(
+            "✖ "
+            + Colors.colorize(
+                "Interactive credential setup requires a TTY.", Colors.RED
+            )
+        )
+        return 1
+
+    try:
+        return 0 if run_setup_wizard() else 1
+    except EOFError:
+        print("\n✖ " + Colors.colorize("Interactive input closed.", Colors.RED))
+        return 1
+    except KeyboardInterrupt:
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
 
     class Colors:
+        ENABLED = False
         RESET = ""
         BOLD = ""
         CYAN = ""
@@ -21,6 +22,10 @@ except ImportError:
         @classmethod
         def colorize(cls, text, color):
             return text
+
+
+class WizardSkipped(Exception):
+    """Raised when the user intentionally skips interactive setup."""
 
 
 try:
@@ -547,11 +552,15 @@ def _print_next_steps(config_file: str) -> None:
 
 
 def run_setup_wizard(
-    config_file: str = ".env", template_file: str = ".env.example"
+    config_file: str = ".env",
+    template_file: str = ".env.example",
+    raise_on_skip: bool = False,
 ) -> bool:
     """
     Run an interactive setup wizard to configure the application.
     Returns True if setup was successful, False otherwise.
+    If raise_on_skip is True, a WizardSkipped exception is raised when the user
+    chooses to skip the wizard instead of returning False.
     """
 
     if not Path(template_file).exists():
@@ -569,6 +578,8 @@ def run_setup_wizard(
         # 1. Select Provider
         choice = _select_provider()
         if choice == "4":
+            if raise_on_skip:
+                raise WizardSkipped("User chose to skip setup.")
             return False
 
         provider_map = {
@@ -622,7 +633,9 @@ def main() -> int:
         return 1
 
     try:
-        return 0 if run_setup_wizard() else 1
+        return 0 if run_setup_wizard(raise_on_skip=True) else 1
+    except WizardSkipped:
+        return 2
     except EOFError:
         print("\n✖ " + Colors.colorize("Interactive input closed.", Colors.RED))
         return 1

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -557,7 +557,7 @@ def _execute_setup_steps(
     config_file: str,
     raise_on_skip: bool,
 ) -> bool:
-    """Helper to process provider choice, credentials, and configuration writing."""
+    """Process provider choice, credentials, and configuration writing."""
     if choice == "4":
         if raise_on_skip:
             raise WizardSkipped("User chose to skip setup.")

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -551,6 +551,49 @@ def _print_next_steps(config_file: str) -> None:
     print(f"2. Run the pipeline: {Colors.colorize('python src/main.py', Colors.CYAN)}")
 
 
+def _execute_setup_steps(
+    choice: str,
+    template_file: str,
+    config_file: str,
+    raise_on_skip: bool,
+) -> bool:
+    """Helper to process provider choice, credentials, and configuration writing."""
+    if choice == "4":
+        if raise_on_skip:
+            raise WizardSkipped("User chose to skip setup.")
+        return False
+
+    provider_map = {
+        "1": ("GMAIL", "Gmail"),
+        "2": ("PROTON", "Proton Mail"),
+        "3": ("OUTLOOK", "Outlook"),
+    }
+    selected_key, selected_name = provider_map[choice]
+
+    # 2. Get Credentials
+    email, app_secret = _get_credentials(choice, selected_name)
+    if not email or not app_secret:
+        return False
+
+    # 3. Read Template
+    template_content = _read_template(template_file)
+    if template_content is None:
+        return False
+
+    # 4. Generate Config
+    new_content = _generate_config_content(
+        template_content, selected_key, email, app_secret
+    )
+
+    # 5. Write Config
+    if not _write_config_file(config_file, new_content):
+        return False
+
+    _print_next_steps(config_file)
+
+    return True
+
+
 def run_setup_wizard(
     config_file: str = ".env",
     template_file: str = ".env.example",
@@ -577,40 +620,7 @@ def run_setup_wizard(
     try:
         # 1. Select Provider
         choice = _select_provider()
-        if choice == "4":
-            if raise_on_skip:
-                raise WizardSkipped("User chose to skip setup.")
-            return False
-
-        provider_map = {
-            "1": ("GMAIL", "Gmail"),
-            "2": ("PROTON", "Proton Mail"),
-            "3": ("OUTLOOK", "Outlook"),
-        }
-        selected_key, selected_name = provider_map[choice]
-
-        # 2. Get Credentials
-        email, app_secret = _get_credentials(choice, selected_name)
-        if not email or not app_secret:
-            return False
-
-        # 3. Read Template
-        template_content = _read_template(template_file)
-        if template_content is None:
-            return False
-
-        # 4. Generate Config
-        new_content = _generate_config_content(
-            template_content, selected_key, email, app_secret
-        )
-
-        # 5. Write Config
-        if not _write_config_file(config_file, new_content):
-            return False
-
-        _print_next_steps(config_file)
-
-        return True
+        return _execute_setup_steps(choice, template_file, config_file, raise_on_skip)
 
     except KeyboardInterrupt:
         warning = Colors.colorize("⚠", Colors.YELLOW)

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, mock_open, patch
 from src.utils.setup_wizard import (
     _generate_config_content,
     _is_valid_email,
+    main,
     run_setup_wizard,
 )
 
@@ -352,6 +353,36 @@ OUTLOOK_APP_PASSWORD=password
 
     def test_skip_verification(self):
         self._run_edge_case(["1", "test@gmail.com", "n"], False, None, True, True)
+
+
+class TestSetupWizardCLI(unittest.TestCase):
+    """Smoke tests for the setup_wizard CLI entry point."""
+
+    @patch("src.utils.setup_wizard.sys.stdin.isatty", return_value=False)
+    def test_main_requires_tty(self, _mock_isatty):
+        """CLI should fail immediately without a TTY."""
+        self.assertEqual(main(), 1)
+
+    @patch("src.utils.setup_wizard.sys.stdin.isatty", return_value=True)
+    @patch("src.utils.setup_wizard.run_setup_wizard", return_value=True)
+    def test_main_success(self, _mock_wizard, _mock_isatty):
+        """CLI should return 0 when the wizard succeeds."""
+        self.assertEqual(main(), 0)
+
+    @patch("src.utils.setup_wizard.sys.stdin.isatty", return_value=True)
+    @patch("src.utils.setup_wizard.run_setup_wizard", return_value=False)
+    def test_main_failure(self, _mock_wizard, _mock_isatty):
+        """CLI should return 1 when the wizard returns False."""
+        self.assertEqual(main(), 1)
+
+    @patch("src.utils.setup_wizard.sys.stdin.isatty", return_value=True)
+    @patch(
+        "src.utils.setup_wizard.run_setup_wizard",
+        side_effect=EOFError(),
+    )
+    def test_main_eof(self, _mock_wizard, _mock_isatty):
+        """CLI should return 1 on unexpected EOF."""
+        self.assertEqual(main(), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,8 +1,12 @@
 import os
+import subprocess  # nosec B404
+import sys
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 from src.utils.setup_wizard import (
+    WizardSkipped,
     _generate_config_content,
     _is_valid_email,
     main,
@@ -226,6 +230,18 @@ OUTLOOK_APP_PASSWORD=password
         result = run_setup_wizard(config_file=".env", template_file=".env.example")
         self.assertFalse(result)
 
+    @patch("builtins.input")
+    @patch("pathlib.Path.exists")
+    def test_user_skip_with_raise(self, mock_exists, mock_input):
+        mock_exists.return_value = True
+        mock_input.return_value = "4"  # Skip
+        with self.assertRaises(WizardSkipped):
+            run_setup_wizard(
+                config_file=".env",
+                template_file=".env.example",
+                raise_on_skip=True,
+            )
+
     def test_connection_failure_retry(self):
         mocks = self._setup_full_mock_dependencies()
         _, _, _, _, _, mock_write_handle, mock_getpass, mock_input, mock_imap_conn = (
@@ -378,11 +394,36 @@ class TestSetupWizardCLI(unittest.TestCase):
     @patch("src.utils.setup_wizard.sys.stdin.isatty", return_value=True)
     @patch(
         "src.utils.setup_wizard.run_setup_wizard",
+        side_effect=WizardSkipped("skipped"),
+    )
+    def test_main_skip(self, _mock_wizard, _mock_isatty):
+        """CLI should return 2 when the wizard is skipped."""
+        self.assertEqual(main(), 2)
+
+    @patch("src.utils.setup_wizard.sys.stdin.isatty", return_value=True)
+    @patch(
+        "src.utils.setup_wizard.run_setup_wizard",
         side_effect=EOFError(),
     )
     def test_main_eof(self, _mock_wizard, _mock_isatty):
         """CLI should return 1 on unexpected EOF."""
         self.assertEqual(main(), 1)
+
+    def test_cli_module_invocation_requires_tty(self):
+        """The real module invocation should fail cleanly without a TTY."""
+        repo_root = Path(__file__).resolve().parents[1]
+        result = subprocess.run(  # nosec B603
+            [sys.executable, "-m", "src.utils.setup_wizard"],
+            cwd=repo_root,
+            input="",
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "Interactive credential setup requires a TTY.",
+            result.stdout + result.stderr,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Removes the remaining password exposure in `setup.sh` by delegating credential collection and `.env` writing to `src/utils/setup_wizard.py`. The password no longer lives in a bash variable or an intermediate `.env.tmp` file.

---

## Type of Change

- [x] `fix` – bug fix
- [ ] `feat` – new feature
- [ ] `docs` – documentation only
- [ ] `chore` – maintenance (deps, config, CI)
- [x] `test` – test additions or improvements
- [ ] `perf` – performance improvement
- [ ] `refactor` – code restructuring, no behaviour change

---

## What Changed and Why

- `setup.sh` previously stored the Gmail app password in the `gmail_password` shell variable and wrote it to `.env` through a temporary `.env.tmp` loop. This left the password in shell memory and on disk temporarily.
- Added a `main()` CLI entry point to `src/utils/setup_wizard.py` so it can be invoked directly. It refuses to run when `stdin` is not a TTY, avoiding accidental non-interactive credential leakage.
- `setup.sh` now prompts for `.env` overwrite consent, then calls `python3 src/utils/setup_wizard.py` to collect credentials and write `.env` directly with `getpass` and `os.open(0o600)`. This reuses the wizard's existing secure write logic, validation, and permissions handling.
- Removed the now-unused `SED_CMD`/`OSTYPE` block and `GMAIL_CONFIGURED` variable, resolving the outstanding `shellcheck` warnings.

---

## How Was This Tested

- Added `TestSetupWizardCLI` in `tests/test_setup_wizard.py` covering the new `main()` entry point: TTY requirement, success, failure, and EOF handling.
- `python3 -m pytest tests/test_setup_wizard.py -q` — 19 passed.
- `pre-commit run --files setup.sh src/utils/setup_wizard.py tests/test_setup_wizard.py QUICK_REFERENCE.md` — passed.
- `trunk check setup.sh src/utils/setup_wizard.py tests/test_setup_wizard.py QUICK_REFERENCE.md --fix` — no new issues.
- The full test suite could not be run in this session because optional runtime dependencies (`cv2`, `ahocorasick`) are not installed in the current Python 3.10 environment. This is a pre-existing environment limitation unrelated to these changes.

---

## Security Implications

- [x] No secrets or credentials are introduced or exposed by this change
- Security notes: This change removes shell-variable and temporary-file handling of the Gmail app password. The password is now read with `getpass` and written directly to `.env` via `os.open()` with `0o600` permissions, matching the secure pattern already used by `app_runner.py`. No new environment-variable fallback for credentials is introduced.

---

## Checklist

- [x] Branch follows naming convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages are clear and descriptive
- [x] New or modified code includes relevant tests
- [x] Pre-commit hooks pass (`pre-commit run --all-files` on changed files)
- [x] Documentation updated if behaviour changed (`QUICK_REFERENCE.md` updated to reflect provider-selection flow)
- [x] No secrets, credentials, or `.env` files are included in this PR

Link to Devin session: https://app.devin.ai/sessions/b4d1ec8aaaee4adda992c0d7b6e92476
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->