### PR TITLE
Jules Daily QA & Agentic Review: Linting Fixes

### DIFF
--- a/src/modules/email_parser.py
+++ b/src/modules/email_parser.py
@@ -46,7 +46,6 @@ class ParseContext:
 logger = logging.getLogger(__name__)
 
 
-
 @dataclass
 class EmailParserConfig:
     """Configuration for EmailParser."""

--- a/src/modules/imap_connection.py
+++ b/src/modules/imap_connection.py
@@ -16,7 +16,6 @@ import re
 import logging
 import socket
 import ssl
-import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -437,14 +437,14 @@ def _set_file_permissions(fd: int, config_path: Path) -> None:
                     os.chmod(config_path_str, 0o600, **chmod_kwargs)
                 else:
                     print(
-                        f"\n✖ " + Colors.colorize("Error: TOCTOU detected on " + str(config_path), Colors.RED)
+                        "\n✖ " + Colors.colorize("Error: TOCTOU detected on " + str(config_path), Colors.RED)
                     )
                     import sys
 
                     sys.exit(1)
             except OSError as exc:
                 print(
-                    f"\n✖ " + Colors.colorize("Error setting permissions: " + str(exc), Colors.RED)
+                    "\n✖ " + Colors.colorize("Error setting permissions: " + str(exc), Colors.RED)
                 )
                 import sys
 

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -309,6 +309,7 @@ def test_styled_input_keyboard_interrupt(
     mock_write.assert_called_once_with("[RESET]")
     mock_flush.assert_called_once()
 
+
 @patch("sys.stdout", new_callable=io.StringIO)
 def test_print_help(mock_stdout, mock_app_runner):
     mock_app_runner.print_help()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -197,7 +197,6 @@ class TestMetrics(unittest.TestCase):
         # The newest value (index -1) should be 1499.0
         self.assertEqual(self.metrics.processing_time_ms[-1], 1499.0)
 
-
     def test_get_summary_format(self):
         """Test that get_summary returns the expected dictionary format."""
         # Add some data to ensure processing_time_stats is populated

--- a/tests/test_nlp_scan_text_patterns.py
+++ b/tests/test_nlp_scan_text_patterns.py
@@ -164,7 +164,6 @@ class TestScanTextPatternsCategories(_BaseNLPScanTest):
 class TestScanTextPatternsTwoPhase(_BaseNLPScanTest):
     """Confirms that the fast simple_master_pattern gate short-circuits correctly."""
 
-
     def test_gate_uses_search_not_match(self):
         # SECURITY STORY: The simple_master_pattern gate must use .search(), not .match().
         # If it used .match(), it would only find keywords at the very beginning of the string,

--- a/tests/test_pattern_compiler.py
+++ b/tests/test_pattern_compiler.py
@@ -158,7 +158,6 @@ class TestCompileNamedGroupPattern:
         pat, _ = compile_named_group_pattern([r"\bphishing\b"])
         assert pat.search("PHISHING attempt detected")
 
-
     def test_empty_list_compiles_to_empty_pattern(self):
         """An empty list should not raise and produces a pattern that matches nothing."""
         pat, group_map = compile_named_group_pattern([])

--- a/tests/test_ssrf_prevention.py
+++ b/tests/test_ssrf_prevention.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from src.utils.config import Config, ConfigurationError
 from src.utils.security_validators import is_safe_webhook_url
 
+
 class TestSSRFPrevention(unittest.TestCase):
 
     def test_empty_url(self):
@@ -180,6 +181,7 @@ class TestSSRFPrevention(unittest.TestCase):
         is_safe, msg = is_safe_webhook_url("https://strict-zero.local/webhook")
         self.assertFalse(is_safe)
         self.assertIn("resolves to zero-net", msg)
+
 
 class TestConfigSSRFPrevention(unittest.TestCase):
 


### PR DESCRIPTION
This PR introduces minor, automated linting and formatting fixes identified during the daily QA run.

## Summary of Findings

- Codebase built and tests passed successfully (`python3 -m pytest tests/`).
- Identified and fixed linting errors using `flake8`.
- Ran `bandit` for security scans which reported 0 issues.
- Search for existing open QA issues via GitHub API returned no results, so generating this PR directly.

## Actions Taken

- Removed unused import `time` in `src/modules/imap_connection.py`.
- Corrected f-strings missing placeholders (F541) in `src/utils/setup_wizard.py`.
- Formatted file spacing using `autopep8`.

## Bash Commands Executed

- `python3 -m pytest tests/`
- `python3 -m pip install flake8 bandit autopep8`
- `flake8 src/ tests/`
- `bandit -r src/`
- `autopep8 -i -a -a <files>`

Closing this task as the repository is now fully healthy.

---
*PR created automatically by Jules for task [17925118773560838](https://jules.google.com/task/17925118773560838) started by @abhimehro*