### PR TITLE
🎨 Palette: Enhance CLI error visual hierarchy for input validation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -235,3 +235,6 @@
 ## 2026-07-10 - Actionable Empty States
 **Learning:** When displaying an empty state or 'not configured' warning, users often lack context on how to resolve it. Adding a direct, actionable next step reduces friction.
 **Action:** Always pair empty states with a clear call-to-action or instruction.
+## 2026-07-19 - Clearer visual hierarchy for CLI errors
+**Learning:** When a terminal application displays validation errors, presenting the entire string in red makes it harder for users to distinguish the failure reason from the required action, increasing friction.
+**Action:** Separate error descriptions (in `Colors.RED`) from actionable remediation advice (in `Colors.YELLOW`) to establish a clear visual hierarchy and guide users to immediate resolution.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -53,7 +53,9 @@ class AppRunner:
 
         if "\0" in raw_config_file:
             print(
-                "✖ " + Colors.colorize(f"Error: Invalid configuration file path '{raw_config_file}'.", Colors.RED)
+                "✖ "
+                + Colors.colorize(f"Error: Invalid configuration file path '{raw_config_file}'. ", Colors.RED)
+                + Colors.colorize("Ensure the path contains no null bytes.", Colors.YELLOW)
             )
             sys.exit(1)
 
@@ -65,7 +67,9 @@ class AppRunner:
             candidate.relative_to(base_dir)
         except ValueError:
             print(
-                "✖ " + Colors.colorize(f"Error: Configuration file path must stay within '{base_dir}'.", Colors.RED)
+                "✖ "
+                + Colors.colorize(f"Error: Configuration file path must stay within '{base_dir}'. ", Colors.RED)
+                + Colors.colorize("Use a local file path instead.", Colors.YELLOW)
             )
             sys.exit(1)
 

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -408,9 +408,8 @@ def _validate_config_path(config_file: str) -> Path | None:
     if "\0" in config_file:
         print(
             "✖ "
-            + Colors.colorize(
-                f"Error: Invalid configuration file path '{config_file}'.", Colors.RED
-            )
+            + Colors.colorize(f"Error: Invalid configuration file path '{config_file}'. ", Colors.RED)
+            + Colors.colorize("Ensure the path contains no null bytes.", Colors.YELLOW)
         )
         return None
 
@@ -422,10 +421,8 @@ def _validate_config_path(config_file: str) -> Path | None:
     ):
         print(
             "✖ "
-            + Colors.colorize(
-                f"Error: Unsafe configuration file path '{config_file}'. Use a filename only.",
-                Colors.RED,
-            )
+            + Colors.colorize(f"Error: Unsafe configuration file path '{config_file}'. ", Colors.RED)
+            + Colors.colorize("Use a filename only.", Colors.YELLOW)
         )
         return None
 
@@ -462,7 +459,7 @@ def _set_file_permissions(fd: int, config_path: Path) -> None:
                     os.chmod(config_path_str, 0o600, **chmod_kwargs)
                 else:
                     print(
-                        f"\n✖ "
+                        "\n✖ "
                         + Colors.colorize(
                             "Error: TOCTOU detected on " + str(config_path), Colors.RED
                         )
@@ -472,7 +469,7 @@ def _set_file_permissions(fd: int, config_path: Path) -> None:
                     sys.exit(1)
             except OSError as exc:
                 print(
-                    f"\n✖ "
+                    "\n✖ "
                     + Colors.colorize(
                         "Error setting permissions: " + str(exc), Colors.RED
                     )
@@ -609,9 +606,8 @@ def run_setup_wizard(
     if not Path(template_file).exists():
         print(
             "✖ "
-            + Colors.colorize(
-                f"Error: Template file '{template_file}' not found.", Colors.RED
-            )
+            + Colors.colorize(f"Error: Template file '{template_file}' not found. ", Colors.RED)
+            + Colors.colorize("Ensure the file exists before running the wizard.", Colors.YELLOW)
         )
         return False
 
@@ -636,9 +632,8 @@ def main() -> int:
     if not sys.stdin.isatty():
         print(
             "✖ "
-            + Colors.colorize(
-                "Interactive credential setup requires a TTY.", Colors.RED
-            )
+            + Colors.colorize("Interactive credential setup requires a TTY. ", Colors.RED)
+            + Colors.colorize("Run the command in an interactive terminal or provide a config file.", Colors.YELLOW)
         )
         return 1
 


### PR DESCRIPTION
## 💡 What
Added distinct `Colors.YELLOW` remediation advice alongside `Colors.RED` validation errors across `app_runner.py` and `setup_wizard.py`.

## 🎯 Why
When terminal applications present errors entirely in red, it's difficult for users to quickly determine what went wrong vs. what they need to do next. Separating the failure from the solution visually reduces cognitive load and provides an immediate call-to-action.

## 📸 Before/After
**Before:** `✖ Error: Invalid configuration file path 'foo'.` (All red)
**After:** `✖ Error: Invalid configuration file path 'foo'.` (Red) `Ensure the path contains no null bytes.` (Yellow)

## ♿ Accessibility
While primarily a visual hierarchy improvement for sighted users, separating the actionable text ensures screen reader output presents a clear logical flow from the error state to the recovery steps.

---
*PR created automatically by Jules for task [5395728972884088862](https://jules.google.com/task/5395728972884088862) started by @abhimehro*