### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in file permission fallback

### DIFF
--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -437,43 +437,16 @@ def _exit_with_error(message: str) -> None:
     sys.exit(1)
 
 
-def _set_permissions_fallback(fd: int, config_path: Path) -> None:
-    """Fallback logic for setting permissions when fchmod fails."""
-    try:
-        stat_fd = os.fstat(fd)
-        config_path_str = str(config_path)
-        stat_path = (
-            os.lstat(config_path_str)
-            if hasattr(os, "lstat")
-            else os.stat(config_path_str)
-        )
-        if stat_fd.st_ino != stat_path.st_ino or stat_fd.st_dev != stat_path.st_dev:
-            _exit_with_error("Error: TOCTOU detected on " + str(config_path))
-
-        # We can't rely on os.chmod(path) without follow_symlinks=False.
-        # Since we have the fd, we should try os.chmod(fd, mode) if the platform supports it,
-        # or error out to avoid a TOCTOU vulnerability.
-        if os.chmod in getattr(os, "supports_follow_symlinks", set()):
-            os.chmod(config_path_str, 0o600, follow_symlinks=False)
-        elif os.chmod in getattr(os, "supports_fd", set()):
-            os.chmod(fd, 0o600)
-        else:
-            _exit_with_error("Error: Cannot securely set file permissions on this platform.")
-    except OSError as exc:
-        _exit_with_error("Error setting permissions: " + str(exc))
-
-
 def _set_file_permissions(fd: int, config_path: Path) -> None:
     """Set file permissions securely to prevent TOCTOU vulnerabilities."""
     try:
         os.fchmod(fd, 0o600)
-    except (AttributeError, OSError, NotImplementedError) as e_primary:
+    except (AttributeError, OSError, NotImplementedError):
         try:
             # Some platforms support os.chmod(fd, mode)
             os.chmod(fd, 0o600)
         except (AttributeError, OSError, NotImplementedError, TypeError):
-            # Final fallback to path-based chmod with inode verification.
-            _set_permissions_fallback(fd, config_path)
+            _exit_with_error("Error: Cannot securely set file permissions on this platform.")
 
 
 def _write_config_file(config_file: str, new_content: str) -> bool:


### PR DESCRIPTION
Removed path-based fallback mechanism for setting file permissions in setup_wizard.py to prevent TOCTOU symlink vulnerabilities. The system now fails securely if atomic fchmod operations are unavailable.

---
*PR created automatically by Jules for task [14165126588835648087](https://jules.google.com/task/14165126588835648087) started by @abhimehro*