### PR TITLE
Jules Daily QA & Agentic Review: Fix F541 Flake8 warnings

### DIFF
--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -462,7 +462,7 @@ def _set_file_permissions(fd: int, config_path: Path) -> None:
                     os.chmod(config_path_str, 0o600, **chmod_kwargs)
                 else:
                     print(
-                        f"\n✖ "
+                        "\n✖ "
                         + Colors.colorize(
                             "Error: TOCTOU detected on " + str(config_path), Colors.RED
                         )
@@ -472,7 +472,7 @@ def _set_file_permissions(fd: int, config_path: Path) -> None:
                     sys.exit(1)
             except OSError as exc:
                 print(
-                    f"\n✖ "
+                    "\n✖ "
                     + Colors.colorize(
                         "Error setting permissions: " + str(exc), Colors.RED
                     )


### PR DESCRIPTION
### Jules Daily QA & Agentic Review - Summary

**Domain:** Email security processing and filtering pipeline
**Priorities Assessed:** Input validation, security best practices, compliance with email security standards

#### Findings:
- The codebase builds and runs successfully.
- All 699 unit tests pass.
- Flake8 linting identified two minor issues in `src/utils/setup_wizard.py`: `F541 f-string is missing placeholders`.
- No open issues tagged "Jules Daily QA & Agentic Review" were found in the repository.

#### Actions Taken:
- Fixed the two F541 errors in `src/utils/setup_wizard.py` by removing the `f` prefix from strings that did not contain placeholders. 

#### Bash Commands Used During Verification:
```bash
# Listed files
ls -la

# Installed requirements
python3 -m pip install -r requirements.txt -r requirements-ci.txt

# Ran full test suite
cp .env.example .env && python3 -m pytest

# Queried GitHub API for open QA issues
REPO=$(git config --get remote.origin.url | sed -e 's/.*github.com\///' -e 's/\.git$//')
if [ -z "$REPO" ]; then
    REPO="owner/email-security-pipeline"
fi
curl -s -H "Authorization: token $GH_TOKEN" "https://api.github.com/search/issues?q=repo:${REPO}+state:open+is:issue+\"Jules+Daily+QA\""

# Installed linting and security tools, ran them
python3 -m pip install flake8 bandit && flake8 src tests || true; bandit -r src || true

# Investigated the F541 errors
grep -n -A 5 -B 5 "f'" src/utils/setup_wizard.py | grep -E "f'\n✖ '|f'✖ '"
sed -n '460,480p' src/utils/setup_wizard.py

# Fixed the F541 errors
cat << 'EOF' > fix_f541.py
import sys

with open("src/utils/setup_wizard.py", "r") as f:
    content = f.read()

content = content.replace("f\"\\n✖ \"", "\"\\n✖ \"")

with open("src/utils/setup_wizard.py", "w") as f:
    f.write(content)
EOF
python3 fix_f541.py
rm fix_f541.py

# Final verification
python3 -m flake8 src/ tests/ && python3 -m pytest tests/
```

---
*PR created automatically by Jules for task [15931605607190669206](https://jules.google.com/task/15931605607190669206) started by @abhimehro*