### PR TITLE
perf(ingestion): extend+comprehension parse collect (salvages #1314)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2025-11-09 - Avoid eager evaluation of IPAddress properties
 **Learning:** When evaluating multiple boolean properties on an ipaddress object for security checks, putting them in a list or tuple structure forces eager evaluation and avoids short-circuiting. An alternative is an if/elif chain, but that increases cyclomatic complexity. The best approach is to iterate over a constant tuple of property name strings and use getattr(), preserving short-circuiting and saving overhead.
 **Action:** For multiple object property checks, favor a short-circuiting approach with getattr over strings rather than eager evaluation or deep if/elif branches when complexity matters.
+
+## 2026-07-21 - Optimize list append loop using extend and list comp (salvage #1314)
+**Learning:** Conditional `.append()` in a Python for-loop pays interpreter overhead; `lst.extend([item for item in iter if item])` pushes generation into C for a material speedup on large batches.
+**Action:** Prefer `extend` + comprehension for filter-and-collect loops without side effects.

--- a/src/modules/email_ingestion.py
+++ b/src/modules/email_ingestion.py
@@ -410,9 +410,9 @@ class EmailIngestionManager:
             results = parse_executor.map(
                 lambda args: client.parse_email(args[0], args[1], folder), raw_emails
             )
-            for email_data in results:
-                if email_data:
-                    folder_emails.append(email_data)
+            folder_emails.extend(
+                [email_data for email_data in results if email_data]
+            )
 
     def _fetch_folder(
         self,


### PR DESCRIPTION
## Summary
Salvages conflicted Bolt #1314 onto `main`:
- `email_ingestion._parse_emails_parallel` uses `extend` + list comprehension
- Append-only `.jules/bolt.md` journal entry

## Test plan
- [x] `python3 -m py_compile src/modules/email_ingestion.py`
- [ ] CI pytest

═══ ELIR ═══
PURPOSE: Recover parse-collect micro-opt blocked by bolt.md conflict.
SECURITY: No auth/secrets; filter semantics unchanged (still drops falsy parses).
FAILS IF: parallel parse executor contract changes.
VERIFY: py_compile + ingestion tests in CI.
MAINTAIN: Append-only journals when salvaging sibling Bolt PRs.

Supersedes #1314.