### PR TITLE
🔒 Fix path traversal vulnerability via tar symlinks/hardlinks

### DIFF
--- a/src/modules/media_analyzer.py
+++ b/src/modules/media_analyzer.py
@@ -885,6 +885,14 @@ class MediaAuthenticityAnalyzer:
                 f"Tar file {filename} contains path traversal attempt: {safe_member_name_traversal}"
             ]
 
+        if (member.issym() or member.islnk()) and self._is_path_traversal_attempt(member.linkname):
+            safe_linkname_traversal = sanitize_for_logging(
+                sanitize_filename(member.linkname)
+            )
+            return 5.0, [
+                f"Tar file {filename} contains link with path traversal attempt: {safe_linkname_traversal}"
+            ]
+
         member_score, member_warnings = self._inspect_archive_member(
             filename,
             member.name,

--- a/src/modules/media_analyzer.py
+++ b/src/modules/media_analyzer.py
@@ -885,13 +885,14 @@ class MediaAuthenticityAnalyzer:
                 f"Tar file {filename} contains path traversal attempt: {safe_member_name_traversal}"
             ]
 
-        if (member.issym() or member.islnk()) and self._is_path_traversal_attempt(member.linkname):
-            safe_linkname_traversal = sanitize_for_logging(
-                sanitize_filename(member.linkname)
-            )
-            return 5.0, [
-                f"Tar file {filename} contains link with path traversal attempt: {safe_linkname_traversal}"
-            ]
+        if member.issym() or member.islnk():
+            if self._is_path_traversal_attempt(member.linkname):
+                safe_linkname_traversal = sanitize_for_logging(
+                    sanitize_filename(member.linkname)
+                )
+                return 5.0, [
+                    f"Tar file {filename} contains link with path traversal attempt: {safe_linkname_traversal}"
+                ]
 
         member_score, member_warnings = self._inspect_archive_member(
             filename,

--- a/tests/test_archive_path_traversal.py
+++ b/tests/test_archive_path_traversal.py
@@ -139,5 +139,33 @@ class TestArchivePathTraversal(unittest.TestCase):
         self.assertTrue(result.threat_score >= 5.0)
 
 
+
+    def test_tar_symlink_path_traversal(self):
+        """Test that symlinks with malicious link targets are flagged."""
+
+        tar_buffer = io.BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode="w") as tf:
+            info = tarfile.TarInfo(name="legit.txt")
+            info.type = tarfile.SYMTYPE
+            info.linkname = "../../etc/passwd"
+            tf.addfile(info)
+
+        tar_data = tar_buffer.getvalue()
+
+        result = self._run_analyzer_on_archive(
+            "test_symlink.tar", "application/x-tar", tar_data
+        )
+
+        self.assertTrue(result.threat_score >= 5.0)
+        found_warning = False
+        for warning in result.suspicious_attachments:
+            if "contains link with path traversal attempt" in warning:
+                self.assertNotIn("../", warning)
+                found_warning = True
+
+        self.assertTrue(
+            found_warning, "Expected to find a warning about path traversal in symlink"
+        )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in tar archive extraction where the analyzer checked the member's `name` but ignored the `linkname` property for symbolic and hard links.

⚠️ **Risk:** If left unfixed, an attacker could craft a malicious tar archive containing a seemingly innocuous symlink (e.g., `legit.txt`) that points to sensitive system paths (e.g., `../../../../etc/passwd` or `/etc/shadow`). When extracted without validation, this could allow arbitrary file overwrite, potentially leading to remote code execution or privilege escalation.

🛡️ **Solution:** Updated `_process_tar_member` in `src/modules/media_analyzer.py` to additionally check `member.linkname` using `self._is_path_traversal_attempt()` if the archive member is a symbolic link (`member.issym()`) or a hard link (`member.islnk()`). If a traversal attempt is detected in the link target, it now correctly returns a maximum threat score of 5.0 and logs a security warning. Additionally, a comprehensive test case was added to `tests/test_archive_path_traversal.py` to verify this protective measure.

---
*PR created automatically by Jules for task [16633193650560249123](https://jules.google.com/task/16633193650560249123) started by @abhimehro*