### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in configuration file permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -54,3 +54,8 @@
 **Vulnerability:** The application used `urlparse(url).netloc` to extract the domain for spam checks and configuration validation.
 **Learning:** `netloc` includes the credentials and port (e.g., `user:pass@domain:port`), which bypasses simple string-matching spam filters. An attacker could craft a URL like `http://domain.com:80@malicious.com` or `http://malicious.com:80` and bypass the filter.
 **Prevention:** Always use `urllib.parse.urlparse(url).hostname` instead of `.netloc` to accurately extract the domain name for validation. Ensure you handle `None` values (e.g., `(parsed.hostname or "").lower()`).
+
+## 2025-07-25 - Fix TOCTOU fallback vulnerability in permissions
+**Vulnerability:** Path-based chmod operations with inode verification fallback were vulnerable to TOCTOU attacks if `follow_symlinks=False` was unsupported by `os.chmod` on certain platforms.
+**Learning:** Relying on `os.chmod` platform checks for symlink support introduces wide regression surfaces and potential TOCTOU windows on unsupported platforms. Strict failure is safer.
+**Prevention:** Strictly enforce operations on open file descriptors (`os.fchmod` or `os.chmod` with an FD). Completely remove path-based permission fallbacks.

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -120,31 +120,10 @@ class AppRunner:
         try:
             os.chmod(fd, SECURE_MODE)
             return
-        except (AttributeError, TypeError):
-            pass  # chmod doesn't support fd on this platform
 
-        # Fallback 2: path-based chmod with TOCTOU detection
-        try:
-            # Get file stats via fd
-            fd_stat = os.fstat(fd)
-
-            # Get file stats via path
-            path_stat = os.lstat(self.config_file)
-
-            # TOCTOU detection: verify inode and device match
-            if fd_stat.st_ino != path_stat.st_ino or fd_stat.st_dev != path_stat.st_dev:
-                print(
-                    "✖ " + Colors.colorize("CRITICAL: TOCTOU detected during permission setting. Aborting.", Colors.RED)
-                )
-                self._print_fallback_instructions()
-                sys.exit(1)
-
-            # Use follow_symlinks=False to prevent symlink attacks
-            os.chmod(self.config_file, SECURE_MODE, follow_symlinks=False)
-            return
-        except OSError as e:
+        except (AttributeError, TypeError, OSError, NotImplementedError):
             print(
-                "✖ " + Colors.colorize(f"CRITICAL: Failed to set secure permissions: {e}", Colors.RED)
+                "✖ " + Colors.colorize("CRITICAL: Failed to set secure permissions. Secure file descriptor operations are not supported on this platform.", Colors.RED)
             )
             self._print_fallback_instructions()
             sys.exit(1)

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -439,45 +439,15 @@ def _set_file_permissions(fd: int, config_path: Path) -> None:
             # Some platforms support os.chmod(fd, mode)
             os.chmod(fd, 0o600)
         except (AttributeError, OSError, NotImplementedError, TypeError):
-            # Final fallback to path-based chmod with inode verification.
-            try:
-                stat_fd = os.fstat(fd)
-                config_path_str = str(config_path)
-                stat_path = (
-                    os.lstat(config_path_str)
-                    if hasattr(os, "lstat")
-                    else os.stat(config_path_str)
+            print(
+                "\n✖ "
+                + Colors.colorize(
+                    "Error: Failed to set secure permissions. Secure file descriptor operations are not supported on this platform.", Colors.RED
                 )
-                if (
-                    stat_fd.st_ino == stat_path.st_ino
-                    and stat_fd.st_dev == stat_path.st_dev
-                ):
-                    chmod_kwargs = (
-                        {"follow_symlinks": False}
-                        if os.chmod in getattr(os, "supports_follow_symlinks", set())
-                        else {}
-                    )
-                    os.chmod(config_path_str, 0o600, **chmod_kwargs)
-                else:
-                    print(
-                        "\n✖ "
-                        + Colors.colorize(
-                            "Error: TOCTOU detected on " + str(config_path), Colors.RED
-                        )
-                    )
-                    import sys
+            )
+            import sys
 
-                    sys.exit(1)
-            except OSError as exc:
-                print(
-                    "\n✖ "
-                    + Colors.colorize(
-                        "Error setting permissions: " + str(exc), Colors.RED
-                    )
-                )
-                import sys
-
-                sys.exit(1)
+            sys.exit(1)
 
 
 def _write_config_file(config_file: str, new_content: str) -> bool:

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -160,79 +160,12 @@ def test_set_secure_permissions_fallback_chmod_fd(
     mock_chmod.assert_called_once_with(123, 0o600)
 
 
-def test_set_secure_permissions_fallback_chmod_path(mock_app_runner):
-    with patch("os.fchmod") as mock_fchmod, patch("os.fstat") as mock_fstat, patch(
-        "os.lstat"
-    ) as mock_lstat, patch("os.chmod") as mock_chmod:
-        import os
-
-        mock_fchmod.side_effect = AttributeError("fchmod not available")
-        mock_chmod.side_effect = [TypeError("chmod fd not supported"), None]
-
-        mock_stat_fd = MagicMock()
-        mock_stat_fd.st_ino = 1
-        mock_stat_fd.st_dev = 2
-        mock_fstat.return_value = mock_stat_fd
-
-        mock_stat_path = MagicMock()
-        mock_stat_path.st_ino = 1
-        mock_stat_path.st_dev = 2
-        mock_lstat.return_value = mock_stat_path
-
-        # Mock the follow_symlinks support
-        original_supports = os.supports_follow_symlinks
-        os.supports_follow_symlinks = {os.chmod}
-
-        try:
-            mock_app_runner._set_secure_permissions(123)
-
-            mock_fchmod.assert_called_once_with(123, 0o600)
-            assert mock_chmod.call_count == 2
-            assert mock_chmod.call_args_list[0] == ((123, 0o600), {})
-            assert mock_chmod.call_args_list[1] == (
-                (mock_app_runner.config_file, 0o600),
-                {"follow_symlinks": False},
-            )
-        finally:
-            os.supports_follow_symlinks = original_supports
-
-
-def test_set_secure_permissions_toctou_detected(mock_app_runner):
+def test_set_secure_permissions_fallback_failure(mock_app_runner):
     with patch("os.fchmod") as mock_fchmod, patch("os.chmod") as mock_chmod, patch(
-        "os.fstat"
-    ) as mock_fstat, patch("os.lstat") as mock_lstat, patch(
         "src.app_runner.sys.exit"
     ) as mock_exit:
         mock_fchmod.side_effect = AttributeError("fchmod not available")
         mock_chmod.side_effect = TypeError("chmod fd not supported")
-        mock_exit.side_effect = SystemExit(1)
-
-        mock_stat_fd = MagicMock()
-        mock_stat_fd.st_ino = 1
-        mock_stat_fd.st_dev = 2
-        mock_fstat.return_value = mock_stat_fd
-
-        mock_stat_path = MagicMock()
-        mock_stat_path.st_ino = 3  # Different inode
-        mock_stat_path.st_dev = 2
-        mock_lstat.return_value = mock_stat_path
-
-        import pytest
-
-        with pytest.raises(SystemExit) as excinfo:
-            mock_app_runner._set_secure_permissions(123)
-
-        assert excinfo.value.code == 1
-        mock_exit.assert_called_once_with(1)
-
-
-def test_set_secure_permissions_oserror(mock_app_runner):
-    with patch("os.fchmod") as mock_fchmod, patch("os.chmod") as mock_chmod, patch(
-        "os.fstat"
-    ) as mock_fstat, patch("src.app_runner.sys.exit") as mock_exit:
-        mock_fchmod.side_effect = AttributeError("fchmod not available")
-        mock_chmod.side_effect = TypeError("chmod fd not supported")
-        mock_fstat.side_effect = OSError("Permission denied")
         mock_exit.side_effect = SystemExit(1)
 
         import pytest


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path-based chmod operation falls back to inode/device checking, but on platforms lacking `follow_symlinks=False` support for `os.chmod`, it remains exploitable to symlink TOCTOU attacks.
🎯 Impact: An attacker with local access could exploit the TOCTOU window to change permissions of unintended files via symlinks.
🔧 Fix: Removed path-based fallbacks entirely. The code now strictly relies on file descriptors (`os.fchmod` or `os.chmod(fd)`) and safely exits if neither is available.
✅ Verification: Tests updated and passed.

---
*PR created automatically by Jules for task [7141099247509225911](https://jules.google.com/task/7141099247509225911) started by @abhimehro*