### PR TITLE
🎨 Palette: Dim repetitive "No new emails" log message

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -241,3 +241,6 @@
 ## 2026-07-24 - Added hidden typing hint
 **Learning:** Users can get confused when CLI password prompts don't show keystrokes, leading to abandoned setups.
 **Action:** Always add a grey '(typing will be hidden)' hint before the cursor on getpass prompts.
+## 2026-07-27 - Dim repetitive polling messages
+**Learning:** Repetitive polling messages ("No new emails to analyze") create significant visual noise in the CLI, drowning out important events like threat detections.
+**Action:** Identify and apply subtle coloring (like GREY) to high-frequency, non-actionable log messages to improve the signal-to-noise ratio and visual hierarchy in the terminal UX.

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -40,6 +40,9 @@ class ColoredFormatter(logging.Formatter):
             elif "Waiting" in record.msg and "seconds until next check" in record.msg:
                 # Dim the waiting message to reduce visual noise
                 record.msg = Colors.colorize(str(record.msg), Colors.GREY)
+            elif "No new emails to analyze" in record.msg:
+                # Dim the repetitive no emails message to reduce visual noise
+                record.msg = Colors.colorize(str(record.msg), Colors.GREY)
             elif "Analysis complete" in record.msg:
                 # Highlight success
                 record.msg = Colors.colorize(str(record.msg), Colors.GREEN)

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -221,5 +221,12 @@ class TestColoredFormatter(unittest.TestCase):
         )
 
 
+    def test_no_new_emails_gets_grey(self):
+        """'No new emails to analyze' messages are dimmed with GREY."""
+        Formatter, C = self._reload_with_tty()
+        record = self._make_record("No new emails to analyze")
+        output = Formatter("%(message)s").format(record)
+        self.assertIn(C.GREY, output)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
💡 What: Dimmed the repetitive "No new emails to analyze" log message to grey.
🎯 Why: Reduces visual noise in the console for the most common, non-actionable event.
♿ Accessibility: Improves visual hierarchy by making important events (like threats or errors) stand out more against the background noise.

---
*PR created automatically by Jules for task [18164890487016773937](https://jules.google.com/task/18164890487016773937) started by @abhimehro*