### PR TITLE
Fix: Remove unused import in email_parser.py

### DIFF
--- a/src/modules/email_parser.py
+++ b/src/modules/email_parser.py
@@ -29,7 +29,6 @@ from ..utils.config import EmailAccountConfig
 from ..utils.sanitization import sanitize_for_logging
 from ..utils.security_validators import (
     MAX_MIME_PARTS,
-    MAX_SUBJECT_LENGTH,
     sanitize_filename,
     validate_subject_length,
 )


### PR DESCRIPTION
Repository Health Review:
- Build and tests pass.
- Found and fixed a flake8 linting error in src/modules/email_parser.py by removing an unused import.

Commands used during verification:
- `python3 -m pytest tests/`
- `pre-commit run --all-files`
- `flake8 src/ tests/`

---
*PR created automatically by Jules for task [7228859577559045578](https://jules.google.com/task/7228859577559045578) started by @abhimehro*