### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in file permission logic

### DIFF
--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -437,43 +437,17 @@ def _exit_with_error(message: str) -> None:
     sys.exit(1)
 
 
-def _set_permissions_fallback(fd: int, config_path: Path) -> None:
-    """Fallback logic for setting permissions when fchmod fails."""
-    try:
-        stat_fd = os.fstat(fd)
-        config_path_str = str(config_path)
-        stat_path = (
-            os.lstat(config_path_str)
-            if hasattr(os, "lstat")
-            else os.stat(config_path_str)
-        )
-        if stat_fd.st_ino != stat_path.st_ino or stat_fd.st_dev != stat_path.st_dev:
-            _exit_with_error("Error: TOCTOU detected on " + str(config_path))
-
-        # We can't rely on os.chmod(path) without follow_symlinks=False.
-        # Since we have the fd, we should try os.chmod(fd, mode) if the platform supports it,
-        # or error out to avoid a TOCTOU vulnerability.
-        if os.chmod in getattr(os, "supports_follow_symlinks", set()):
-            os.chmod(config_path_str, 0o600, follow_symlinks=False)
-        elif os.chmod in getattr(os, "supports_fd", set()):
-            os.chmod(fd, 0o600)
-        else:
-            _exit_with_error("Error: Cannot securely set file permissions on this platform.")
-    except OSError as exc:
-        _exit_with_error("Error setting permissions: " + str(exc))
-
-
-def _set_file_permissions(fd: int, config_path: Path) -> None:
+def _set_file_permissions(fd: int) -> None:
     """Set file permissions securely to prevent TOCTOU vulnerabilities."""
     try:
         os.fchmod(fd, 0o600)
-    except (AttributeError, OSError, NotImplementedError) as e_primary:
+    except (AttributeError, OSError, NotImplementedError):
         try:
             # Some platforms support os.chmod(fd, mode)
             os.chmod(fd, 0o600)
         except (AttributeError, OSError, NotImplementedError, TypeError):
-            # Final fallback to path-based chmod with inode verification.
-            _set_permissions_fallback(fd, config_path)
+            # Fail securely if atomic operations are unavailable
+            _exit_with_error("Error: Cannot securely set file permissions on this platform.")
 
 
 def _write_config_file(config_file: str, new_content: str) -> bool:
@@ -495,7 +469,7 @@ def _write_config_file(config_file: str, new_content: str) -> bool:
         # We prioritize using the file descriptor (fchmod or chmod with FD) to prevent TOCTOU
         # vulnerabilities. Path-based chmod is only used as a final fallback on systems
         # that don't support FD-based permission changes (like some older Windows versions).
-        _set_file_permissions(fd, config_path)
+        _set_file_permissions(fd)
 
         with os.fdopen(fd, "w") as f:
             f.write(new_content)


### PR DESCRIPTION
🚨 Severity: HIGH\n💡 Vulnerability: The `_set_file_permissions` fallback logic for creating config files was vulnerable to Time-of-Check to Time-of-Use (TOCTOU) symlink attacks if the platform didn't support file descriptor based chmod operations and `follow_symlinks` parameter.\n🎯 Impact: An attacker could bypass permission checks by swapping the file with a symlink between the inode check and the permission setting.\n🔧 Fix: Removed path-based fallback mechanisms relying on inode/device verification for security-critical files entirely. Fail securely instead if atomic operations (`fchmod` or `chmod` with fd) are unavailable. Removed unused `config_path` argument from `_set_file_permissions`.\n✅ Verification: Ran `pytest tests/test_setup_wizard.py` successfully.

---
*PR created automatically by Jules for task [10234813086896534928](https://jules.google.com/task/10234813086896534928) started by @abhimehro*