### PR TITLE
perf(ingestion): extend+comprehension parse collect (salvages #1335/#1314)

### DIFF
--- a/src/modules/email_ingestion.py
+++ b/src/modules/email_ingestion.py
@@ -420,9 +420,9 @@ class EmailIngestionManager:
             results = parse_executor.map(
                 lambda args: client.parse_email(args[0], args[1], folder), raw_emails
             )
-            for email_data in results:
-                if email_data:
-                    folder_emails.append(email_data)
+            folder_emails.extend(
+                [email_data for email_data in results if email_data]
+            )
 
     def _fetch_folder(self, context: FetchContext) -> list:
         folder_emails = []


### PR DESCRIPTION
## TL;DR
Draft re-salvage of conflicted [#1335](https://github.com/abhimehro/email-security-pipeline/pull/1335) (itself a salvage of #1314): replace append-loop with `extend` + comprehension in parse collect.

## Why
#1335 went `CONFLICTING` after sibling merges on `email_ingestion.py`. Change is still absent from `main`.

## Verify
```bash
python3 -m py_compile src/modules/email_ingestion.py
python3 -m pytest -q --tb=no  # or CI
```

## ELIR
**PURPOSE:** Land a small perf/clarity collect rewrite stranded by conflicts.  
**SECURITY:** No auth/secrets surface; ingestion behavior unchanged for non-empty parses.  
**FAILS IF:** Callers relied on append side-effects (none expected).  
**VERIFY:** Diff is three lines in `email_ingestion.py`.  
**MAINTAIN:** Prefer this over reopening #1335/#1314.

**Tier:** T3 · draft-only · security-classified repo → human merge  
Refs: #1335 #1314