### PR TITLE
perf(imap): list-comp size parse filter (salvages #1331)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2025-11-09 - Avoid eager evaluation of IPAddress properties
 **Learning:** When evaluating multiple boolean properties on an ipaddress object for security checks, putting them in a list or tuple structure forces eager evaluation and avoids short-circuiting. An alternative is an if/elif chain, but that increases cyclomatic complexity. The best approach is to iterate over a constant tuple of property name strings and use getattr(), preserving short-circuiting and saving overhead.
 **Action:** For multiple object property checks, favor a short-circuiting approach with getattr over strings rather than eager evaluation or deep if/elif branches when complexity matters.
+
+## 2026-07-21 - Fast Sequential Filtering (salvage #1331)
+**Learning:** When evaluating items with a function that both parses and validates, a list comprehension powered by an inner generator expression (e.g., `[p for p in (func(x) for x in data) if p]`) reduces pure loop overhead for simple batch processing without the walrus operator.
+**Action:** Prefer list comprehensions over nested iteration when mapping + filtering a sequence without heavy internal side effects.

--- a/src/modules/imap_connection.py
+++ b/src/modules/imap_connection.py
@@ -421,13 +421,9 @@ class IMAPConnection:
             status, size_data = self.connection.fetch(ids_str, "(RFC822.SIZE)")
 
             if status == "OK" and isinstance(size_data, list):
-                for item in size_data:
-                    parsed = self._parse_size_item(item)
-                    if not parsed:
-                        continue
-
-                    seq, size = parsed
-
+                for seq, size in [
+                    p for p in (self._parse_size_item(item) for item in size_data) if p
+                ]:
                     # Check against limit
                     if size > self.max_email_size:
                         self.logger.warning(


### PR DESCRIPTION
## Summary
Salvages conflicted Bolt #1331 onto `main`:
- `src/modules/imap_connection.py` size-parse list comprehension
- Append-only `.jules/bolt.md` journal entry (did not overwrite main journal)

## Test plan
- [x] `python3 -m py_compile src/modules/imap_connection.py`
- [ ] `python3 -m pytest` (CI)

═══ ELIR ═══
PURPOSE: Recover IMAP size-filter micro-opt blocked by bolt.md journal conflict.
SECURITY: No auth/secrets; parsing filter semantics unchanged.
FAILS IF: `_parse_size_item` return contract changes.
VERIFY: py_compile + existing IMAP tests in CI.
MAINTAIN: Always append bolt journals; never checkout PR journal wholesale.

Supersedes #1331.