### PR TITLE
🎨 Palette: Add typing hint to password prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -238,3 +238,6 @@
 ## 2026-07-19 - Clearer visual hierarchy for CLI errors
 **Learning:** When a terminal application displays validation errors, presenting the entire string in red makes it harder for users to distinguish the failure reason from the required action, increasing friction.
 **Action:** Separate error descriptions (in `Colors.RED`) from actionable remediation advice (in `Colors.YELLOW`) to establish a clear visual hierarchy and guide users to immediate resolution.
+## 2026-07-24 - Added hidden typing hint
+**Learning:** Users can get confused when CLI password prompts don't show keystrokes, leading to abandoned setups.
+**Action:** Always add a grey '(typing will be hidden)' hint before the cursor on getpass prompts.

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -279,6 +279,7 @@ def _prompt_for_password(provider_name: str) -> str:
     prompt = (
         Colors.colorize("? ", Colors.CYAN)
         + Colors.colorize(f"Enter your {provider_name} app password ", Colors.BOLD)
+        + Colors.colorize("(typing will be hidden) ", Colors.GREY)
         + Colors.colorize("*", Colors.RED)
         + Colors.colorize(": ", Colors.BOLD)
     )


### PR DESCRIPTION
💡 What: Added a '(typing will be hidden)' hint to the password prompt.
🎯 Why: Users often get confused and think the terminal is frozen when keystrokes aren't echoed during password entry. This small hint improves the setup UX.
♿ Accessibility: Improves clarity for cognitive accessibility.

---
*PR created automatically by Jules for task [9294475714898158122](https://jules.google.com/task/9294475714898158122) started by @abhimehro*