### PR TITLE
chore(actions): bump release-drafter to v7.7.0 (salvages #1381)

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7.6.0
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         with:
           commitish: ${{ github.event.pull_request.head.sha || github.sha }}
         env:


### PR DESCRIPTION
## What

Surgical salvage of the **only unique residual** from #1381 after #1366 landed on `main`: bump `release-drafter/release-drafter` from v7.6.0 → **v7.7.0** (SHA `34d80673…`).

## Why

#1381 is a two-dot twin of #1366 that mostly rewrites already-pinned `actions/checkout` SHAs. Merging it wholesale would churn pins without benefit (Lesson **0ev**). The release-drafter bump is the sole keepable delta.

## How

- Branched from current `main`
- Single-file edit: `.github/workflows/release-drafter.yml`
- Did **not** carry checkout SHA churn from #1381

## Testing

- [x] Human: confirm release draft still updates on next merge to `main`
- Diff is one line; no pytest surface

## Security

Trust-boundary: GitHub Actions third-party action pin. SHA pinned (not floating tag). Security-classified repo — left as **draft** for human merge (S1/S6). Phase 2 never auto-merges.

═══ ELIR ═══
PURPOSE: Land release-drafter v7.7.0 without regressing checkout pins from #1366.
SECURITY: SHA-pinned action; no secrets changed; draft-only for human ack.
FAILS IF: release-drafter SHA is wrong / action unavailable.
VERIFY: After merge, confirm next `update_release_draft` job succeeds.
MAINTAIN: Close #1381 as superseded by this PR; do not re-open the twin.

Refs: #1381 (salvage source)