### PR TITLE
refactor(parser): validate_subject_length + restore warning assert (salvages #1320)

### DIFF
--- a/src/modules/email_parser.py
+++ b/src/modules/email_parser.py
@@ -31,6 +31,7 @@ from ..utils.security_validators import (
     MAX_MIME_PARTS,
     MAX_SUBJECT_LENGTH,
     sanitize_filename,
+    validate_subject_length,
 )
 from .email_data import EmailData
 
@@ -182,12 +183,7 @@ class EmailParser:
         """
         subject = self._decode_header_value(msg.get("Subject", ""))
 
-        if len(subject) > MAX_SUBJECT_LENGTH:
-            subject = subject[:MAX_SUBJECT_LENGTH]
-            safe_id = sanitize_for_logging(email_id)
-            self.logger.warning(
-                f"Subject truncated to {MAX_SUBJECT_LENGTH} chars for email {safe_id}"
-            )
+        subject = validate_subject_length(subject)
 
         return subject
 

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -16,7 +16,7 @@ from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from src.modules.email_parser import EmailParser, EmailParserConfig
 from src.utils.config import EmailAccountConfig
@@ -582,15 +582,17 @@ class TestHeaderSizeLimits(unittest.TestCase):
 
     def test_oversized_subject_logs_warning(self):
         """Truncating an oversized subject must produce a warning log."""
-        self.parser.parse_email(
-            "hdr-warn",
-            _simple_raw(subject="W" * (MAX_SUBJECT_LENGTH + 100)),
-            "INBOX",
-        )
-        warning_texts = [str(c) for c in self.parser.logger.warning.call_args_list]
+        # Logging moved into validate_subject_length (security_validators).
+        with patch("src.utils.security_validators.logger") as mock_logger:
+            self.parser.parse_email(
+                "hdr-warn",
+                _simple_raw(subject="W" * (MAX_SUBJECT_LENGTH + 100)),
+                "INBOX",
+            )
+            warning_texts = [str(c) for c in mock_logger.warning.call_args_list]
         self.assertTrue(
             any(
-                "truncated" in t.lower() or str(MAX_SUBJECT_LENGTH) in t
+                "truncat" in t.lower() or str(MAX_SUBJECT_LENGTH) in t
                 for t in warning_texts
             ),
             f"Expected a truncation warning, got: {warning_texts}",


### PR DESCRIPTION
## TL;DR
Salvages [#1320](https://github.com/abhimehro/email-security-pipeline/pull/1320) onto `main` **and restores** `test_oversized_subject_logs_warning` (was stubbed to `pass`).

## What changed
- `_extract_subject` calls `validate_subject_length`
- Warning assertion patches `src.utils.security_validators.logger` (logging lives there now)

## Verify
```bash
python3 -m pytest tests/test_email_parser.py::TestHeaderSizeLimits -q
```
Local: **7 passed**.

## Policy
Draft-only — **no autonomous merge** (Phase 2 S1).

═══ ELIR ═══
PURPOSE: Keep subject DoS truncation centralized without dropping the warning regression test.
SECURITY: Same MAX_SUBJECT_LENGTH truncation path; no new trust boundary.
FAILS IF: Logger path for validate_subject_length changes without updating the patch target.
VERIFY: TestHeaderSizeLimits green.
MAINTAIN: Never accept `pass` as a replacement for the truncation-warning assertion.

Closes / supersedes: #1320