### PR TITLE
refactor(repo-health): split media_analyzer and alert_system god modules

### DIFF
--- a/src/modules/alert_channels.py
+++ b/src/modules/alert_channels.py
@@ -8,7 +8,7 @@ webhook and Slack alerting. HTTP calls remain in the alert facade.
 import re
 from dataclasses import asdict
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from ..utils.colors import Colors

--- a/src/modules/alert_channels.py
+++ b/src/modules/alert_channels.py
@@ -1,0 +1,352 @@
+"""
+Alert channel helpers.
+
+Handles payload construction, text/URL sanitization, and token redaction for
+webhook and Slack alerting. HTTP calls remain in the alert facade.
+"""
+
+import re
+from dataclasses import asdict
+from datetime import datetime
+from typing import Any, Dict, List
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+from ..utils.colors import Colors
+from ..utils.sanitization import (
+    _TRANSLATOR,
+    _WHITESPACE_TRANS,
+    ANSI_ESCAPE_PATTERN,
+    sanitize_for_csv,
+)
+from .alert_report import ThreatReport
+
+
+# Regex pattern for extracting URLs from error messages (compiled once for performance)
+# Expanded to catch bare paths/hosts for complete redaction when scheme is missing.
+URL_PATTERN = re.compile(r'(?:https?://[^\s<>"]+|www\.[^\s<>"]+|/[^\s<>"]+)')
+
+# Pre-compiled pattern for fast URL redaction replacement without re.IGNORECASE penalty
+REDACTED_URL_PATTERN = re.compile(r"%5[bB]REDACTED%5[dD]", flags=0)
+
+
+def sanitize_text(text: str, csv_safe: bool = False) -> str:
+    """
+    Sanitize text for safe output.
+    Removes control characters, BiDi overrides, and normalizes whitespace.
+
+    Args:
+        text: Input text
+        csv_safe: If True, applies CSV/Formula injection prevention
+
+    """
+    if not text:
+        return ""
+
+    # Replace newlines and tabs with spaces
+    sanitized = (
+        text.translate(_WHITESPACE_TRANS)
+        if "\n" in text or "\r" in text or "\t" in text
+        else text
+    )
+
+    if "\x1b" in sanitized:
+        sanitized = ANSI_ESCAPE_PATTERN.sub("", sanitized)
+
+    # Remove non-printable characters (including BiDi overrides, control chars, etc.)
+    # Only keep characters that are printable or separators (Zs)
+    # Optimization: Use str.translate with a lazy-evaluating dictionary
+    # for significantly faster filtering (~15-20x) than a list comprehension inside join().
+    sanitized = sanitized.translate(_TRANSLATOR)
+
+    if csv_safe:
+        # Prevent Formula/CSV Injection for console logs that might be exported
+        sanitized = sanitize_for_csv(sanitized)
+
+    return sanitized
+
+
+def sanitize_for_slack(text: str) -> str:
+    """
+    Sanitize text for Slack to prevent injection and spoofing.
+    Escapes &, <, > and sanitizes control characters.
+    """
+    if not text:
+        return ""
+
+    # First sanitize control characters using the existing method
+    # We do NOT use csv_safe=True here to avoid messing up Slack formatting
+    text = sanitize_text(text, csv_safe=False)
+
+    # Escape Slack special characters
+    # Reference: https://api.slack.com/reference/surfaces/formatting#escaping
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def sanitize_url_for_display(url: str) -> str:
+    """Redact sensitive tokens/parameters from a URL for safe console display."""
+    redacted = redact_url_secrets(url)
+    return REDACTED_URL_PATTERN.sub("[REDACTED]", redacted)
+
+
+def sanitize_error_message(error: str) -> str:
+    """
+    Sanitize exception messages to prevent leaking sensitive URLs/tokens.
+    Detects URLs in the error message and redacts them.
+    """
+    msg = str(error)
+    try:
+        # Find all URLs in the message
+        # Simple regex for http/https URLs to catch full URLs including query params
+        urls = URL_PATTERN.findall(msg)
+
+        for url in urls:
+            # Clean up trailing punctuation that might have been matched
+            clean_url = url.rstrip(".,;:)'")
+
+            # Apply redaction
+            redacted = redact_url_secrets(clean_url)
+
+            # If redaction changed anything, update the message
+            if redacted != clean_url:
+                msg = msg.replace(clean_url, redacted)
+
+        return msg
+    except Exception:
+        return "An error occurred (details redacted for security)"
+
+
+def redact_url_secrets(url: str) -> str:
+    """
+    Redact sensitive information from URL (query params and specific paths).
+    Handles Slack/Discord webhooks and sensitive query parameters.
+    """
+    try:
+        if not url:
+            return ""
+
+        # 1. Redact sensitive query parameters (reusing logic)
+        url = redact_sensitive_url_params(url)
+
+        parsed = urlparse(url)
+
+        # 2. Redact credentials in authority section
+        if parsed.password:
+            # Reconstruct URL with redacted password.
+            # Use netloc.rpartition to safely separate authority from host, preserving IPv6 brackets.
+            _, _, host_part = parsed.netloc.rpartition("@")
+
+            if parsed.username:
+                # Extract the raw username from the netloc to avoid re-encoding ambiguity
+                # parsed.netloc is "user:pass@host", so partition gives us "user:pass"
+                user_pass_part = parsed.netloc.rpartition("@")[0]
+                # Partition gives us "user"
+                username_part = user_pass_part.partition(":")[0]
+                new_netloc = f"{username_part}:[REDACTED]@{host_part}"
+            else:
+                # Case: https://:password@host (no username)
+                new_netloc = f":[REDACTED]@{host_part}"
+
+            parsed = parsed._replace(netloc=new_netloc)
+
+        # 3. Redact Slack Webhooks
+        # Format: /services/T000/B000/TOKEN
+        hostname = (parsed.hostname or "").lower()
+        if (
+            not hostname
+            or hostname == "hooks.slack.com"
+            or hostname.endswith(".slack.com")
+        ) and parsed.path.startswith("/services/"):
+            parts = parsed.path.split("/")
+            # parts[0] is empty, parts[1] is 'services'
+            # parts[2] is Team ID, parts[3] is Bot ID, parts[4] is Token
+            # We redact the token (last part)
+            if len(parts) >= 5:
+                parts[-1] = "[REDACTED]"
+                new_path = "/".join(parts)
+                parsed = parsed._replace(path=new_path)
+                return urlunparse(parsed)
+
+        # 4. Redact Discord Webhooks
+        # Format: /api/webhooks/ID/TOKEN
+        if (
+            not hostname
+            or hostname == "discord.com"
+            or hostname.endswith(".discord.com")
+        ) and parsed.path.startswith("/api/webhooks/"):
+            parts = parsed.path.split("/")
+            # parts[-1] is likely the token
+            if len(parts) >= 5:
+                parts[-1] = "[REDACTED]"
+                new_path = "/".join(parts)
+                parsed = parsed._replace(path=new_path)
+                return urlunparse(parsed)
+
+        return urlunparse(parsed)
+    except Exception:
+        return url
+
+
+def redact_sensitive_url_params(url: str) -> str:
+    """
+    Redact sensitive query parameters from URL.
+    Prevents leaking credentials or tokens in logs/alerts.
+    """
+    try:
+        if not url:
+            return ""
+
+        parsed = urlparse(url)
+        # keep_blank_values=True ensures we don't drop empty params
+        query_params = parse_qs(parsed.query, keep_blank_values=True)
+
+        sensitive_keys = {
+            "password",
+            "token",
+            "secret",
+            "key",
+            "apikey",
+            "api_key",
+            "access_token",
+            "auth",
+            "authorization",
+            "sig",
+            "signature",
+        }
+
+        changed = False
+        for key in query_params:
+            if key.lower() in sensitive_keys:
+                query_params[key] = ["[REDACTED]"]
+                changed = True
+
+        if changed:
+            # doseq=True handles lists of values correctly
+            new_query = urlencode(query_params, doseq=True)
+            parsed = parsed._replace(query=new_query)
+            return urlunparse(parsed)
+        return url
+    except Exception:
+        # If parsing fails, return original to avoid losing data,
+        # but rely on other sanitization layers if any.
+        return url
+
+
+def create_slack_field(title: str, analysis_dict: Dict[str, Any], indicator: str) -> Dict[str, Any]:
+    """Helper to create a standard Slack field dictionary with risk emojis."""
+    level = analysis_dict.get("risk_level", "unknown")
+    score = analysis_dict.get("score", 0)
+    symbol = Colors.get_risk_symbol(level)
+
+    value = f"{symbol} {level.upper()} ({score:.2f})"
+    if indicator:
+        value += f"{indicator}"
+
+    return {"title": title, "value": value, "short": True}
+
+
+def generate_slack_fields(report: ThreatReport) -> List[Dict[str, Any]]:
+    """Generate the fields array for the Slack payload."""
+    fields = [
+        {
+            "title": "Subject",
+            "value": sanitize_for_slack(report.subject),
+            "short": False,
+        },
+        {
+            "title": "From",
+            "value": sanitize_for_slack(report.sender),
+            "short": True,
+        },
+        {
+            "title": "Overall Threat Score",
+            "value": f"{report.overall_threat_score:.2f}",
+            "short": True,
+        },
+    ]
+
+    # Add analysis breakdown using helper method
+    # Spam
+    spam_data = report.spam_analysis or {}
+    spam_ind = ""
+    if spam_data.get("indicators"):
+        spam_ind = f" - {spam_data['indicators'][0]}"
+    elif spam_data.get("suspicious_urls"):
+        spam_ind = " - Suspicious URLs"
+
+    fields.append(create_slack_field("📧 Spam Analysis", spam_data, spam_ind))
+
+    # NLP
+    nlp_data = report.nlp_analysis or {}
+    nlp_ind = ""
+    if nlp_data.get("social_engineering_indicators"):
+        nlp_ind = f" - {nlp_data['social_engineering_indicators'][0]}"
+    elif nlp_data.get("authority_impersonation"):
+        nlp_ind = f" - {nlp_data['authority_impersonation'][0]}"
+
+    fields.append(create_slack_field("🧠 NLP Analysis", nlp_data, nlp_ind))
+
+    # Media
+    media_data = report.media_analysis or {}
+    media_ind = ""
+    if media_data.get("file_type_warnings"):
+        media_ind = f" - {media_data['file_type_warnings'][0]}"
+    elif media_data.get("potential_deepfakes"):
+        media_ind = " - Deepfake Detected"
+
+    fields.append(create_slack_field("📎 Media Analysis", media_data, media_ind))
+
+    # Top Recommendation
+    fields.append(
+        {
+            "title": "Top Recommendation",
+            "value": (
+                report.recommendations[0]
+                if report.recommendations
+                else "Review email"
+            ),
+            "short": False,
+        }
+    )
+    return fields
+
+
+def build_webhook_payload(report: ThreatReport) -> Dict[str, Any]:
+    """Build the JSON payload for a webhook alert with sensitive URL redaction."""
+    payload = asdict(report)
+
+    # Redact sensitive info from suspicious URLs if present
+    if (
+        "spam_analysis" in payload
+        and "suspicious_urls" in payload["spam_analysis"]
+    ):
+        urls = payload["spam_analysis"]["suspicious_urls"]
+        if urls:
+            payload["spam_analysis"]["suspicious_urls"] = [
+                redact_sensitive_url_params(url) for url in urls
+            ]
+
+    return payload
+
+
+def build_slack_payload(report: ThreatReport) -> Dict[str, Any]:
+    """Build the JSON payload for a Slack alert."""
+    color = {"low": "#36a64f", "medium": "#ff9900", "high": "#ff0000"}.get(
+        report.risk_level, "#808080"
+    )
+
+    fields = generate_slack_fields(report)
+
+    attachments = [
+        {
+            "color": color,
+            "title": (f"🚨 Security Alert - {report.risk_level.upper()} Risk"),
+            "fields": fields,
+            "footer": "Email Security Pipeline",
+            "ts": int(datetime.now().timestamp()),
+        }
+    ]
+
+    return {
+        "text": "New email security threat detected",
+        "attachments": attachments,
+    }

--- a/src/modules/alert_channels.py
+++ b/src/modules/alert_channels.py
@@ -8,7 +8,7 @@ webhook and Slack alerting. HTTP calls remain in the alert facade.
 import re
 from dataclasses import asdict
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from ..utils.colors import Colors
@@ -115,6 +115,43 @@ def sanitize_error_message(error: str) -> str:
         return "An error occurred (details redacted for security)"
 
 
+def _redact_authority_credentials(parsed: Any) -> Any:
+    """Redact password/credentials in the netloc of a parsed URL."""
+    if not parsed.password:
+        return parsed
+    _, _, host_part = parsed.netloc.rpartition("@")
+    if parsed.username:
+        user_pass_part = parsed.netloc.rpartition("@")[0]
+        username_part = user_pass_part.partition(":")[0]
+        new_netloc = f"{username_part}:[REDACTED]@{host_part}"
+    else:
+        new_netloc = f":[REDACTED]@{host_part}"
+    return parsed._replace(netloc=new_netloc)
+
+
+def _redact_webhook_by_platform(parsed: Any, prefix: str, domain: str) -> Optional[Any]:
+    """Helper to redact webhook token for a specific platform."""
+    hostname = (parsed.hostname or "").lower()
+    is_platform = not hostname or hostname == domain or hostname.endswith(f".{domain}")
+    if is_platform and parsed.path.startswith(prefix):
+        parts = parsed.path.split("/")
+        if len(parts) >= 5:
+            parts[-1] = "[REDACTED]"
+            new_path = "/".join(parts)
+            return parsed._replace(path=new_path)
+    return None
+
+
+def _redact_slack_webhook(parsed: Any) -> Optional[Any]:
+    """Redact Slack webhook token if applicable."""
+    return _redact_webhook_by_platform(parsed, "/services/", "slack.com")
+
+
+def _redact_discord_webhook(parsed: Any) -> Optional[Any]:
+    """Redact Discord webhook token if applicable."""
+    return _redact_webhook_by_platform(parsed, "/api/webhooks/", "discord.com")
+
+
 def redact_url_secrets(url: str) -> str:
     """
     Redact sensitive information from URL (query params and specific paths).
@@ -124,62 +161,18 @@ def redact_url_secrets(url: str) -> str:
         if not url:
             return ""
 
-        # 1. Redact sensitive query parameters (reusing logic)
         url = redact_sensitive_url_params(url)
-
         parsed = urlparse(url)
 
-        # 2. Redact credentials in authority section
-        if parsed.password:
-            # Reconstruct URL with redacted password.
-            # Use netloc.rpartition to safely separate authority from host, preserving IPv6 brackets.
-            _, _, host_part = parsed.netloc.rpartition("@")
+        parsed = _redact_authority_credentials(parsed)
 
-            if parsed.username:
-                # Extract the raw username from the netloc to avoid re-encoding ambiguity
-                # parsed.netloc is "user:pass@host", so partition gives us "user:pass"
-                user_pass_part = parsed.netloc.rpartition("@")[0]
-                # Partition gives us "user"
-                username_part = user_pass_part.partition(":")[0]
-                new_netloc = f"{username_part}:[REDACTED]@{host_part}"
-            else:
-                # Case: https://:password@host (no username)
-                new_netloc = f":[REDACTED]@{host_part}"
+        slack_parsed = _redact_slack_webhook(parsed)
+        if slack_parsed:
+            return urlunparse(slack_parsed)
 
-            parsed = parsed._replace(netloc=new_netloc)
-
-        # 3. Redact Slack Webhooks
-        # Format: /services/T000/B000/TOKEN
-        hostname = (parsed.hostname or "").lower()
-        if (
-            not hostname
-            or hostname == "hooks.slack.com"
-            or hostname.endswith(".slack.com")
-        ) and parsed.path.startswith("/services/"):
-            parts = parsed.path.split("/")
-            # parts[0] is empty, parts[1] is 'services'
-            # parts[2] is Team ID, parts[3] is Bot ID, parts[4] is Token
-            # We redact the token (last part)
-            if len(parts) >= 5:
-                parts[-1] = "[REDACTED]"
-                new_path = "/".join(parts)
-                parsed = parsed._replace(path=new_path)
-                return urlunparse(parsed)
-
-        # 4. Redact Discord Webhooks
-        # Format: /api/webhooks/ID/TOKEN
-        if (
-            not hostname
-            or hostname == "discord.com"
-            or hostname.endswith(".discord.com")
-        ) and parsed.path.startswith("/api/webhooks/"):
-            parts = parsed.path.split("/")
-            # parts[-1] is likely the token
-            if len(parts) >= 5:
-                parts[-1] = "[REDACTED]"
-                new_path = "/".join(parts)
-                parsed = parsed._replace(path=new_path)
-                return urlunparse(parsed)
+        discord_parsed = _redact_discord_webhook(parsed)
+        if discord_parsed:
+            return urlunparse(discord_parsed)
 
         return urlunparse(parsed)
     except Exception:
@@ -244,6 +237,18 @@ def create_slack_field(title: str, analysis_dict: Dict[str, Any], indicator: str
     return {"title": title, "value": value, "short": True}
 
 
+def _get_analysis_indicator(data: Dict[str, Any], keys: List[str], defaults: Dict[str, str]) -> str:
+    """Extract a descriptive indicator from analysis data."""
+    for key in keys:
+        val = data.get(key)
+        if val:
+            if isinstance(val, list) and val:
+                return f" - {val[0]}"
+            elif key in defaults:
+                return f" - {defaults[key]}"
+    return ""
+
+
 def generate_slack_fields(report: ThreatReport) -> List[Dict[str, Any]]:
     """Generate the fields array for the Slack payload."""
     fields = [
@@ -264,35 +269,25 @@ def generate_slack_fields(report: ThreatReport) -> List[Dict[str, Any]]:
         },
     ]
 
-    # Add analysis breakdown using helper method
     # Spam
     spam_data = report.spam_analysis or {}
-    spam_ind = ""
-    if spam_data.get("indicators"):
-        spam_ind = f" - {spam_data['indicators'][0]}"
-    elif spam_data.get("suspicious_urls"):
-        spam_ind = " - Suspicious URLs"
-
+    spam_ind = _get_analysis_indicator(
+        spam_data, ["indicators", "suspicious_urls"], {"suspicious_urls": "Suspicious URLs"}
+    )
     fields.append(create_slack_field("📧 Spam Analysis", spam_data, spam_ind))
 
     # NLP
     nlp_data = report.nlp_analysis or {}
-    nlp_ind = ""
-    if nlp_data.get("social_engineering_indicators"):
-        nlp_ind = f" - {nlp_data['social_engineering_indicators'][0]}"
-    elif nlp_data.get("authority_impersonation"):
-        nlp_ind = f" - {nlp_data['authority_impersonation'][0]}"
-
+    nlp_ind = _get_analysis_indicator(
+        nlp_data, ["social_engineering_indicators", "authority_impersonation"], {}
+    )
     fields.append(create_slack_field("🧠 NLP Analysis", nlp_data, nlp_ind))
 
     # Media
     media_data = report.media_analysis or {}
-    media_ind = ""
-    if media_data.get("file_type_warnings"):
-        media_ind = f" - {media_data['file_type_warnings'][0]}"
-    elif media_data.get("potential_deepfakes"):
-        media_ind = " - Deepfake Detected"
-
+    media_ind = _get_analysis_indicator(
+        media_data, ["file_type_warnings", "potential_deepfakes"], {"potential_deepfakes": "Deepfake Detected"}
+    )
     fields.append(create_slack_field("📎 Media Analysis", media_data, media_ind))
 
     # Top Recommendation

--- a/src/modules/alert_channels.py
+++ b/src/modules/alert_channels.py
@@ -242,10 +242,12 @@ def _get_analysis_indicator(data: Dict[str, Any], keys: List[str], defaults: Dic
     for key in keys:
         val = data.get(key)
         if val:
+            # Prefer a generic label when one is configured (e.g. "Suspicious URLs"),
+            # otherwise show the first concrete item from the list.
+            if key in defaults:
+                return f" - {defaults[key]}"
             if isinstance(val, list) and val:
                 return f" - {val[0]}"
-            elif key in defaults:
-                return f" - {defaults[key]}"
     return ""
 
 

--- a/src/modules/alert_console.py
+++ b/src/modules/alert_console.py
@@ -539,5 +539,3 @@ def render_clean_report(report: ThreatReport, threat_low: float, terminal_width:
         f"{sep} From: {sender:<{sender_width}} "
         f"{sep} {subject}"
     )
-
-

--- a/src/modules/alert_console.py
+++ b/src/modules/alert_console.py
@@ -369,10 +369,11 @@ def print_analysis_details(
 
 def _strip_recommendation_prefix(rec: str) -> str:
     """Remove existing prefixes to prevent double icons."""
-    if rec.startswith(RECOMMENDATION_PREFIXES_TUPLE):
+    while rec.startswith(RECOMMENDATION_PREFIXES_TUPLE):
         for prefix in RECOMMENDATION_PREFIXES:
             if rec.startswith(prefix):
-                return rec[len(prefix) :]
+                rec = rec[len(prefix) :]
+                break
     return rec
 
 
@@ -415,8 +416,10 @@ def print_recommendations(
     print_alert_row("", risk_color)
 
     for rec in recommendations:
-        rec = _strip_recommendation_prefix(rec)
+        # Compute uppercase before stripping prefixes so keyword matching matches
+        # the original implementation.
         rec_upper = rec.upper()
+        rec = _strip_recommendation_prefix(rec)
         color = _determine_recommendation_color(rec_upper)
         icon = "►"
 

--- a/src/modules/alert_console.py
+++ b/src/modules/alert_console.py
@@ -11,7 +11,11 @@ from typing import Dict, List
 
 from ..utils.colors import Colors
 from ..utils.sanitization import ANSI_ESCAPE_PATTERN
-from .alert_channels import sanitize_text, sanitize_url_for_display
+from .alert_channels import (
+    REDACTED_URL_PATTERN,
+    sanitize_text,
+    redact_sensitive_url_params,
+)
 from .alert_recommendations import (
     RECOMMENDATION_PREFIXES,
     RECOMMENDATION_PREFIXES_TUPLE,
@@ -64,7 +68,9 @@ def truncate_text(text: str, width: int) -> str:
 
 def safe_console_url(url: str) -> str:
     """Return a URL safe for console output with tokens redacted."""
-    redacted_url = sanitize_url_for_display(url)
+    redacted_url = REDACTED_URL_PATTERN.sub(
+        "[REDACTED]", redact_sensitive_url_params(url)
+    )
     return sanitize_text(redacted_url, csv_safe=True)
 
 

--- a/src/modules/alert_console.py
+++ b/src/modules/alert_console.py
@@ -306,10 +306,11 @@ def spam_detail_rows(
 def print_spam_details(
     spam_analysis: Dict,
     risk_color: str,
-    max_spam: int,
-    max_header: int,
-    max_urls: int,
+    limits: Dict[str, int],
 ) -> None:
+    max_spam = limits.get("MAX_SPAM_INDICATORS_DISPLAY", 5)
+    max_header = limits.get("MAX_HEADER_ISSUES_DISPLAY", 5)
+    max_urls = limits.get("MAX_URLS_DISPLAY", 3)
     rows = spam_detail_rows(spam_analysis, max_spam, max_header, max_urls)
     if not rows:
         print_alert_row(
@@ -342,9 +343,7 @@ def print_analysis_details(
     print_spam_details(
         report.spam_analysis,
         risk_color,
-        limits.get("MAX_SPAM_INDICATORS_DISPLAY", 5),
-        limits.get("MAX_HEADER_ISSUES_DISPLAY", 5),
-        limits.get("MAX_URLS_DISPLAY", 3),
+        limits,
     )
     print_alert_row("", risk_color)
 
@@ -368,6 +367,42 @@ def print_analysis_details(
     )
 
 
+def _strip_recommendation_prefix(rec: str) -> str:
+    """Remove existing prefixes to prevent double icons."""
+    if rec.startswith(RECOMMENDATION_PREFIXES_TUPLE):
+        for prefix in RECOMMENDATION_PREFIXES:
+            if rec.startswith(prefix):
+                return rec[len(prefix) :]
+    return rec
+
+
+def _determine_recommendation_color(rec_upper: str) -> str:
+    """Determine the recommendation color based on keywords."""
+    if RED_KEYWORDS_PATTERN.search(rec_upper):
+        return Colors.RED
+    if YELLOW_KEYWORDS_PATTERN.search(rec_upper):
+        return Colors.YELLOW
+    return Colors.GREEN
+
+
+def _print_wrapped_lines(wrapped_lines: List[str], icon: str, color: str, risk_color: str) -> None:
+    """Print wrapped recommendation lines with appropriate formatting."""
+    if not wrapped_lines:
+        return
+
+    # First line gets the bullet point
+    first_line = wrapped_lines[0]
+    print_alert_row(
+        f"{Colors.colorize(icon, color)} {first_line}", risk_color
+    )
+
+    # Subsequent lines get indentation based on icon width
+    indent = "   " if icon == "⚠️ " else "  "
+
+    for line in wrapped_lines[1:]:
+        print_alert_row(f"{indent}{line}", risk_color)
+
+
 def print_recommendations(
     recommendations: List[str], width: int, risk_color: str
 ):
@@ -380,48 +415,17 @@ def print_recommendations(
     print_alert_row("", risk_color)
 
     for rec in recommendations:
-        color = Colors.GREEN
+        rec = _strip_recommendation_prefix(rec)
         rec_upper = rec.upper()
+        color = _determine_recommendation_color(rec_upper)
         icon = "►"
 
-        # Remove existing prefixes to prevent double icons
-        # Optimization: tuple-based startswith executes entirely in C and avoids Python loop overhead
-        # We still need to find which prefix matched to slice it correctly, but the initial
-        # fast check filters out the vast majority of cases instantly.
-        if rec.startswith(RECOMMENDATION_PREFIXES_TUPLE):
-            for prefix in RECOMMENDATION_PREFIXES:
-                if rec.startswith(prefix):
-                    rec = rec[len(prefix) :]
-
-        # Optimization: compiled regex search is faster than any() generator loop for substring matching
-        if RED_KEYWORDS_PATTERN.search(rec_upper):
-            color = Colors.RED
-        elif YELLOW_KEYWORDS_PATTERN.search(rec_upper):
-            color = Colors.YELLOW
-
         # Calculate available width for text
-        # Width - 2 (left border/space) - 3 (icon + space) - 2 (right padding) = Width - 7
-        # We use 8 to be safe and consistent with previous layout
         max_text_width = width - 8
 
         # Wrap text nicely
         wrapped_lines = textwrap.wrap(rec, width=max_text_width)
-
-        if not wrapped_lines:
-            continue
-
-        # First line gets the bullet point
-        first_line = wrapped_lines[0]
-        print_alert_row(
-            f"{Colors.colorize(icon, color)} {first_line}", risk_color
-        )
-
-        # Subsequent lines get indentation based on icon width
-        # ► is 1 char, ⚠️ is 2 chars (usually). We align to 3 spaces for visual consistency.
-        indent = "   " if icon == "⚠️ " else "  "
-
-        for line in wrapped_lines[1:]:
-            print_alert_row(f"{indent}{line}", risk_color)
+        _print_wrapped_lines(wrapped_lines, icon, color, risk_color)
 
     # Bottom Border (└───┘)
     print(Colors.colorize(f"└{'─'*border_len}┘", risk_color))

--- a/src/modules/alert_console.py
+++ b/src/modules/alert_console.py
@@ -1,0 +1,543 @@
+"""
+Console alert rendering helpers.
+
+Builds the terminal card output for threat alerts and clean email reports.
+"""
+
+import shutil
+import textwrap
+from datetime import datetime
+from typing import Dict, List
+
+from ..utils.colors import Colors
+from ..utils.sanitization import ANSI_ESCAPE_PATTERN
+from .alert_channels import sanitize_text, sanitize_url_for_display
+from .alert_recommendations import (
+    RECOMMENDATION_PREFIXES,
+    RECOMMENDATION_PREFIXES_TUPLE,
+    RED_KEYWORDS_PATTERN,
+    YELLOW_KEYWORDS_PATTERN,
+)
+from .alert_report import RenderConfig, ThreatReport
+
+
+def get_terminal_width() -> int:
+    """Get the current terminal width or default to 80.
+
+    This is wrapped in a try/except so we don't crash in environments where
+    shutil.get_terminal_size is unavailable or cannot determine the size.
+    In those cases we conservatively fall back to 80 columns.
+    """
+    try:
+        return shutil.get_terminal_size((80, 20)).columns
+    except (AttributeError, OSError, ValueError):
+        # AttributeError: get_terminal_size might not exist (older/embedded runtimes)
+        # OSError/ValueError: terminal size can't be determined in this environment
+        return 80
+
+
+def get_visual_length(text: str) -> int:
+    """Get the character count of text after stripping ANSI color codes."""
+    if not text:
+        return 0
+    if "\x1b" in text:
+        return len(ANSI_ESCAPE_PATTERN.sub("", text))
+    return len(text)
+
+
+def truncate_text(text: str, width: int) -> str:
+    """
+    Truncate text to a specified width based on character count.
+    Adds '...' if truncated. Assumes input text has no ANSI codes.
+    """
+    if not text:
+        return ""
+
+    # Simple truncation since input (sanitized sender/subject) doesn't have ANSI codes
+    if len(text) > width:
+        # We need at least 3 chars for '...'
+        if width <= 3:
+            return "." * width
+        return text[: width - 3] + "..."
+    return text
+
+
+def safe_console_url(url: str) -> str:
+    """Return a URL safe for console output with tokens redacted."""
+    redacted_url = sanitize_url_for_display(url)
+    return sanitize_text(redacted_url, csv_safe=True)
+
+
+def print_alert_row(text: str, risk_color: str, indent: int = 0):
+    """Helper to print a row with the left border."""
+    # Note: We don't print the right border '│' because calculating visual width
+    # with ANSI codes and unicode/emojis is complex without external dependencies.
+    # The design uses an open-sided card metaphor for text rows.
+    prefix = Colors.colorize("│", risk_color) + " " * (2 + indent)
+    print(f"{prefix}{text}")
+
+
+def print_alert_header(
+    risk_level: str,
+    render_config: RenderConfig,
+):
+    """Print the alert header."""
+    print()
+    # Top Border (┌───┐)
+    # Width adjustment: -2 for the corners
+    border_len = render_config.width - 2
+    print(Colors.colorize(f"┌{'─'*border_len}┐", render_config.risk_color))
+
+    # Header Row
+    title = "🚨 SECURITY ALERT"
+    risk_label = f"{risk_level.upper()} RISK"
+
+    # Padding calculation:
+    # Width - (left_border + space) - title_len - padding - risk_label_len - (space + symbol + right_border)
+    # Visual estimation:
+    # │  (3 chars visual)
+    # title (~18 chars visual with emoji)
+    # risk_label (variable)
+    # symbol (1-2 chars visual)
+    # right_border (not printed in header row in original, but let's add it if we can align)
+
+    # Simpler approach for header: Just use the same layout but maybe without the right border for the text row
+    # strictly if alignment is hard. But the PR comment asked for closed borders.
+    # Let's try to close the top/bottom/separators first as requested.
+
+    # Padding for the header text row:
+    # We need to fill the space between title and risk label.
+    # Fixed width = render_config.width
+    # Content = "│  " + title + PADDING + risk_label + " " + symbol
+    # We don't print a right border '│' here because alignment is tricky with emojis.
+    # But we can try to approximate.
+
+    # Magic number explanation:
+    # 5 comes from: 3 chars for left prefix ("│  ") + 1 char space before symbol + 1 char approx for symbol/emoji width variance
+    padding_len = render_config.width - len(title) - len(risk_label) - 5
+    padding = " " * max(1, padding_len)
+
+    print(
+        Colors.colorize("│  ", render_config.risk_color)
+        + Colors.colorize(title, Colors.BOLD)
+        + padding
+        + Colors.colorize(risk_label, render_config.risk_color + Colors.BOLD)
+        + " "
+        + render_config.risk_symbol
+    )
+
+    # Separator (├───┤)
+    print(Colors.colorize(f"├{'─'*border_len}┤", render_config.risk_color))
+
+
+def print_alert_metadata(
+    report: ThreatReport, width: int, risk_color: str, formatted_time: str
+):
+    """Print alert metadata (Timestamp, Subject, From, To)."""
+    max_field_len = width - 15
+
+    def safe_field(val):
+        s = sanitize_text(val, csv_safe=True)
+        if len(s) > max_field_len:
+            return s[: max_field_len - 3] + "..."
+        return s
+
+    print_alert_row(
+        f"{Colors.colorize('Timestamp:', Colors.BOLD)} {formatted_time}", risk_color
+    )
+    print_alert_row(
+        f"{Colors.colorize('Subject:', Colors.BOLD)}   {safe_field(report.subject)}",
+        risk_color,
+    )
+    print_alert_row(
+        f"{Colors.colorize('From:', Colors.BOLD)}      {safe_field(report.sender)}",
+        risk_color,
+    )
+    print_alert_row(
+        f"{Colors.colorize('To:', Colors.BOLD)}        {safe_field(report.recipient)}",
+        risk_color,
+    )
+    print_alert_row("", risk_color)
+
+
+def print_threat_score(
+    score: float, risk_level: str, width: int, risk_color: str
+):
+    """Print the threat score and progress bar."""
+    score_val = min(max(score, 0), 100)
+    meter_len = 40
+    filled_len = int(score_val / 100 * meter_len)
+    bar = "█" * filled_len + "░" * (meter_len - filled_len)
+    meter_color = Colors.get_risk_color(risk_level)
+
+    print_alert_row(
+        f"{Colors.colorize('THREAT SCORE:', Colors.BOLD)} {score:.2f}/100",
+        risk_color,
+    )
+    print_alert_row(f"{Colors.colorize(bar, meter_color)}", risk_color)
+
+
+def print_analysis_section_header(
+    title: str, analysis_data: Dict, risk_color: str
+) -> None:
+    level = analysis_data.get("risk_level", "unknown")
+    color = Colors.get_risk_color(level)
+    symbol = Colors.get_risk_symbol(level)
+    print_alert_row(
+        f"{Colors.colorize(title + ':', Colors.BOLD)} {Colors.colorize(level.upper(), color)} {symbol}",
+        risk_color,
+    )
+
+
+def print_nlp_details(nlp_analysis: Dict, risk_color: str, max_nlp: int) -> None:
+    has_nlp = False
+
+    indicator_configs = [
+        ("social_engineering_indicators", "Social Engineering:", Colors.RED),
+        ("urgency_markers", "Urgency Markers:", Colors.YELLOW),
+        ("authority_impersonation", "Authority Impersonation:", Colors.RED),
+        ("psychological_triggers", "Psychological Triggers:", Colors.YELLOW),
+    ]
+
+    for key, title, item_color in indicator_configs:
+        items = nlp_analysis.get(key)
+        if items:
+            print_alert_row(
+                Colors.colorize(title, Colors.BOLD), risk_color, indent=3
+            )
+            for item in items[:max_nlp]:
+                print_alert_row(
+                    f"{Colors.colorize('•', item_color)} {item}",
+                    risk_color,
+                    indent=5,
+                )
+            has_nlp = True
+
+    if not has_nlp:
+        print_alert_row(
+            f"{Colors.colorize('✓', Colors.GREEN)} No NLP threats detected",
+            risk_color,
+            indent=3,
+        )
+
+
+def print_media_details(media_analysis: Dict, risk_color: str, max_media: int) -> None:
+    has_media_warnings = False
+
+    indicator_configs = [
+        ("file_type_warnings", "File Warnings:", Colors.YELLOW),
+        ("suspicious_attachments", "Suspicious Attachments:", Colors.RED),
+        ("size_anomalies", "Size Anomalies:", Colors.YELLOW),
+        ("potential_deepfakes", "Potential Deepfakes:", Colors.RED),
+    ]
+
+    for key, title, item_color in indicator_configs:
+        items = media_analysis.get(key)
+        if items:
+            print_alert_row(
+                Colors.colorize(title, Colors.BOLD), risk_color, indent=3
+            )
+            for item in items[:max_media]:
+                print_alert_row(
+                    f"{Colors.colorize('•', item_color)} {item}",
+                    risk_color,
+                    indent=5,
+                )
+            has_media_warnings = True
+
+    if not has_media_warnings:
+        print_alert_row(
+            f"{Colors.colorize('✓', Colors.GREEN)} Attachments appear safe",
+            risk_color,
+            indent=3,
+        )
+
+
+def spam_indicator_rows(indicators: List[str], max_spam: int) -> List[tuple[str, int]]:
+    return [
+        (f"{Colors.colorize('•', Colors.GREY)} {indicator}", 3)
+        for indicator in indicators[:max_spam]
+    ]
+
+
+def spam_header_issue_rows(
+    header_issues: List[str], max_header: int
+) -> List[tuple[str, int]]:
+    rows: List[tuple[str, int]] = []
+    if header_issues:
+        rows.append((Colors.colorize("Header Issues:", Colors.BOLD), 3))
+    rows.extend(
+        (f"{Colors.colorize('•', Colors.YELLOW)} {issue}", 5)
+        for issue in header_issues[:max_header]
+    )
+    return rows
+
+
+def spam_url_rows(suspicious_urls: List[str], max_urls: int) -> List[tuple[str, int]]:
+    rows: List[tuple[str, int]] = []
+    if suspicious_urls:
+        rows.append((Colors.colorize("Suspicious URLs:", Colors.BOLD), 3))
+    rows.extend(
+        (f"{Colors.colorize('•', Colors.RED)} {safe_console_url(url)}", 5)
+        for url in suspicious_urls[:max_urls]
+    )
+    return rows
+
+
+def spam_detail_rows(
+    spam_analysis: Dict,
+    max_spam: int,
+    max_header: int,
+    max_urls: int,
+) -> List[tuple[str, int]]:
+    rows: List[tuple[str, int]] = []
+    rows.extend(spam_indicator_rows(spam_analysis.get("indicators") or [], max_spam))
+    rows.extend(spam_header_issue_rows(spam_analysis.get("header_issues") or [], max_header))
+    rows.extend(spam_url_rows(spam_analysis.get("suspicious_urls") or [], max_urls))
+    return rows
+
+
+def print_spam_details(
+    spam_analysis: Dict,
+    risk_color: str,
+    max_spam: int,
+    max_header: int,
+    max_urls: int,
+) -> None:
+    rows = spam_detail_rows(spam_analysis, max_spam, max_header, max_urls)
+    if not rows:
+        print_alert_row(
+            f"{Colors.colorize('✓', Colors.GREEN)} No suspicious patterns",
+            risk_color,
+            indent=3,
+        )
+        return
+
+    for text, indent in rows:
+        print_alert_row(text, risk_color, indent=indent)
+
+
+def print_analysis_details(
+    report: ThreatReport,
+    width: int,
+    risk_color: str,
+    limits: Dict[str, int],
+):
+    """Print detailed analysis sections."""
+    border_len = width - 2
+    print(Colors.colorize(f"├{'─'*border_len}┤", risk_color))
+    print_alert_row(
+        Colors.colorize("ANALYSIS DETAILS", Colors.BOLD), risk_color
+    )
+    print_alert_row("", risk_color)
+
+    # Spam
+    print_analysis_section_header("📧 SPAM", report.spam_analysis, risk_color)
+    print_spam_details(
+        report.spam_analysis,
+        risk_color,
+        limits.get("MAX_SPAM_INDICATORS_DISPLAY", 5),
+        limits.get("MAX_HEADER_ISSUES_DISPLAY", 5),
+        limits.get("MAX_URLS_DISPLAY", 3),
+    )
+    print_alert_row("", risk_color)
+
+    # NLP
+    print_analysis_section_header("🧠 NLP", report.nlp_analysis, risk_color)
+    print_nlp_details(
+        report.nlp_analysis,
+        risk_color,
+        limits.get("MAX_NLP_INDICATORS_DISPLAY", 3),
+    )
+    print_alert_row("", risk_color)
+
+    # Media
+    print_analysis_section_header(
+        "📎 MEDIA", report.media_analysis, risk_color
+    )
+    print_media_details(
+        report.media_analysis,
+        risk_color,
+        limits.get("MAX_MEDIA_WARNINGS_DISPLAY", 3),
+    )
+
+
+def print_recommendations(
+    recommendations: List[str], width: int, risk_color: str
+):
+    """Print recommendations section."""
+    border_len = width - 2
+    print(Colors.colorize(f"├{'─'*border_len}┤", risk_color))
+    print_alert_row(
+        Colors.colorize("RECOMMENDATIONS", Colors.BOLD), risk_color
+    )
+    print_alert_row("", risk_color)
+
+    for rec in recommendations:
+        color = Colors.GREEN
+        rec_upper = rec.upper()
+        icon = "►"
+
+        # Remove existing prefixes to prevent double icons
+        # Optimization: tuple-based startswith executes entirely in C and avoids Python loop overhead
+        # We still need to find which prefix matched to slice it correctly, but the initial
+        # fast check filters out the vast majority of cases instantly.
+        if rec.startswith(RECOMMENDATION_PREFIXES_TUPLE):
+            for prefix in RECOMMENDATION_PREFIXES:
+                if rec.startswith(prefix):
+                    rec = rec[len(prefix) :]
+
+        # Optimization: compiled regex search is faster than any() generator loop for substring matching
+        if RED_KEYWORDS_PATTERN.search(rec_upper):
+            color = Colors.RED
+        elif YELLOW_KEYWORDS_PATTERN.search(rec_upper):
+            color = Colors.YELLOW
+
+        # Calculate available width for text
+        # Width - 2 (left border/space) - 3 (icon + space) - 2 (right padding) = Width - 7
+        # We use 8 to be safe and consistent with previous layout
+        max_text_width = width - 8
+
+        # Wrap text nicely
+        wrapped_lines = textwrap.wrap(rec, width=max_text_width)
+
+        if not wrapped_lines:
+            continue
+
+        # First line gets the bullet point
+        first_line = wrapped_lines[0]
+        print_alert_row(
+            f"{Colors.colorize(icon, color)} {first_line}", risk_color
+        )
+
+        # Subsequent lines get indentation based on icon width
+        # ► is 1 char, ⚠️ is 2 chars (usually). We align to 3 spaces for visual consistency.
+        indent = "   " if icon == "⚠️ " else "  "
+
+        for line in wrapped_lines[1:]:
+            print_alert_row(f"{indent}{line}", risk_color)
+
+    # Bottom Border (└───┘)
+    print(Colors.colorize(f"└{'─'*border_len}┘", risk_color))
+    print()
+
+
+def render_alert(report: ThreatReport, limits: Dict[str, int]) -> None:
+    """Render the full console alert card for a threat report."""
+    # Configuration
+    width = 70
+    risk_color = Colors.get_risk_color(report.risk_level)
+    risk_symbol = Colors.get_risk_symbol(report.risk_level)
+
+    # Format timestamp
+    try:
+        dt = datetime.fromisoformat(report.timestamp)
+        formatted_time = dt.strftime("%b %d, %Y at %H:%M:%S")
+    except ValueError:
+        formatted_time = report.timestamp
+
+    render_config = RenderConfig(
+        width=width,
+        risk_color=risk_color,
+        risk_symbol=risk_symbol,
+    )
+
+    print_alert_header(report.risk_level, render_config)
+    print_alert_metadata(report, width, risk_color, formatted_time)
+    print_threat_score(
+        report.overall_threat_score, report.risk_level, width, risk_color
+    )
+    print_analysis_details(report, width, risk_color, limits)
+    print_recommendations(report.recommendations, width, risk_color)
+
+
+def render_clean_report(report: ThreatReport, threat_low: float, terminal_width: int) -> None:
+    """Render the compact one-line clean report."""
+    # Compact format for clean emails
+    score_val = max(0.0, report.overall_threat_score)
+
+    # Calculate risk relative to the low threshold (the "clean" budget)
+    threshold = threat_low
+    if threshold <= 0:
+        threshold = 30
+
+    percent_of_threshold = min(score_val / threshold, 1.0)
+
+    # Mini bar: 10 chars
+    bar_len = 10
+    filled = int(percent_of_threshold * bar_len)
+
+    # Bar construction
+    fill_char = "■"
+    empty_char = "·"
+
+    filled_part = fill_char * filled
+    empty_part = empty_char * (bar_len - filled)
+
+    # Color logic
+    bar_color = Colors.GREEN
+    if percent_of_threshold > 0.6:
+        bar_color = Colors.YELLOW
+
+    colored_filled = Colors.colorize(filled_part, bar_color)
+    colored_empty = Colors.colorize(empty_part, Colors.GREY)
+
+    visual_bar = f"[{colored_filled}{colored_empty}]"
+
+    # Short timestamp
+    try:
+        dt = datetime.fromisoformat(report.timestamp)
+        time_str = dt.strftime("%H:%M:%S")
+    except ValueError:
+        time_str = report.timestamp
+
+    # Determine available width based on terminal size
+    # Calculate width of fixed parts dynamically
+    # Structure: "✓ CLEAN | HH:MM:SS | Score: XX.X [■■···] | From: " + sender + " | " + subject
+
+    sep = Colors.colorize("│", Colors.GREY)
+
+    clean_str = Colors.colorize("✓ CLEAN", Colors.GREEN)
+    prefix = f"{clean_str} {sep} {time_str} {sep} Score: {score_val:4.1f} {visual_bar} {sep} From: "
+    prefix_len = get_visual_length(prefix)
+
+    suffix_sep = f" {sep} "
+    suffix_sep_len = get_visual_length(suffix_sep)
+
+    # Fixed width is prefix + space for suffix separator
+    # We add 1 char buffer
+    fixed_width = prefix_len + suffix_sep_len + 1
+
+    available_width = max(20, terminal_width - fixed_width)
+
+    # Allocate width: 35% for sender, 65% for subject
+    sender_target = int(available_width * 0.35)
+    # Minimum reduced to 8 to fit 80-column terminals better
+    sender_width = max(8, sender_target)
+
+    subject_width = available_width - sender_width
+    # Ensure subject has at least some space
+    subject_width = max(10, subject_width)
+
+    # Sender truncated
+    sanitized_sender = sanitize_text(report.sender, csv_safe=True)
+    sender = truncate_text(sanitized_sender, sender_width)
+
+    # Subject truncated
+    sanitized_subject = sanitize_text(report.subject, csv_safe=True)
+    if not sanitized_subject:
+        sanitized_subject = "(No Subject)"
+
+    subject = truncate_text(sanitized_subject, subject_width)
+
+    # Format:
+    # ✓ CLEAN | HH:MM:SS | Score: XX.X [■■···] | From: Sender                       | Subject
+    print(
+        f"{clean_str} "
+        f"{sep} {time_str} "
+        f"{sep} Score: {score_val:4.1f} {visual_bar} "
+        f"{sep} From: {sender:<{sender_width}} "
+        f"{sep} {subject}"
+    )
+
+

--- a/src/modules/alert_recommendations.py
+++ b/src/modules/alert_recommendations.py
@@ -1,0 +1,75 @@
+"""
+Alert recommendations generation.
+
+Turns per-layer analysis results into actionable user guidance.
+"""
+
+import re
+from typing import List
+
+from .media_analyzer import MediaAnalysisResult
+from .nlp_analyzer import NLPAnalysisResult
+from .spam_analyzer import SpamAnalysisResult
+
+
+# Common prefixes for recommendations to strip during display to prevent duplication
+RECOMMENDATION_PREFIXES = ["⚠️ ", "🎣 ", "🔗 ", "⏰ ", "📎 ", "👤 "]
+
+# Pre-allocated tuple for fast C-level execution of startswith()
+RECOMMENDATION_PREFIXES_TUPLE = tuple(RECOMMENDATION_PREFIXES)
+
+# Compiled regex patterns for fast substring keyword checks in recommendations
+# Use re.compile directly since we are passing a single regex string, not a list
+RED_KEYWORDS_PATTERN = re.compile(r"HIGH RISK|DANGEROUS|PHISHING")
+YELLOW_KEYWORDS_PATTERN = re.compile(r"SUSPICIOUS|VERIFY|URGENCY|IMPERSONATION")
+
+# Fallback recommendation text used by generate_recommendations when no
+# specific threat condition is matched.  Defined at module level so the alert
+# facade can re-export it and tests can reference it without hardcoding the
+# string in two places.
+DEFAULT_CLEAN_RECOMMENDATION = "✅ No issues detected"
+
+
+def generate_recommendations(
+    spam_result: SpamAnalysisResult,
+    nlp_result: NLPAnalysisResult,
+    media_result: MediaAnalysisResult,
+) -> List[str]:
+    """Generate actionable recommendations based on threat analysis results."""
+    recommendations = []
+
+    # High-risk recommendations
+    if spam_result.risk_level == "high":
+        recommendations.append("⚠️ HIGH RISK: Move to spam folder immediately")
+
+    if nlp_result.social_engineering_indicators:
+        recommendations.append(
+            "🎣 Potential phishing: Do not click links or provide credentials"
+        )
+
+    if media_result.file_type_warnings:
+        recommendations.append(
+            "📎 Dangerous attachment detected: Do not open attachments"
+        )
+
+    # Medium-risk recommendations
+    if spam_result.suspicious_urls:
+        recommendations.append(
+            "🔗 Suspicious URLs detected: Verify links before clicking"
+        )
+
+    if nlp_result.authority_impersonation:
+        recommendations.append(
+            "👤 Authority impersonation suspected: Verify sender identity"
+        )
+
+    if nlp_result.urgency_markers:
+        recommendations.append(
+            "⏰ Urgency tactics detected: Take time to verify before acting"
+        )
+
+    # General recommendations
+    if not recommendations:
+        recommendations.append(DEFAULT_CLEAN_RECOMMENDATION)
+
+    return recommendations

--- a/src/modules/alert_report.py
+++ b/src/modules/alert_report.py
@@ -1,0 +1,137 @@
+"""
+Threat report generation.
+
+Aggregates per-layer analysis results into a comprehensive, serializable report.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List
+
+from .alert_recommendations import generate_recommendations
+from .email_data import EmailData
+from .media_analyzer import MediaAnalysisResult
+from .nlp_analyzer import NLPAnalysisResult
+from .spam_analyzer import SpamAnalysisResult
+
+
+@dataclass
+class ThreatReport:
+    """Comprehensive threat report."""
+
+    email_id: str
+    subject: str
+    sender: str
+    recipient: str
+    date: str
+    overall_threat_score: float
+    risk_level: str
+    spam_analysis: Dict
+    nlp_analysis: Dict
+    media_analysis: Dict
+    recommendations: List[str]
+    timestamp: str
+
+
+@dataclass
+class RenderConfig:
+    """Configuration options for console rendering."""
+
+    width: int
+    risk_color: str
+    risk_symbol: str
+
+
+def _calculate_overall_risk_level(
+    spam_result: SpamAnalysisResult,
+    nlp_result: NLPAnalysisResult,
+    media_result: MediaAnalysisResult,
+) -> str:
+    """Calculate overall risk level from individual analysis results."""
+    risk_levels = [
+        spam_result.risk_level,
+        nlp_result.risk_level,
+        media_result.risk_level,
+    ]
+
+    if "high" in risk_levels:
+        return "high"
+    if "medium" in risk_levels:
+        return "medium"
+    return "low"
+
+
+def _build_spam_analysis_dict(spam_result: SpamAnalysisResult) -> Dict:
+    """Build spam analysis dictionary for threat report."""
+    return {
+        "score": spam_result.score,
+        "risk_level": spam_result.risk_level,
+        "indicators": spam_result.indicators,
+        "suspicious_urls": spam_result.suspicious_urls,
+        "header_issues": spam_result.header_issues,
+    }
+
+
+def _build_nlp_analysis_dict(nlp_result: NLPAnalysisResult) -> Dict:
+    """Build NLP analysis dictionary for threat report."""
+    return {
+        "score": nlp_result.threat_score,
+        "risk_level": nlp_result.risk_level,
+        "social_engineering_indicators": nlp_result.social_engineering_indicators,
+        "urgency_markers": nlp_result.urgency_markers,
+        "authority_impersonation": nlp_result.authority_impersonation,
+        "psychological_triggers": nlp_result.psychological_triggers,
+    }
+
+
+def _build_media_analysis_dict(media_result: MediaAnalysisResult) -> Dict:
+    """Build media analysis dictionary for threat report."""
+    return {
+        "score": media_result.threat_score,
+        "risk_level": media_result.risk_level,
+        "suspicious_attachments": media_result.suspicious_attachments,
+        "file_type_warnings": media_result.file_type_warnings,
+        "size_anomalies": media_result.size_anomalies,
+        "potential_deepfakes": media_result.potential_deepfakes,
+    }
+
+
+def generate_threat_report(
+    email_data: EmailData,
+    spam_result: SpamAnalysisResult,
+    nlp_result: NLPAnalysisResult,
+    media_result: MediaAnalysisResult,
+) -> ThreatReport:
+    """
+    Generate comprehensive threat report.
+
+    Args:
+        email_data: Email data
+        spam_result: Spam analysis result
+        nlp_result: NLP analysis result
+        media_result: Media analysis result
+
+    Returns:
+        ThreatReport
+
+    """
+    overall_score = (
+        spam_result.score + nlp_result.threat_score + media_result.threat_score
+    )
+    risk_level = _calculate_overall_risk_level(spam_result, nlp_result, media_result)
+    recommendations = generate_recommendations(spam_result, nlp_result, media_result)
+
+    return ThreatReport(
+        email_id=email_data.message_id,
+        subject=email_data.subject,
+        sender=email_data.sender,
+        recipient=email_data.recipient,
+        date=email_data.date.isoformat(),
+        overall_threat_score=overall_score,
+        risk_level=risk_level,
+        spam_analysis=_build_spam_analysis_dict(spam_result),
+        nlp_analysis=_build_nlp_analysis_dict(nlp_result),
+        media_analysis=_build_media_analysis_dict(media_result),
+        recommendations=recommendations,
+        timestamp=datetime.now().isoformat(),
+    )

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -5,24 +5,11 @@ Handles threat notifications and alerting across multiple channels.
 
 import asyncio
 import logging
-import re
-import shutil
-import textwrap
 import threading
-from dataclasses import asdict, dataclass
-from datetime import datetime
 from typing import Dict, List, Optional
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import requests
 
-from ..utils.colors import Colors
-from ..utils.sanitization import (
-    _TRANSLATOR,
-    _WHITESPACE_TRANS,
-    ANSI_ESCAPE_PATTERN,
-    sanitize_for_csv,
-)
 from ..utils.security_validators import is_safe_webhook_url
 from .alert_recommendations import (
     DEFAULT_CLEAN_RECOMMENDATION,
@@ -36,10 +23,8 @@ from .alert_report import RenderConfig, ThreatReport, generate_threat_report
 from .media_analyzer import MediaAnalysisResult
 from .nlp_analyzer import NLPAnalysisResult
 from .spam_analyzer import SpamAnalysisResult
-
-# Regex pattern for extracting URLs from error messages (compiled once for performance)
-# Expanded to catch bare paths/hosts for complete redaction when scheme is missing.
-URL_PATTERN = re.compile(r'(?:https?://[^\s<>"]+|www\.[^\s<>"]+|/[^\s<>"]+)')
+from . import alert_channels
+from . import alert_console
 
 
 class AlertSystem:
@@ -56,8 +41,6 @@ class AlertSystem:
     RED_KEYWORDS_PATTERN = RED_KEYWORDS_PATTERN
     YELLOW_KEYWORDS_PATTERN = YELLOW_KEYWORDS_PATTERN
 
-    # Pre-compiled pattern for fast URL redaction replacement without re.IGNORECASE penalty
-    REDACTED_URL_PATTERN = re.compile(r"%5[bB]REDACTED%5[dD]", flags=0)
 
     # Maximum number of items shown per section in the console threat report.
     # Helps keep the output readable; lists may be truncated in the console view.
@@ -388,485 +371,62 @@ class AlertSystem:
             else:
                 self.logger.error("Failed to enqueue alert: %s", exc)
 
-    def _print_alert_row(self, text: str, risk_color: str, indent: int = 0):
-        """Helper to print a row with the left border."""
-        # Note: We don't print the right border '│' because calculating visual width
-        # with ANSI codes and unicode/emojis is complex without external dependencies.
-        # The design uses an open-sided card metaphor for text rows.
-        prefix = Colors.colorize("│", risk_color) + " " * (2 + indent)
-        print(f"{prefix}{text}")
-
-    def _print_alert_header(
-        self,
-        risk_level: str,
-        render_config: RenderConfig,
-    ):
-        """Print the alert header."""
-        print()
-        # Top Border (┌───┐)
-        # Width adjustment: -2 for the corners
-        border_len = render_config.width - 2
-        print(Colors.colorize(f"┌{'─'*border_len}┐", render_config.risk_color))
-
-        # Header Row
-        title = "🚨 SECURITY ALERT"
-        risk_label = f"{risk_level.upper()} RISK"
-
-        # Padding calculation:
-        # Width - (left_border + space) - title_len - padding - risk_label_len - (space + symbol + right_border)
-        # Visual estimation:
-        # │  (3 chars visual)
-        # title (~18 chars visual with emoji)
-        # risk_label (variable)
-        # symbol (1-2 chars visual)
-        # right_border (not printed in header row in original, but let's add it if we can align)
-
-        # Simpler approach for header: Just use the same layout but maybe without the right border for the text row
-        # strictly if alignment is hard. But the PR comment asked for closed borders.
-        # Let's try to close the top/bottom/separators first as requested.
-
-        # Padding for the header text row:
-        # We need to fill the space between title and risk label.
-        # Fixed width = render_config.width
-        # Content = "│  " + title + PADDING + risk_label + " " + symbol
-        # We don't print a right border '│' here because alignment is tricky with emojis.
-        # But we can try to approximate.
-
-        # Magic number explanation:
-        # 5 comes from: 3 chars for left prefix ("│  ") + 1 char space before symbol + 1 char approx for symbol/emoji width variance
-        padding_len = render_config.width - len(title) - len(risk_label) - 5
-        padding = " " * max(1, padding_len)
-
-        print(
-            Colors.colorize("│  ", render_config.risk_color)
-            + Colors.colorize(title, Colors.BOLD)
-            + padding
-            + Colors.colorize(risk_label, render_config.risk_color + Colors.BOLD)
-            + " "
-            + render_config.risk_symbol
-        )
-
-        # Separator (├───┤)
-        print(Colors.colorize(f"├{'─'*border_len}┤", render_config.risk_color))
-
-    def _print_alert_metadata(
-        self, report: ThreatReport, width: int, risk_color: str, formatted_time: str
-    ):
-        """Print alert metadata (Timestamp, Subject, From, To)."""
-        max_field_len = width - 15
-
-        def safe_field(val):
-            s = self._sanitize_text(val, csv_safe=True)
-            if len(s) > max_field_len:
-                return s[: max_field_len - 3] + "..."
-            return s
-
-        self._print_alert_row(
-            f"{Colors.colorize('Timestamp:', Colors.BOLD)} {formatted_time}", risk_color
-        )
-        self._print_alert_row(
-            f"{Colors.colorize('Subject:', Colors.BOLD)}   {safe_field(report.subject)}",
-            risk_color,
-        )
-        self._print_alert_row(
-            f"{Colors.colorize('From:', Colors.BOLD)}      {safe_field(report.sender)}",
-            risk_color,
-        )
-        self._print_alert_row(
-            f"{Colors.colorize('To:', Colors.BOLD)}        {safe_field(report.recipient)}",
-            risk_color,
-        )
-        self._print_alert_row("", risk_color)
-
-    def _print_threat_score(
-        self, score: float, risk_level: str, width: int, risk_color: str
-    ):
-        """Print the threat score and progress bar."""
-        score_val = min(max(score, 0), 100)
-        meter_len = 40
-        filled_len = int(score_val / 100 * meter_len)
-        bar = "█" * filled_len + "░" * (meter_len - filled_len)
-        meter_color = Colors.get_risk_color(risk_level)
-
-        self._print_alert_row(
-            f"{Colors.colorize('THREAT SCORE:', Colors.BOLD)} {score:.2f}/100",
-            risk_color,
-        )
-        self._print_alert_row(f"{Colors.colorize(bar, meter_color)}", risk_color)
-
-    def _print_analysis_details(
-        self, report: ThreatReport, width: int, risk_color: str
-    ):
-        """Print detailed analysis sections."""
-        border_len = width - 2
-        print(Colors.colorize(f"├{'─'*border_len}┤", risk_color))
-        self._print_alert_row(
-            Colors.colorize("ANALYSIS DETAILS", Colors.BOLD), risk_color
-        )
-        self._print_alert_row("", risk_color)
-
-        # Spam
-        self._print_analysis_section_header("📧 SPAM", report.spam_analysis, risk_color)
-        self._print_spam_details(report.spam_analysis, risk_color)
-        self._print_alert_row("", risk_color)
-
-        # NLP
-        self._print_analysis_section_header("🧠 NLP", report.nlp_analysis, risk_color)
-        self._print_nlp_details(report.nlp_analysis, risk_color)
-        self._print_alert_row("", risk_color)
-
-        # Media
-        self._print_analysis_section_header(
-            "📎 MEDIA", report.media_analysis, risk_color
-        )
-        self._print_media_details(report.media_analysis, risk_color)
-
-    def _print_nlp_details(self, nlp_analysis: Dict, risk_color: str) -> None:
-        has_nlp = False
-
-        indicator_configs = [
-            ("social_engineering_indicators", "Social Engineering:", Colors.RED),
-            ("urgency_markers", "Urgency Markers:", Colors.YELLOW),
-            ("authority_impersonation", "Authority Impersonation:", Colors.RED),
-            ("psychological_triggers", "Psychological Triggers:", Colors.YELLOW),
-        ]
-
-        for key, title, item_color in indicator_configs:
-            items = nlp_analysis.get(key)
-            if items:
-                self._print_alert_row(
-                    Colors.colorize(title, Colors.BOLD), risk_color, indent=3
-                )
-                for item in items[: self.MAX_NLP_INDICATORS_DISPLAY]:
-                    self._print_alert_row(
-                        f"{Colors.colorize('•', item_color)} {item}",
-                        risk_color,
-                        indent=5,
-                    )
-                has_nlp = True
-
-        if not has_nlp:
-            self._print_alert_row(
-                f"{Colors.colorize('✓', Colors.GREEN)} No NLP threats detected",
-                risk_color,
-                indent=3,
-            )
-
-    def _print_media_details(self, media_analysis: Dict, risk_color: str) -> None:
-        has_media_warnings = False
-
-        indicator_configs = [
-            ("file_type_warnings", "File Warnings:", Colors.YELLOW),
-            ("suspicious_attachments", "Suspicious Attachments:", Colors.RED),
-            ("size_anomalies", "Size Anomalies:", Colors.YELLOW),
-            ("potential_deepfakes", "Potential Deepfakes:", Colors.RED),
-        ]
-
-        for key, title, item_color in indicator_configs:
-            items = media_analysis.get(key)
-            if items:
-                self._print_alert_row(
-                    Colors.colorize(title, Colors.BOLD), risk_color, indent=3
-                )
-                for item in items[: self.MAX_MEDIA_WARNINGS_DISPLAY]:
-                    self._print_alert_row(
-                        f"{Colors.colorize('•', item_color)} {item}",
-                        risk_color,
-                        indent=5,
-                    )
-                has_media_warnings = True
-
-        if not has_media_warnings:
-            self._print_alert_row(
-                f"{Colors.colorize('✓', Colors.GREEN)} Attachments appear safe",
-                risk_color,
-                indent=3,
-            )
-
-    def _print_analysis_section_header(
-        self, title: str, analysis_data: Dict, risk_color: str
-    ) -> None:
-        level = analysis_data.get("risk_level", "unknown")
-        color = Colors.get_risk_color(level)
-        symbol = Colors.get_risk_symbol(level)
-        self._print_alert_row(
-            f"{Colors.colorize(title + ':', Colors.BOLD)} {Colors.colorize(level.upper(), color)} {symbol}",
-            risk_color,
-        )
-
-    def _print_spam_details(self, spam_analysis: Dict, risk_color: str) -> None:
-        spam_rows = self._spam_detail_rows(spam_analysis)
-        if not spam_rows:
-            self._print_alert_row(
-                f"{Colors.colorize('✓', Colors.GREEN)} No suspicious patterns",
-                risk_color,
-                indent=3,
-            )
-            return
-
-        for text, indent in spam_rows:
-            self._print_alert_row(text, risk_color, indent=indent)
-
-    def _spam_detail_rows(self, spam_analysis: Dict) -> List[tuple[str, int]]:
-        rows: List[tuple[str, int]] = []
-        rows.extend(self._spam_indicator_rows(spam_analysis.get("indicators") or []))
-        rows.extend(
-            self._spam_header_issue_rows(spam_analysis.get("header_issues") or [])
-        )
-        rows.extend(self._spam_url_rows(spam_analysis.get("suspicious_urls") or []))
-        return rows
-
-    def _spam_indicator_rows(self, indicators: List[str]) -> List[tuple[str, int]]:
-        return [
-            (f"{Colors.colorize('•', Colors.GREY)} {indicator}", 3)
-            for indicator in indicators[: self.MAX_SPAM_INDICATORS_DISPLAY]
-        ]
-
-    def _spam_header_issue_rows(
-        self, header_issues: List[str]
-    ) -> List[tuple[str, int]]:
-        rows: List[tuple[str, int]] = []
-        if header_issues:
-            rows.append((Colors.colorize("Header Issues:", Colors.BOLD), 3))
-        rows.extend(
-            (f"{Colors.colorize('•', Colors.YELLOW)} {issue}", 5)
-            for issue in header_issues[: self.MAX_HEADER_ISSUES_DISPLAY]
-        )
-        return rows
-
-    def _spam_url_rows(self, suspicious_urls: List[str]) -> List[tuple[str, int]]:
-        rows: List[tuple[str, int]] = []
-        if suspicious_urls:
-            rows.append((Colors.colorize("Suspicious URLs:", Colors.BOLD), 3))
-        rows.extend(
-            (f"{Colors.colorize('•', Colors.RED)} {self._safe_console_url(url)}", 5)
-            for url in suspicious_urls[: self.MAX_URLS_DISPLAY]
-        )
-        return rows
-
     def _safe_console_url(self, url: str) -> str:
-        redacted_url = self.REDACTED_URL_PATTERN.sub(
-            "[REDACTED]",
-            self._redact_sensitive_url_params(url),
-        )
-        return self._sanitize_text(redacted_url, csv_safe=True)
-
-    def _print_recommendations(
-        self, recommendations: List[str], width: int, risk_color: str
-    ):
-        """Print recommendations section."""
-        border_len = width - 2
-        print(Colors.colorize(f"├{'─'*border_len}┤", risk_color))
-        self._print_alert_row(
-            Colors.colorize("RECOMMENDATIONS", Colors.BOLD), risk_color
-        )
-        self._print_alert_row("", risk_color)
-
-        for rec in recommendations:
-            color = Colors.GREEN
-            rec_upper = rec.upper()
-            icon = "►"
-
-            # Remove existing prefixes to prevent double icons
-            # Optimization: tuple-based startswith executes entirely in C and avoids Python loop overhead
-            # We still need to find which prefix matched to slice it correctly, but the initial
-            # fast check filters out the vast majority of cases instantly.
-            if rec.startswith(self.RECOMMENDATION_PREFIXES_TUPLE):
-                for prefix in self.RECOMMENDATION_PREFIXES:
-                    if rec.startswith(prefix):
-                        rec = rec[len(prefix) :]
-
-            # Optimization: compiled regex search is faster than any() generator loop for substring matching
-            if self.RED_KEYWORDS_PATTERN.search(rec_upper):
-                color = Colors.RED
-            elif self.YELLOW_KEYWORDS_PATTERN.search(rec_upper):
-                color = Colors.YELLOW
-
-            # Calculate available width for text
-            # Width - 2 (left border/space) - 3 (icon + space) - 2 (right padding) = Width - 7
-            # We use 8 to be safe and consistent with previous layout
-            max_text_width = width - 8
-
-            # Wrap text nicely
-            wrapped_lines = textwrap.wrap(rec, width=max_text_width)
-
-            if not wrapped_lines:
-                continue
-
-            # First line gets the bullet point
-            first_line = wrapped_lines[0]
-            self._print_alert_row(
-                f"{Colors.colorize(icon, color)} {first_line}", risk_color
-            )
-
-            # Subsequent lines get indentation based on icon width
-            # ► is 1 char, ⚠️ is 2 chars (usually). We align to 3 spaces for visual consistency.
-            indent = "   " if icon == "⚠️ " else "  "
-
-            for line in wrapped_lines[1:]:
-                self._print_alert_row(f"{indent}{line}", risk_color)
-
-        # Bottom Border (└───┘)
-        print(Colors.colorize(f"└{'─'*border_len}┘", risk_color))
-        print()
-
-    def _console_alert(self, report: ThreatReport):
-        """Print alert to console with enhanced UX."""
-        # Configuration
-        WIDTH = 70
-        risk_color = Colors.get_risk_color(report.risk_level)
-        risk_symbol = Colors.get_risk_symbol(report.risk_level)
-
-        # Format timestamp
-        try:
-            dt = datetime.fromisoformat(report.timestamp)
-            formatted_time = dt.strftime("%b %d, %Y at %H:%M:%S")
-        except ValueError:
-            formatted_time = report.timestamp
-
-        render_config = RenderConfig(
-            width=WIDTH,
-            risk_color=risk_color,
-            risk_symbol=risk_symbol,
-        )
-
-        self._print_alert_header(report.risk_level, render_config)
-        self._print_alert_metadata(report, WIDTH, risk_color, formatted_time)
-        self._print_threat_score(
-            report.overall_threat_score, report.risk_level, WIDTH, risk_color
-        )
-        self._print_analysis_details(report, WIDTH, risk_color)
-        self._print_recommendations(report.recommendations, WIDTH, risk_color)
-
-    def _console_clean_report(self, report: ThreatReport):
-        """Print clean report to console."""
-        # Compact format for clean emails
-        score_val = max(0.0, report.overall_threat_score)
-
-        # Calculate risk relative to the low threshold (the "clean" budget)
-        threshold = self.config.threat_low
-        if threshold <= 0:
-            threshold = 30
-
-        percent_of_threshold = min(score_val / threshold, 1.0)
-
-        # Mini bar: 10 chars
-        bar_len = 10
-        filled = int(percent_of_threshold * bar_len)
-
-        # Bar construction
-        fill_char = "■"
-        empty_char = "·"
-
-        filled_part = fill_char * filled
-        empty_part = empty_char * (bar_len - filled)
-
-        # Color logic
-        bar_color = Colors.GREEN
-        if percent_of_threshold > 0.6:
-            bar_color = Colors.YELLOW
-
-        colored_filled = Colors.colorize(filled_part, bar_color)
-        colored_empty = Colors.colorize(empty_part, Colors.GREY)
-
-        visual_bar = f"[{colored_filled}{colored_empty}]"
-
-        # Short timestamp
-        try:
-            dt = datetime.fromisoformat(report.timestamp)
-            time_str = dt.strftime("%H:%M:%S")
-        except ValueError:
-            time_str = report.timestamp
-
-        # Determine available width based on terminal size
-        terminal_width = self._get_terminal_width()
-
-        # Calculate width of fixed parts dynamically
-        # Structure: "✓ CLEAN | HH:MM:SS | Score: XX.X [■■···] | From: " + sender + " | " + subject
-
-        sep = Colors.colorize("│", Colors.GREY)
-
-        clean_str = Colors.colorize("✓ CLEAN", Colors.GREEN)
-        prefix = f"{clean_str} {sep} {time_str} {sep} Score: {score_val:4.1f} {visual_bar} {sep} From: "
-        prefix_len = self._get_visual_length(prefix)
-
-        suffix_sep = f" {sep} "
-        suffix_sep_len = self._get_visual_length(suffix_sep)
-
-        # Fixed width is prefix + space for suffix separator
-        # We add 1 char buffer
-        fixed_width = prefix_len + suffix_sep_len + 1
-
-        available_width = max(20, terminal_width - fixed_width)
-
-        # Allocate width: 35% for sender, 65% for subject
-        sender_target = int(available_width * 0.35)
-        # Minimum reduced to 8 to fit 80-column terminals better
-        sender_width = max(8, sender_target)
-
-        subject_width = available_width - sender_width
-        # Ensure subject has at least some space
-        subject_width = max(10, subject_width)
-
-        # Sender truncated
-        sanitized_sender = self._sanitize_text(report.sender, csv_safe=True)
-        sender = self._truncate_text(sanitized_sender, sender_width)
-
-        # Subject truncated
-        sanitized_subject = self._sanitize_text(report.subject, csv_safe=True)
-        if not sanitized_subject:
-            sanitized_subject = "(No Subject)"
-
-        subject = self._truncate_text(sanitized_subject, subject_width)
-
-        # Format:
-        # ✓ CLEAN | HH:MM:SS | Score: XX.X [■■···] | From: Sender                       | Subject
-        clean_str = Colors.colorize("✓ CLEAN", Colors.GREEN)
-        print(
-            f"{clean_str} "
-            f"{sep} {time_str} "
-            f"{sep} Score: {score_val:4.1f} {visual_bar} "
-            f"{sep} From: {sender:<{sender_width}} "
-            f"{sep} {subject}"
-        )
+        """Return a URL safe for console output with tokens redacted."""
+        return alert_console.safe_console_url(url)
 
     def _get_terminal_width(self) -> int:
-        """Get the current terminal width or default to 80.
-
-        This is wrapped in a try/except so we don't crash in environments where
-        shutil.get_terminal_size is unavailable or cannot determine the size.
-        In those cases we conservatively fall back to 80 columns.
-        """
-        try:
-            return shutil.get_terminal_size((80, 20)).columns
-        except (AttributeError, OSError, ValueError):
-            # AttributeError: get_terminal_size might not exist (older/embedded runtimes)
-            # OSError/ValueError: terminal size can't be determined in this environment
-            return 80
+        """Get the current terminal width or default to 80."""
+        return alert_console.get_terminal_width()
 
     def _get_visual_length(self, text: str) -> int:
         """Get the character count of text after stripping ANSI color codes."""
-        if not text:
-            return 0
-        if "\x1b" in text:
-            return len(ANSI_ESCAPE_PATTERN.sub("", text))
-        return len(text)
+        return alert_console.get_visual_length(text)
 
     def _truncate_text(self, text: str, width: int) -> str:
-        """
-        Truncate text to a specified width based on character count.
-        Adds '...' if truncated. Assumes input text has no ANSI codes.
-        """
-        if not text:
-            return ""
+        """Truncate text to a specified width based on character count."""
+        return alert_console.truncate_text(text, width)
 
-        # Simple truncation since input (sanitized sender/subject) doesn't have ANSI codes
-        if len(text) > width:
-            # We need at least 3 chars for '...'
-            if width <= 3:
-                return "." * width
-            return text[: width - 3] + "..."
-        return text
+    def _console_alert(self, report: ThreatReport):
+        """Print alert to console with enhanced UX."""
+        alert_console.render_alert(
+            report,
+            limits={
+                "MAX_SPAM_INDICATORS_DISPLAY": self.MAX_SPAM_INDICATORS_DISPLAY,
+                "MAX_HEADER_ISSUES_DISPLAY": self.MAX_HEADER_ISSUES_DISPLAY,
+                "MAX_NLP_INDICATORS_DISPLAY": self.MAX_NLP_INDICATORS_DISPLAY,
+                "MAX_MEDIA_WARNINGS_DISPLAY": self.MAX_MEDIA_WARNINGS_DISPLAY,
+                "MAX_URLS_DISPLAY": self.MAX_URLS_DISPLAY,
+            },
+        )
+
+    def _console_clean_report(self, report: ThreatReport):
+        """Print clean report to console."""
+        alert_console.render_clean_report(
+            report,
+            self.config.threat_low,
+            self._get_terminal_width(),
+        )
+
+    def _sanitize_text(self, text: str, csv_safe: bool = False) -> str:
+        """Sanitize text for safe console output."""
+        return alert_channels.sanitize_text(text, csv_safe)
+
+    def _sanitize_for_slack(self, text: str) -> str:
+        """Sanitize text for Slack to prevent injection and spoofing."""
+        return alert_channels.sanitize_for_slack(text)
+
+    def _sanitize_error_message(self, error: Exception) -> str:
+        """Sanitize exception messages to prevent leaking sensitive URLs/tokens."""
+        return alert_channels.sanitize_error_message(str(error))
+
+    def _redact_url_secrets(self, url: str) -> str:
+        """Redact sensitive information from URL (query params and specific paths)."""
+        return alert_channels.redact_url_secrets(url)
+
+    def _redact_sensitive_url_params(self, url: str) -> str:
+        """Redact sensitive query parameters from URL."""
+        return alert_channels.redact_sensitive_url_params(url)
 
     def _webhook_alert(self, report: ThreatReport) -> bool:
         """Send alert via webhook.
@@ -885,22 +445,9 @@ class AlertSystem:
                 )
                 return False
 
-            payload = asdict(report)
-
-            # Redact sensitive info from suspicious URLs if present
-            if (
-                "spam_analysis" in payload
-                and "suspicious_urls" in payload["spam_analysis"]
-            ):
-                urls = payload["spam_analysis"]["suspicious_urls"]
-                if urls:
-                    payload["spam_analysis"]["suspicious_urls"] = [
-                        self._redact_sensitive_url_params(url) for url in urls
-                    ]
-
             response = requests.post(
                 self.config.webhook_url,
-                json=payload,
+                json=alert_channels.build_webhook_payload(report),
                 headers={"Content-Type": "application/json"},
                 timeout=10,
                 allow_redirects=False,
@@ -920,278 +467,6 @@ class AlertSystem:
             )
             return False
 
-    def _sanitize_error_message(self, error: Exception) -> str:
-        """
-        Sanitize exception messages to prevent leaking sensitive URLs/tokens.
-        Detects URLs in the error message and redacts them.
-        """
-        msg = str(error)
-        try:
-            # Find all URLs in the message
-            # Simple regex for http/https URLs to catch full URLs including query params
-            urls = URL_PATTERN.findall(msg)
-
-            for url in urls:
-                # Clean up trailing punctuation that might have been matched
-                clean_url = url.rstrip(".,;:)'")
-
-                # Apply redaction
-                redacted = self._redact_url_secrets(clean_url)
-
-                # If redaction changed anything, update the message
-                if redacted != clean_url:
-                    msg = msg.replace(clean_url, redacted)
-
-            return msg
-        except Exception:
-            return "An error occurred (details redacted for security)"
-
-    def _redact_url_secrets(self, url: str) -> str:
-        """
-        Redact sensitive information from URL (query params and specific paths).
-        Handles Slack/Discord webhooks and sensitive query parameters.
-        """
-        try:
-            if not url:
-                return ""
-
-            # 1. Redact sensitive query parameters (reusing logic)
-            url = self._redact_sensitive_url_params(url)
-
-            parsed = urlparse(url)
-
-            # 2. Redact credentials in authority section
-            if parsed.password:
-                # Reconstruct URL with redacted password.
-                # Use netloc.rpartition to safely separate authority from host, preserving IPv6 brackets.
-                _, _, host_part = parsed.netloc.rpartition("@")
-
-                if parsed.username:
-                    # Extract the raw username from the netloc to avoid re-encoding ambiguity
-                    # parsed.netloc is "user:pass@host", so partition gives us "user:pass"
-                    user_pass_part = parsed.netloc.rpartition("@")[0]
-                    # Partition gives us "user"
-                    username_part = user_pass_part.partition(":")[0]
-                    new_netloc = f"{username_part}:[REDACTED]@{host_part}"
-                else:
-                    # Case: https://:password@host (no username)
-                    new_netloc = f":[REDACTED]@{host_part}"
-
-                parsed = parsed._replace(netloc=new_netloc)
-
-            # 3. Redact Slack Webhooks
-            # Format: /services/T000/B000/TOKEN
-            hostname = (parsed.hostname or "").lower()
-            if (
-                not hostname
-                or hostname == "hooks.slack.com"
-                or hostname.endswith(".slack.com")
-            ) and parsed.path.startswith("/services/"):
-                parts = parsed.path.split("/")
-                # parts[0] is empty, parts[1] is 'services'
-                # parts[2] is Team ID, parts[3] is Bot ID, parts[4] is Token
-                # We redact the token (last part)
-                if len(parts) >= 5:
-                    parts[-1] = "[REDACTED]"
-                    new_path = "/".join(parts)
-                    parsed = parsed._replace(path=new_path)
-                    return urlunparse(parsed)
-
-            # 4. Redact Discord Webhooks
-            # Format: /api/webhooks/ID/TOKEN
-            if (
-                not hostname
-                or hostname == "discord.com"
-                or hostname.endswith(".discord.com")
-            ) and parsed.path.startswith("/api/webhooks/"):
-                parts = parsed.path.split("/")
-                # parts[-1] is likely the token
-                if len(parts) >= 5:
-                    parts[-1] = "[REDACTED]"
-                    new_path = "/".join(parts)
-                    parsed = parsed._replace(path=new_path)
-                    return urlunparse(parsed)
-
-            return urlunparse(parsed)
-        except Exception:
-            return url
-
-    def _redact_sensitive_url_params(self, url: str) -> str:
-        """
-        Redact sensitive query parameters from URL.
-        Prevents leaking credentials or tokens in logs/alerts.
-        """
-        try:
-            if not url:
-                return ""
-
-            parsed = urlparse(url)
-            # keep_blank_values=True ensures we don't drop empty params
-            query_params = parse_qs(parsed.query, keep_blank_values=True)
-
-            sensitive_keys = {
-                "password",
-                "token",
-                "secret",
-                "key",
-                "apikey",
-                "api_key",
-                "access_token",
-                "auth",
-                "authorization",
-                "sig",
-                "signature",
-            }
-
-            changed = False
-            for key in query_params:
-                if key.lower() in sensitive_keys:
-                    query_params[key] = ["[REDACTED]"]
-                    changed = True
-
-            if changed:
-                # doseq=True handles lists of values correctly
-                new_query = urlencode(query_params, doseq=True)
-                parsed = parsed._replace(query=new_query)
-                return urlunparse(parsed)
-            return url
-        except Exception:
-            # If parsing fails, return original to avoid losing data,
-            # but rely on other sanitization layers if any.
-            return url
-
-    def _sanitize_text(self, text: str, csv_safe: bool = False) -> str:
-        """
-        Sanitize text for safe console output.
-        Removes control characters, BiDi overrides, and normalizes whitespace.
-
-        Args:
-            text: Input text
-            csv_safe: If True, applies CSV/Formula injection prevention
-
-        """
-        if not text:
-            return ""
-
-        # Replace newlines and tabs with spaces
-        sanitized = (
-            text.translate(_WHITESPACE_TRANS)
-            if "\n" in text or "\r" in text or "\t" in text
-            else text
-        )
-
-        if "\x1b" in sanitized:
-            sanitized = ANSI_ESCAPE_PATTERN.sub("", sanitized)
-
-        # Remove non-printable characters (including BiDi overrides, control chars, etc.)
-        # Only keep characters that are printable or separators (Zs)
-        # Optimization: Use str.translate with a lazy-evaluating dictionary
-        # for significantly faster filtering (~15-20x) than a list comprehension inside join().
-        sanitized = sanitized.translate(_TRANSLATOR)
-
-        if csv_safe:
-            # Prevent Formula/CSV Injection for console logs that might be exported
-            sanitized = sanitize_for_csv(sanitized)
-
-        return sanitized
-
-    def _sanitize_for_slack(self, text: str) -> str:
-        """
-        Sanitize text for Slack to prevent injection and spoofing.
-        Escapes &, <, > and sanitizes control characters.
-        """
-        if not text:
-            return ""
-
-        # First sanitize control characters using the existing method
-        # We do NOT use csv_safe=True here to avoid messing up Slack formatting
-        text = self._sanitize_text(text, csv_safe=False)
-
-        # Escape Slack special characters
-        # Reference: https://api.slack.com/reference/surfaces/formatting#escaping
-        return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-
-    def _create_slack_field(
-        self, title: str, analysis_dict: Dict, indicator: str
-    ) -> Dict:
-        """Helper to create a standard Slack field dictionary with risk emojis."""
-        level = analysis_dict.get("risk_level", "unknown")
-        score = analysis_dict.get("score", 0)
-        symbol = Colors.get_risk_symbol(level)
-
-        value = f"{symbol} {level.upper()} ({score:.2f})"
-        if indicator:
-            value += f"{indicator}"
-
-        return {"title": title, "value": value, "short": True}
-
-    def _generate_slack_fields(self, report: ThreatReport) -> List[Dict]:
-        """Generate the fields array for the Slack payload."""
-        fields = [
-            {
-                "title": "Subject",
-                "value": self._sanitize_for_slack(report.subject),
-                "short": False,
-            },
-            {
-                "title": "From",
-                "value": self._sanitize_for_slack(report.sender),
-                "short": True,
-            },
-            {
-                "title": "Overall Threat Score",
-                "value": f"{report.overall_threat_score:.2f}",
-                "short": True,
-            },
-        ]
-
-        # Add analysis breakdown using helper method
-        # Spam
-        spam_data = report.spam_analysis or {}
-        spam_ind = ""
-        if spam_data.get("indicators"):
-            spam_ind = f" - {spam_data['indicators'][0]}"
-        elif spam_data.get("suspicious_urls"):
-            spam_ind = " - Suspicious URLs"
-
-        fields.append(self._create_slack_field("📧 Spam Analysis", spam_data, spam_ind))
-
-        # NLP
-        nlp_data = report.nlp_analysis or {}
-        nlp_ind = ""
-        if nlp_data.get("social_engineering_indicators"):
-            nlp_ind = f" - {nlp_data['social_engineering_indicators'][0]}"
-        elif nlp_data.get("authority_impersonation"):
-            nlp_ind = f" - {nlp_data['authority_impersonation'][0]}"
-
-        fields.append(self._create_slack_field("🧠 NLP Analysis", nlp_data, nlp_ind))
-
-        # Media
-        media_data = report.media_analysis or {}
-        media_ind = ""
-        if media_data.get("file_type_warnings"):
-            media_ind = f" - {media_data['file_type_warnings'][0]}"
-        elif media_data.get("potential_deepfakes"):
-            media_ind = " - Deepfake Detected"
-
-        fields.append(
-            self._create_slack_field("📎 Media Analysis", media_data, media_ind)
-        )
-
-        # Top Recommendation
-        fields.append(
-            {
-                "title": "Top Recommendation",
-                "value": (
-                    report.recommendations[0]
-                    if report.recommendations
-                    else "Review email"
-                ),
-                "short": False,
-            }
-        )
-        return fields
-
     def _slack_alert(self, report: ThreatReport) -> bool:
         """Send alert to Slack.
 
@@ -1207,31 +482,9 @@ class AlertSystem:
                 self.logger.error(f"Aborting Slack alert (SSRF prevention): {err_msg}")
                 return False
 
-            # Format Slack message
-            color = {"low": "#36a64f", "medium": "#ff9900", "high": "#ff0000"}.get(
-                report.risk_level, "#808080"
-            )
-
-            fields = self._generate_slack_fields(report)
-
-            attachments = [
-                {
-                    "color": color,
-                    "title": (f"🚨 Security Alert - {report.risk_level.upper()} Risk"),
-                    "fields": fields,
-                    "footer": "Email Security Pipeline",
-                    "ts": int(datetime.now().timestamp()),
-                }
-            ]
-
-            payload = {
-                "text": "New email security threat detected",
-                "attachments": attachments,
-            }
-
             response = requests.post(
                 self.config.slack_webhook,
-                json=payload,
+                json=alert_channels.build_slack_payload(report),
                 headers={"Content-Type": "application/json"},
                 timeout=10,
                 allow_redirects=False,
@@ -1251,7 +504,6 @@ class AlertSystem:
             )
             return False
 
-    @staticmethod
     def _generate_recommendations(
         spam_result: SpamAnalysisResult,
         nlp_result: NLPAnalysisResult,

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -504,6 +504,7 @@ class AlertSystem:
             )
             return False
 
+    @staticmethod
     def _generate_recommendations(
         spam_result: SpamAnalysisResult,
         nlp_result: NLPAnalysisResult,

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -24,7 +24,15 @@ from ..utils.sanitization import (
     sanitize_for_csv,
 )
 from ..utils.security_validators import is_safe_webhook_url
-from .email_data import EmailData
+from .alert_recommendations import (
+    DEFAULT_CLEAN_RECOMMENDATION,
+    RECOMMENDATION_PREFIXES,
+    RECOMMENDATION_PREFIXES_TUPLE,
+    RED_KEYWORDS_PATTERN,
+    YELLOW_KEYWORDS_PATTERN,
+    generate_recommendations,
+)
+from .alert_report import RenderConfig, ThreatReport, generate_threat_report
 from .media_analyzer import MediaAnalysisResult
 from .nlp_analyzer import NLPAnalysisResult
 from .spam_analyzer import SpamAnalysisResult
@@ -34,46 +42,19 @@ from .spam_analyzer import SpamAnalysisResult
 URL_PATTERN = re.compile(r'(?:https?://[^\s<>"]+|www\.[^\s<>"]+|/[^\s<>"]+)')
 
 
-@dataclass
-class ThreatReport:
-    """Comprehensive threat report."""
-
-    email_id: str
-    subject: str
-    sender: str
-    recipient: str
-    date: str
-    overall_threat_score: float
-    risk_level: str
-    spam_analysis: Dict
-    nlp_analysis: Dict
-    media_analysis: Dict
-    recommendations: List[str]
-    timestamp: str
-
-
-@dataclass
-class RenderConfig:
-    """Configuration options for console rendering."""
-
-    width: int
-    risk_color: str
-    risk_symbol: str
-
-
 class AlertSystem:
     """Manages alerts and notifications."""
 
     # Common prefixes for recommendations to strip during display to prevent duplication
-    RECOMMENDATION_PREFIXES = ["⚠️ ", "🎣 ", "🔗 ", "⏰ ", "📎 ", "👤 "]
+    RECOMMENDATION_PREFIXES = RECOMMENDATION_PREFIXES
 
     # Pre-allocated tuple for fast C-level execution of startswith()
-    RECOMMENDATION_PREFIXES_TUPLE = tuple(RECOMMENDATION_PREFIXES)
+    RECOMMENDATION_PREFIXES_TUPLE = RECOMMENDATION_PREFIXES_TUPLE
 
     # Compiled regex patterns for fast substring keyword checks in recommendations
     # Use re.compile directly since we are passing a single regex string, not a list
-    RED_KEYWORDS_PATTERN = re.compile(r"HIGH RISK|DANGEROUS|PHISHING")
-    YELLOW_KEYWORDS_PATTERN = re.compile(r"SUSPICIOUS|VERIFY|URGENCY|IMPERSONATION")
+    RED_KEYWORDS_PATTERN = RED_KEYWORDS_PATTERN
+    YELLOW_KEYWORDS_PATTERN = YELLOW_KEYWORDS_PATTERN
 
     # Pre-compiled pattern for fast URL redaction replacement without re.IGNORECASE penalty
     REDACTED_URL_PATTERN = re.compile(r"%5[bB]REDACTED%5[dD]", flags=0)
@@ -98,7 +79,7 @@ class AlertSystem:
     # Fallback recommendation text used by _generate_recommendations when no
     # specific threat condition is matched.  Defined as a class constant so
     # tests can reference it without hardcoding the string in two places.
-    DEFAULT_CLEAN_RECOMMENDATION = "✅ No issues detected"
+    DEFAULT_CLEAN_RECOMMENDATION = DEFAULT_CLEAN_RECOMMENDATION
 
     def __init__(self, config):
         """
@@ -1277,137 +1258,6 @@ class AlertSystem:
         media_result: MediaAnalysisResult,
     ) -> List[str]:
         """Generate actionable recommendations based on threat analysis results."""
-        recommendations = []
-
-        # High-risk recommendations
-        if spam_result.risk_level == "high":
-            recommendations.append("⚠️ HIGH RISK: Move to spam folder immediately")
-
-        if nlp_result.social_engineering_indicators:
-            recommendations.append(
-                "🎣 Potential phishing: Do not click links or provide credentials"
-            )
-
-        if media_result.file_type_warnings:
-            recommendations.append(
-                "📎 Dangerous attachment detected: Do not open attachments"
-            )
-
-        # Medium-risk recommendations
-        if spam_result.suspicious_urls:
-            recommendations.append(
-                "🔗 Suspicious URLs detected: Verify links before clicking"
-            )
-
-        if nlp_result.authority_impersonation:
-            recommendations.append(
-                "👤 Authority impersonation suspected: Verify sender identity"
-            )
-
-        if nlp_result.urgency_markers:
-            recommendations.append(
-                "⏰ Urgency tactics detected: Take time to verify before acting"
-            )
-
-        # General recommendations
-        if not recommendations:
-            recommendations.append(AlertSystem.DEFAULT_CLEAN_RECOMMENDATION)
-
-        return recommendations
+        return generate_recommendations(spam_result, nlp_result, media_result)
 
 
-def _calculate_overall_risk_level(
-    spam_result: SpamAnalysisResult,
-    nlp_result: NLPAnalysisResult,
-    media_result: MediaAnalysisResult,
-) -> str:
-    """Calculate overall risk level from individual analysis results."""
-    risk_levels = [
-        spam_result.risk_level,
-        nlp_result.risk_level,
-        media_result.risk_level,
-    ]
-
-    if "high" in risk_levels:
-        return "high"
-    if "medium" in risk_levels:
-        return "medium"
-    return "low"
-
-
-def _build_spam_analysis_dict(spam_result: SpamAnalysisResult) -> Dict:
-    """Build spam analysis dictionary for threat report."""
-    return {
-        "score": spam_result.score,
-        "risk_level": spam_result.risk_level,
-        "indicators": spam_result.indicators,
-        "suspicious_urls": spam_result.suspicious_urls,
-        "header_issues": spam_result.header_issues,
-    }
-
-
-def _build_nlp_analysis_dict(nlp_result: NLPAnalysisResult) -> Dict:
-    """Build NLP analysis dictionary for threat report."""
-    return {
-        "score": nlp_result.threat_score,
-        "risk_level": nlp_result.risk_level,
-        "social_engineering_indicators": nlp_result.social_engineering_indicators,
-        "urgency_markers": nlp_result.urgency_markers,
-        "authority_impersonation": nlp_result.authority_impersonation,
-        "psychological_triggers": nlp_result.psychological_triggers,
-    }
-
-
-def _build_media_analysis_dict(media_result: MediaAnalysisResult) -> Dict:
-    """Build media analysis dictionary for threat report."""
-    return {
-        "score": media_result.threat_score,
-        "risk_level": media_result.risk_level,
-        "suspicious_attachments": media_result.suspicious_attachments,
-        "file_type_warnings": media_result.file_type_warnings,
-        "size_anomalies": media_result.size_anomalies,
-        "potential_deepfakes": media_result.potential_deepfakes,
-    }
-
-
-def generate_threat_report(
-    email_data: EmailData,
-    spam_result: SpamAnalysisResult,
-    nlp_result: NLPAnalysisResult,
-    media_result: MediaAnalysisResult,
-) -> ThreatReport:
-    """
-    Generate comprehensive threat report.
-
-    Args:
-        email_data: Email data
-        spam_result: Spam analysis result
-        nlp_result: NLP analysis result
-        media_result: Media analysis result
-
-    Returns:
-        ThreatReport
-
-    """
-    overall_score = (
-        spam_result.score + nlp_result.threat_score + media_result.threat_score
-    )
-    risk_level = _calculate_overall_risk_level(spam_result, nlp_result, media_result)
-    recommendations = AlertSystem._generate_recommendations(
-        spam_result, nlp_result, media_result
-    )
-
-    return ThreatReport(
-        email_id=email_data.message_id,
-        subject=email_data.subject,
-        sender=email_data.sender,
-        recipient=email_data.recipient,
-        date=email_data.date.isoformat(),
-        overall_threat_score=overall_score,
-        risk_level=risk_level,
-        spam_analysis=_build_spam_analysis_dict(spam_result),
-        nlp_analysis=_build_nlp_analysis_dict(nlp_result),
-        media_analysis=_build_media_analysis_dict(media_result),
-        recommendations=recommendations,
-        timestamp=datetime.now().isoformat(),
-    )

--- a/src/modules/alert_system.py
+++ b/src/modules/alert_system.py
@@ -511,5 +511,3 @@ class AlertSystem:
     ) -> List[str]:
         """Generate actionable recommendations based on threat analysis results."""
         return generate_recommendations(spam_result, nlp_result, media_result)
-
-

--- a/src/modules/media_analyzer.py
+++ b/src/modules/media_analyzer.py
@@ -3,33 +3,23 @@ Layer 3: Media Authenticity Verification
 Analyzes attachments for synthetic content and deepfakes.
 """
 
-import io
+import cv2
 import logging
 import os
-import tarfile
 import tempfile
-import zipfile
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
-import cv2
-import numpy as np
-
-from ..utils.sanitization import sanitize_for_logging
-from ..utils.security_validators import sanitize_filename
 from ..utils.threat_scoring import calculate_risk_level
 from .email_data import EmailData
+from . import media_file_type
+from . import media_archive
+from . import media_deepfake
 
-
-@dataclass
-class FrameExtractionOptions:
-    """Options for frame extraction."""
-
-    max_frames: int = 10
-    max_dim: int = 1920
-    step: int = 1
-    total_frames: int = 0
+# Inject the facade's cv2 object into the deepfake helper module so that
+# tests patching src.modules.media_analyzer.cv2 continue to work.
+media_deepfake.cv2 = cv2
 
 
 @dataclass
@@ -210,19 +200,104 @@ class MediaAuthenticityAnalyzer:
         "flac": (".flac",),
     }
 
-    def _is_path_traversal_attempt(self, path: str) -> bool:
-        """Check if a path string contains traversal attempts or absolute paths."""
-        if path.startswith(("/", "\\")):
-            return True
-        if ".." in path:
-            return True
+    def _is_path_traversal_attempt(self, *args, **kwargs):
+        return media_file_type._is_path_traversal_attempt(self, *args, **kwargs)
 
-        # Simplifies the Windows drive check to avoid "Complex Conditional" flag
-        # We only check the first two chars if the string is long enough
-        if len(path) < 2:
-            return False
+    def _check_file_extension(self, *args, **kwargs):
+        return media_file_type._check_file_extension(self, *args, **kwargs)
 
-        return path[0].isalpha() and path[1] == ":"
+    def _check_riff_container(self, *args, **kwargs):
+        return media_file_type._check_riff_container(self, *args, **kwargs)
+
+    def _detect_file_type(self, *args, **kwargs):
+        return media_file_type._detect_file_type(self, *args, **kwargs)
+
+    def _check_content_type_mismatch(self, *args, **kwargs):
+        return media_file_type._check_content_type_mismatch(self, *args, **kwargs)
+
+    def _validate_signature_match(self, *args, **kwargs):
+        return media_file_type._validate_signature_match(self, *args, **kwargs)
+
+    def _validate_missing_signature(self, *args, **kwargs):
+        return media_file_type._validate_missing_signature(self, *args, **kwargs)
+
+    def _check_size_anomaly(self, *args, **kwargs):
+        return media_file_type._check_size_anomaly(self, *args, **kwargs)
+
+    def _is_nested_archive(self, *args, **kwargs):
+        return media_file_type._is_nested_archive(self, *args, **kwargs)
+
+    def _analyze_attachment_metadata(self, *args, **kwargs):
+        return media_file_type._analyze_attachment_metadata(self, *args, **kwargs)
+
+    def _inspect_zip_contents(self, *args, **kwargs):
+        return media_archive._inspect_zip_contents(self, *args, **kwargs)
+
+    def _check_file_count(self, *args, **kwargs):
+        return media_archive._check_file_count(self, *args, **kwargs)
+
+    def _inspect_zip_member_and_check_traversal(self, *args, **kwargs):
+        return media_archive._inspect_zip_member_and_check_traversal(self, *args, **kwargs)
+
+    def _inspect_archive_member(self, *args, **kwargs):
+        return media_archive._inspect_archive_member(self, *args, **kwargs)
+
+    def _handle_nested_zip_member(self, *args, **kwargs):
+        return media_archive._handle_nested_zip_member(self, *args, **kwargs)
+
+    def _inspect_tar_contents(self, *args, **kwargs):
+        return media_archive._inspect_tar_contents(self, *args, **kwargs)
+
+    def _inspect_tar_contents_safe(self, *args, **kwargs):
+        return media_archive._inspect_tar_contents_safe(self, *args, **kwargs)
+
+    def _apply_tar_filter(self, *args, **kwargs):
+        return media_archive._apply_tar_filter(self, *args, **kwargs)
+
+    def _get_tar_members_safely(self, *args, **kwargs):
+        return media_archive._get_tar_members_safely(self, *args, **kwargs)
+
+    def _process_tar_member(self, *args, **kwargs):
+        return media_archive._process_tar_member(self, *args, **kwargs)
+
+    def _handle_nested_tar_member(self, *args, **kwargs):
+        return media_archive._handle_nested_tar_member(self, *args, **kwargs)
+
+    def _read_file_securely(self, *args, **kwargs):
+        return media_archive._read_file_securely(self, *args, **kwargs)
+
+    def _read_zip_member_securely(self, *args, **kwargs):
+        return media_archive._read_zip_member_securely(self, *args, **kwargs)
+
+    def _extract_frames_from_video(self, *args, **kwargs):
+        return media_deepfake._extract_frames_from_video(self, *args, **kwargs)
+
+    def _extract_frames_sequential(self, *args, **kwargs):
+        return media_deepfake._extract_frames_sequential(self, *args, **kwargs)
+
+    def _extract_frames_sampled(self, *args, **kwargs):
+        return media_deepfake._extract_frames_sampled(self, *args, **kwargs)
+
+    def _advance_to_frame(self, *args, **kwargs):
+        return media_deepfake._advance_to_frame(self, *args, **kwargs)
+
+    def _resize_frame_if_needed(self, *args, **kwargs):
+        return media_deepfake._resize_frame_if_needed(self, *args, **kwargs)
+
+    def _analyze_facial_inconsistencies(self, *args, **kwargs):
+        return media_deepfake._analyze_facial_inconsistencies(self, *args, **kwargs)
+
+    def _check_audio_visual_sync(self, *args, **kwargs):
+        return media_deepfake._check_audio_visual_sync(self, *args, **kwargs)
+
+    def _check_compression_artifacts(self, *args, **kwargs):
+        return media_deepfake._check_compression_artifacts(self, *args, **kwargs)
+
+    def _run_deepfake_model(self, *args, **kwargs):
+        return media_deepfake._run_deepfake_model(self, *args, **kwargs)
+
+    def _analyze_video_frames(self, *args, **kwargs):
+        return media_deepfake._analyze_video_frames(self, *args, **kwargs)
 
     def __init__(self, config):
         """
@@ -237,6 +312,7 @@ class MediaAuthenticityAnalyzer:
         self.face_cascade = None
         # Optimization: Reuse thread pool for deepfake detection to avoid overhead
         self._deepfake_executor = ThreadPoolExecutor()
+
 
     def analyze(self, email_data: EmailData) -> MediaAnalysisResult:
         """
@@ -315,6 +391,7 @@ class MediaAuthenticityAnalyzer:
             risk_level=risk_level,
         )
 
+
     def _process_attachment_parallel(
         self, attachment: dict, shared_state: dict
     ) -> tuple:
@@ -340,74 +417,6 @@ class MediaAuthenticityAnalyzer:
 
         return meta_res, deepfake_res
 
-    def _analyze_attachment_metadata(self, attachment: dict) -> dict:
-        """
-        Analyze attachment metadata and basic properties.
-        Returns a dict with scores and warnings.
-        """
-        filename = attachment.get("filename", "")
-        content_type = attachment.get("content_type", "")
-        size = attachment.get("size", 0)
-        data = attachment.get("data", b"")
-        truncated = attachment.get("truncated", False)
-
-        result = {
-            "score": 0.0,
-            "size_anomalies": [],
-            "file_type_warnings": [],
-            "suspicious_attachments": [],
-        }
-
-        if truncated:
-            result["size_anomalies"].append(
-                f"Attachment truncated for scanning: {filename}"
-            )
-
-        # Check file extension
-        ext_score, ext_warnings = self._check_file_extension(filename)
-        result["score"] += ext_score
-        result["file_type_warnings"].extend(ext_warnings)
-
-        # Check content type mismatch
-        mismatch_score, mismatch_warnings = self._check_content_type_mismatch(
-            filename, content_type, data
-        )
-        result["score"] += mismatch_score
-        if mismatch_warnings:
-            result["suspicious_attachments"].append(f"{filename}: {mismatch_warnings}")
-
-        # Check file size anomalies
-        size_score, size_warning = self._check_size_anomaly(filename, size)
-        result["score"] += size_score
-        if size_warning:
-            result["size_anomalies"].append(size_warning)
-
-        # Check for dangerous contents in archives (e.g. Zip files)
-        filename_lower = filename.lower()
-        is_zip = False
-        if data and data.startswith(b"PK\x03\x04"):
-            is_zip = True
-        elif filename_lower.endswith(".zip"):
-            is_zip = True
-
-        if is_zip:
-            zip_score, zip_warnings = self._inspect_zip_contents(filename, data)
-            result["score"] += zip_score
-            if zip_warnings:
-                result["suspicious_attachments"].extend(zip_warnings)
-
-        # Check for tar archives
-        is_tar = False
-        if filename_lower.endswith((".tar", ".tar.gz", ".tgz", ".gz")):
-            is_tar = True
-
-        if is_tar:
-            tar_score, tar_warnings = self._inspect_tar_contents(filename, data)
-            result["score"] += tar_score
-            if tar_warnings:
-                result["suspicious_attachments"].extend(tar_warnings)
-
-        return result
 
     def _analyze_deepfake_threat(
         self, filename: str, data: bytes, content_type: str
@@ -436,603 +445,6 @@ class MediaAuthenticityAnalyzer:
 
         return result
 
-    def _check_file_extension(self, filename: str) -> Tuple[float, List[str]]:
-        """Check if file extension is dangerous."""
-        score = 0.0
-        warnings = []
-
-        # Sanitize filename (strip whitespace and null bytes for check)
-        # Also strip trailing dots which can bypass extension checks but still be executable on Windows
-        filename_lower = filename.lower().strip().replace("\0", "").rstrip(".")
-
-        # Check for dangerous extensions
-        # Optimization: tuple-based endswith() is ~10-15x faster than looping
-        if filename_lower.endswith(self.DANGEROUS_EXTENSIONS):
-            score += 5.0  # Very high score for dangerous files
-            warnings.append(f"Dangerous file type: {filename}")
-
-        # Check for suspicious extensions
-        # Optimization: tuple-based endswith() avoids slow Python looping overhead
-        if filename_lower.endswith(self.SUSPICIOUS_EXTENSIONS):
-            score += 3.0
-            warnings.append(f"Suspicious file extension: {filename}")
-
-        # Check for double extensions
-        parts = filename_lower.split(".")
-        if len(parts) > 2:
-            score += 1.5
-            warnings.append(f"Multiple extensions detected: {filename}")
-
-        return score, warnings
-
-    def _check_riff_container(self, data: bytes) -> Optional[str]:
-        """Check for specific media types within a RIFF container."""
-        if len(data) >= 12:
-            format_type = data[8:12]
-            if format_type == b"AVI ":
-                return "avi"
-            elif format_type == b"WAVE":
-                return "wav"
-            elif format_type == b"WEBP":
-                return "webp"
-        return None
-
-    def _detect_file_type(self, data: bytes) -> Optional[str]:
-        """Detect file type from magic bytes."""
-        if not data or len(data) < 4:
-            return None
-
-        # Check RIFF container (AVI, WAV, WEBP)
-        if data.startswith(b"RIFF"):
-            return self._check_riff_container(data)
-
-        # Optimization: Fast check for all signatures with offset 0
-        if data.startswith(self.MAGIC_PREFIXES_OFFSET_0):
-            for sig, name in self.MAGIC_SIGNATURES_OFFSET_0:
-                if data.startswith(sig):
-                    return name
-
-        # Check signatures with non-zero offset
-        if len(data) >= 8 and data[4:8] == b"ftyp":  # Common for MP4/MOV
-            return "mp4"
-
-        return None
-
-    def _check_content_type_mismatch(
-        self, filename: str, content_type: str, data: bytes
-    ) -> Tuple[float, str]:
-        """Check if actual file content matches declared content type."""
-        actual_type = self._detect_file_type(data)
-
-        if actual_type:
-            return self._validate_signature_match(filename, actual_type)
-        else:
-            return self._validate_missing_signature(filename)
-
-    def _validate_signature_match(
-        self, filename: str, actual_type: str
-    ) -> Tuple[float, str]:
-        """Check if file extension matches the detected signature."""
-        filename_lower = filename.lower().strip().replace("\0", "").rstrip(".")
-
-        # Special case for executables disguised as documents
-        if actual_type == "exe" and not filename_lower.endswith(".exe"):
-            return 5.0, "Executable disguised as another file type"
-
-        # Check for general mismatches
-        expected_exts = self.EXPECTED_EXTENSIONS.get(actual_type)
-        if expected_exts and not filename_lower.endswith(expected_exts):
-            return 2.0, f"File type mismatch: {filename} (detected {actual_type})"
-
-        return 0.0, ""
-
-    def _validate_missing_signature(self, filename: str) -> Tuple[float, str]:
-        """Check if missing signature violates strict extension rules."""
-        # Type not detected. Validate that if extension claims a known type, it matches.
-        # This prevents processing invalid/corrupt media files.
-        filename_lower = filename.lower().strip().replace("\0", "").rstrip(".")
-
-        # Lazily initialize strict validation configuration on the class so we don't
-        # rebuild it on every call. This keeps the mapping centralized and efficient.
-        cls = self.__class__
-
-        if not hasattr(cls, "_STRICT_VALIDATION_EXTS"):
-            # Map extensions to their expected descriptions for error messages
-            cls._STRICT_VALIDATION_EXTS = {
-                # Note: '.exe' and '.dll' are also handled earlier when a valid PE signature
-                # is detected (actual_type == 'exe'). They are included here as a fallback
-                # for cases where signature detection fails but the extension claims an executable.
-                ".exe": "executable",
-                ".dll": "executable",
-                ".zip": "archive",
-                ".pdf": "PDF",
-                ".png": "PNG image",
-                ".jpg": "JPEG image",
-                ".jpeg": "JPEG image",
-                ".gif": "GIF image",
-                ".mp4": "MP4 video",
-                ".avi": "AVI video",
-                ".mkv": "MKV video",
-                ".wav": "WAV audio",
-                # Additional strict validation for media types processed by OpenCV
-                ".mov": "QuickTime video",
-                ".wmv": "WMV video",
-                ".flv": "FLV video",
-                ".ogg": "Ogg audio/video",
-                ".flac": "FLAC audio",
-                ".m4a": "M4A audio",
-            }
-
-        if not hasattr(cls, "_CRITICAL_MEDIA_EXTS"):
-            # Treat all known media extensions (and WAV) as critical when their signatures are invalid,
-            # to prevent them from reaching deepfake/OpenCV processing. Use getattr so we degrade
-            # safely if MEDIA_EXTENSIONS is not defined on this instance.
-            media_exts = getattr(self, "MEDIA_EXTENSIONS", [])
-            cls._CRITICAL_MEDIA_EXTS = {
-                ext
-                for ext in cls._STRICT_VALIDATION_EXTS.keys()
-                if ext in media_exts or ext == ".wav"
-            }
-
-        strict_validation_exts = cls._STRICT_VALIDATION_EXTS
-        critical_media_exts = cls._CRITICAL_MEDIA_EXTS
-        for ext, type_desc in strict_validation_exts.items():
-            if filename_lower.endswith(ext):
-                # Return 5.0 (Critical) for media files to ensure they don't reach deepfake analysis
-                # which could trigger vulnerabilities in processing libraries (e.g., OpenCV)
-                # Note: 5.0 is intentionally chosen to fail the `threat_score < 5.0` gate (see earlier check),
-                # so that invalid media never reaches the deepfake/OpenCV processing pipeline.
-                if ext in critical_media_exts:
-                    return (
-                        5.0,
-                        f"Invalid file signature for {ext}: expected {type_desc} signature but none found",
-                    )
-                return (
-                    2.0,
-                    f"Invalid file signature for {ext}: expected {type_desc} signature but none found",
-                )
-
-        return 0.0, ""
-
-    def _check_size_anomaly(self, filename: str, size: int) -> Tuple[float, str]:
-        """Check for unusual file sizes."""
-        score = 0.0
-        warning = ""
-
-        # Very large attachments (potential data exfiltration)
-        if size > self.MAX_ATTACHMENT_SIZE_MB * 1024 * 1024:
-            score += 1.5
-            warning = (
-                f"Unusually large attachment: {filename} ({size / (1024*1024):.1f}MB)"
-            )
-
-        # Suspiciously small media files
-        filename_lower = filename.lower()
-        # Optimization: O(1) loop iteration using tuple-based endswith() check
-        if filename_lower.endswith(self.MEDIA_EXTENSIONS):
-            if size < self.MIN_MEDIA_FILE_SIZE_BYTES:
-                score += 1.0
-                warning = f"Suspiciously small media file: {filename} ({size} bytes)"
-
-        return score, warning
-
-    def _is_nested_archive(self, filename_lower: str) -> bool:
-        """Check if filename is a nested archive type. Assumes filename_lower is already lowercase."""
-        # Optimization: O(1) loop iteration using tuple-based endswith() check
-        return filename_lower.endswith(self.ARCHIVE_EXTENSIONS)
-
-    def _inspect_zip_contents(
-        self, filename: str, data: bytes, depth: int = 0
-    ) -> Tuple[float, List[str]]:
-        """Inspect contents of zip file for dangerous files, with recursion."""
-        score = 0.0
-        warnings = []
-
-        # Max recursion depth to prevent zip bombs
-        if depth > 2:
-            return score, warnings
-
-        try:
-            with zipfile.ZipFile(io.BytesIO(data)) as zf:
-                file_list = zf.namelist()
-                score, warnings = self._check_file_count(
-                    filename, file_list, score, warnings
-                )
-
-                # Always cap the number of files we inspect to MAX_ZIP_FILE_COUNT to limit processing
-                files_to_check = file_list[: self.MAX_ZIP_FILE_COUNT]
-
-                for contained_file in files_to_check:
-                    member_score, member_warnings = (
-                        self._inspect_zip_member_and_check_traversal(
-                            zf, contained_file, filename, depth
-                        )
-                    )
-                    score += member_score
-                    warnings.extend(member_warnings)
-
-                    if score >= 5.0:
-                        return score, warnings
-
-        except zipfile.BadZipFile as e:
-            self.logger.warning(f"Bad zip file {filename}: {e}")
-        except Exception as e:
-            self.logger.warning(f"Error inspecting zip {filename}: {e}")
-
-        return score, warnings
-
-    def _check_file_count(
-        self, filename: str, file_list: List[str], score: float, warnings: List[str]
-    ) -> Tuple[float, List[str]]:
-        """Check if archive contains too many files."""
-        if len(file_list) > self.MAX_ZIP_FILE_COUNT:
-            score += 1.0
-            warnings.append(
-                f"Archive {filename} contains too many files ({len(file_list)})"
-            )
-        return score, warnings
-
-    def _inspect_zip_member_and_check_traversal(
-        self, zf: zipfile.ZipFile, contained_file: str, filename: str, depth: int
-    ) -> Tuple[float, List[str]]:
-        score = 0.0
-        warnings = []
-        if self._is_path_traversal_attempt(contained_file):
-            score += 5.0
-            safe_contained_file = sanitize_for_logging(
-                sanitize_filename(contained_file)
-            )
-            warnings.append(
-                f"Zip file {filename} contains path traversal attempt: {safe_contained_file}"
-            )
-
-        member_score, member_warnings = self._inspect_archive_member(
-            filename,
-            contained_file,
-            lambda: self._handle_nested_zip_member(zf, contained_file, filename, depth),
-        )
-        score += member_score
-        warnings.extend(member_warnings)
-        return score, warnings
-
-    def _inspect_archive_member(
-        self, parent_filename: str, member_name: str, nested_handler_fn
-    ) -> Tuple[float, List[str]]:
-        """
-        Inspect a single member of an archive.
-
-        Args:
-            parent_filename: Name of the parent archive
-            member_name: Name of the member file
-            nested_handler_fn: Function to call if member is a nested archive
-
-        Returns:
-            Tuple of (score, warnings)
-
-        """
-        score = 0.0
-        warnings = []
-
-        # SECURITY: Sanitize member name to prevent path traversal and log injection
-        safe_member_name = sanitize_for_logging(sanitize_filename(member_name))
-        member_lower = safe_member_name.lower()
-
-        # Check for dangerous extensions
-        # Optimization: O(1) loop iteration using tuple-based endswith() check
-        if member_lower.endswith(self.DANGEROUS_EXTENSIONS):
-            score += 5.0
-            warnings.append(
-                f"Archive {parent_filename} contains dangerous file: {safe_member_name}"
-            )
-            return score, warnings
-
-        # Check for nested archives
-        is_nested = self._is_nested_archive(member_lower)
-        if is_nested:
-            score += 2.0
-            warnings.append(
-                f"Archive {parent_filename} contains nested archive: {safe_member_name}"
-            )
-
-            # Recurse
-            nested_score, nested_warnings = nested_handler_fn()
-            score += nested_score
-            warnings.extend(nested_warnings)
-
-            if score >= 5.0:
-                return score, warnings
-
-        # Check for suspicious extensions
-        # Optimization: O(1) loop iteration using tuple-based endswith() check
-        if member_lower.endswith(self.SUSPICIOUS_EXTENSIONS):
-            score += 3.0
-            warnings.append(
-                f"Archive {parent_filename} contains suspicious file: {safe_member_name}"
-            )
-
-        return score, warnings
-
-    def _handle_nested_zip_member(
-        self, zf: zipfile.ZipFile, member_name: str, parent_filename: str, depth: int
-    ) -> Tuple[float, List[str]]:
-        """Handle nested archive found inside a zip file."""
-        score = 0.0
-        warnings = []
-
-        # SECURITY: Sanitize member name for logging and recursive path building
-        safe_member_name = sanitize_for_logging(sanitize_filename(member_name))
-        member_lower = safe_member_name.lower()
-
-        # Only recurse into supported formats
-        if (
-            not (
-                member_lower.endswith(".zip")
-                or member_lower.endswith((".tar", ".tar.gz", ".tgz", ".gz"))
-            )
-            or depth >= 2
-        ):
-            return score, warnings
-
-        try:
-            # Check declared size
-            info = zf.getinfo(member_name)
-            if info.file_size >= self.MAX_NESTED_ZIP_SIZE:
-                self.logger.warning(
-                    f"Skipping nested archive {safe_member_name} (declared size {info.file_size} > limit)"
-                )
-                return score, warnings
-
-            # Extract securely
-            nested_data = self._read_zip_member_securely(
-                zf, member_name, self.MAX_NESTED_ZIP_SIZE
-            )
-
-            # Recurse based on type
-            if member_lower.endswith(".zip"):
-                return self._inspect_zip_contents(
-                    f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
-                )
-            else:
-                return self._inspect_tar_contents(
-                    f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
-                )
-
-        except ValueError as e:
-            score += 5.0
-            warnings.append(
-                f"Zip bomb detected: {parent_filename}/{safe_member_name} ({str(e)})"
-            )
-        except Exception as e:
-            self.logger.warning(
-                f"Error inspecting nested archive {safe_member_name}: {e}"
-            )
-            score += 3.0
-            warnings.append(
-                f"Failed to inspect nested archive {safe_member_name}: {str(e)}"
-            )
-
-        return score, warnings
-
-    def _inspect_tar_contents(
-        self, filename: str, data: bytes, depth: int = 0
-    ) -> Tuple[float, List[str]]:
-        """Inspect contents of tar file for dangerous files, with recursion."""
-        if depth > 2:
-            return 0.0, []
-
-        try:
-            return self._inspect_tar_contents_safe(filename, data)
-        except tarfile.TarError as e:
-            self.logger.warning(f"Error inspecting tar {filename}: {e}")
-        except Exception as e:
-            self.logger.warning(f"Error inspecting tar {filename}: {e}")
-
-        return 0.0, []
-
-    def _inspect_tar_contents_safe(
-        self, filename: str, data: bytes
-    ) -> Tuple[float, List[str]]:
-        """Safely inspect tar contents with proper filtering and member processing."""
-        score = 0.0
-        warnings = []
-
-        with tarfile.open(fileobj=io.BytesIO(data), mode="r:*") as tf:
-            self._apply_tar_filter(tf)
-            members = self._get_tar_members_safely(tf)
-
-            score, warnings = self._check_file_count(
-                filename, [m.name for m in members], score, warnings
-            )
-
-            for member in members[: self.MAX_ZIP_FILE_COUNT]:
-                member_score, member_warnings = self._process_tar_member(
-                    tf, member, filename
-                )
-                score += member_score
-                warnings.extend(member_warnings)
-                if score >= 5.0:
-                    return score, warnings
-
-        return score, warnings
-
-    def _apply_tar_filter(self, tf: tarfile.TarFile) -> None:
-        """Apply PEP-706 data filter if available to prevent extraction traversal."""
-        if hasattr(tarfile, "data_filter"):
-            tf.extraction_filter = getattr(
-                tarfile, "data_filter", (lambda member, path: member)
-            )
-
-    def _get_tar_members_safely(self, tf: tarfile.TarFile) -> List[tarfile.TarInfo]:
-        """Get tar members safely with count limit."""
-        members = []
-        for m in tf:
-            members.append(m)
-            if len(members) > self.MAX_ZIP_FILE_COUNT:
-                break
-        return members
-
-    def _process_tar_member(
-        self, tf: tarfile.TarFile, member: tarfile.TarInfo, filename: str
-    ) -> Tuple[float, List[str]]:
-        """Process a single tar member for threats."""
-        safe_member_name = sanitize_for_logging(sanitize_filename(member.name))
-        member_lower = safe_member_name.lower()
-
-        if member_lower.endswith(self.DANGEROUS_EXTENSIONS):
-            return 5.0, [
-                f"Archive {filename} contains dangerous file: {safe_member_name}"
-            ]
-
-        if self._is_path_traversal_attempt(member.name):
-            safe_member_name_traversal = sanitize_for_logging(
-                sanitize_filename(member.name)
-            )
-            return 5.0, [
-                f"Tar file {filename} contains path traversal attempt: {safe_member_name_traversal}"
-            ]
-
-        if member.issym() or member.islnk():
-            if self._is_path_traversal_attempt(member.linkname):
-                safe_linkname_traversal = sanitize_for_logging(
-                    sanitize_filename(member.linkname)
-                )
-                return 5.0, [
-                    f"Tar file {filename} contains link with path traversal attempt: {safe_linkname_traversal}"
-                ]
-
-        member_score, member_warnings = self._inspect_archive_member(
-            filename,
-            member.name,
-            lambda: self._handle_nested_tar_member(tf, member, filename, 0),
-        )
-        return member_score, member_warnings
-
-    def _handle_nested_tar_member(
-        self,
-        tf: tarfile.TarFile,
-        member: tarfile.TarInfo,
-        parent_filename: str,
-        depth: int,
-    ) -> Tuple[float, List[str]]:
-        """Handle nested archive found inside a tar file."""
-        score = 0.0
-        warnings = []
-        member_name = member.name
-
-        # SECURITY: Sanitize member name for logging and recursive path building
-        safe_member_name = sanitize_for_logging(sanitize_filename(member_name))
-        member_lower = safe_member_name.lower()
-
-        if (
-            not (
-                member_lower.endswith(".zip")
-                or member_lower.endswith((".tar", ".tar.gz", ".tgz", ".gz"))
-            )
-            or depth >= 2
-        ):
-            return score, warnings
-
-        # Skip if declared size is too large
-        if member.size >= self.MAX_NESTED_ZIP_SIZE:
-            self.logger.warning(
-                f"Skipping nested archive {safe_member_name} (declared size {member.size} > limit)"
-            )
-            return score, warnings
-
-        try:
-            f = tf.extractfile(member)
-            if f:
-                nested_data = self._read_file_securely(
-                    f, member_name, self.MAX_NESTED_ZIP_SIZE
-                )
-
-                if member_lower.endswith(".zip"):
-                    return self._inspect_zip_contents(
-                        f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
-                    )
-                else:
-                    return self._inspect_tar_contents(
-                        f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
-                    )
-
-        except Exception as e:
-            self.logger.warning(
-                f"Error inspecting nested archive {safe_member_name} inside tar: {e}"
-            )
-            score += 3.0
-            warnings.append(
-                f"Failed to inspect nested archive {safe_member_name}: {str(e)}"
-            )
-
-        return score, warnings
-
-    def _read_file_securely(self, f, filename: str, max_size: int) -> bytes:
-        """
-        Read a file-like object securely with a size limit.
-        """
-        content = io.BytesIO()
-        total_read = 0
-        chunk_size = 8192
-
-        while True:
-            chunk = f.read(chunk_size)
-            if not chunk:
-                break
-            total_read += len(chunk)
-            if total_read > max_size:
-                raise ValueError(
-                    f"File {filename} exceeds maximum size of {max_size} bytes"
-                )
-            content.write(chunk)
-
-        return content.getvalue()
-
-    def _read_zip_member_securely(
-        self, zf: zipfile.ZipFile, filename: str, max_size: int
-    ) -> bytes:
-        """
-        Read a zip member securely with a size limit to prevent zip bombs.
-
-        Args:
-            zf: ZipFile object
-            filename: Name of the file to read
-            max_size: Maximum allowed size in bytes
-
-        Returns:
-            Decompressed bytes
-
-        Raises:
-            ValueError: If decompressed size exceeds max_size
-
-        """
-        content = io.BytesIO()
-        total_read = 0
-        chunk_size = 8192
-
-        # Don't use 'with' to avoid implicit close() which might trigger CRC check on partial read
-        # causing the ValueError to be masked by BadZipFile exception
-        f = zf.open(filename)
-        try:
-            while True:
-                chunk = f.read(chunk_size)
-                if not chunk:
-                    break
-                total_read += len(chunk)
-                if total_read > max_size:
-                    raise ValueError(
-                        f"Zip member {filename} exceeds maximum size of {max_size} bytes"
-                    )
-                content.write(chunk)
-        finally:
-            try:
-                f.close()
-            except zipfile.BadZipFile as e:
-                # Ignore errors on close (like CRC mismatch due to partial read)
-                self.logger.debug(
-                    f"Ignored error closing zip stream for {filename}: {e}"
-                )
-
-        return content.getvalue()
 
     def _check_deepfake_indicators(
         self, filename: str, data: bytes, content_type: str
@@ -1104,403 +516,6 @@ class MediaAuthenticityAnalyzer:
 
         return score, indicators
 
-    def _analyze_video_frames(
-        self, filename: str, temp_file_path: str, frames: list, content_type: str
-    ) -> Tuple[float, List[str]]:
-        """
-        Analyze extracted video frames for deepfake indicators.
-        """
-        score = 0.0
-        indicators = []
-
-        # Optimization: Convert frames to grayscale once to avoid repeated conversions
-        # This saves CPU time in subsequent analysis steps
-        gray_frames = [cv2.cvtColor(f, cv2.COLOR_BGR2GRAY) for f in frames]
-
-        # 2. Analyze for facial inconsistencies
-        facial_score, facial_issues = self._analyze_facial_inconsistencies(gray_frames)
-        if facial_score > 0:
-            score += facial_score
-            indicators.extend([f"{filename}: {issue}" for issue in facial_issues])
-
-        # 3. Check audio-visual synchronization
-        sync_score, sync_issues = self._check_audio_visual_sync(temp_file_path, frames)
-        if sync_score > 0:
-            score += sync_score
-            indicators.extend([f"{filename}: {issue}" for issue in sync_issues])
-
-        # 4. Look for compression artifacts typical of deepfakes
-        compression_score, compression_issues = self._check_compression_artifacts(
-            gray_frames
-        )
-        if compression_score > 0:
-            score += compression_score
-            indicators.extend([f"{filename}: {issue}" for issue in compression_issues])
-
-        # 5. Use specialized deepfake detection models (Simulated)
-        model_score = self._run_deepfake_model(frames, gray_frames, content_type)
-        if model_score > 0.7:
-            score += 3.0
-            indicators.append(
-                f"High probability of deepfake detected by model: {filename}"
-            )
-
-        return score, indicators
-
-    def _extract_frames_from_video(
-        self, video_path: str, max_frames: int = 10, max_dim: int = 1920
-    ) -> List[np.ndarray]:
-        """
-        Extract a sample of frames from the video.
-
-        Frames are sampled up to ``max_frames`` times, distributed across the video
-        when the total frame count is known, or sequentially from the start if it is not.
-
-        Each extracted frame is optionally resized via ``_resize_frame_if_needed`` so
-        that its longest side does not exceed ``max_dim`` pixels, while preserving
-        aspect ratio. Frames smaller than ``max_dim`` are left at their original size.
-
-        Args:
-            video_path: Path to the video file to sample.
-            max_frames: Maximum number of frames to extract from the video.
-            max_dim: Maximum allowed dimension (in pixels) for the width or height
-                of each returned frame. The frame is downscaled if necessary so its
-                longest side is at most this value, preserving aspect ratio.
-
-        """
-        frames = []
-        try:
-            cap = cv2.VideoCapture(video_path)
-            if not cap.isOpened():
-                return frames
-
-            total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-
-            if total_frames <= 0:
-                # Fallback if frame count is unknown
-                frames = self._extract_frames_sequential(cap, max_frames, max_dim)
-            else:
-                # Sample evenly distributed frames
-                step = max(1, total_frames // max_frames)
-
-                # Optimization: For step=1 (sequential reading), avoid expensive seek operations
-                if step == 1:
-                    count = 0
-                    while count < max_frames:
-                        success, frame = cap.read()
-                        if not success:
-                            break
-                        if frame is not None:
-                            frames.append(self._resize_frame_if_needed(frame, max_dim))
-                        count += 1
-                else:
-                    options = FrameExtractionOptions(
-                        max_frames=max_frames,
-                        max_dim=max_dim,
-                        step=step,
-                        total_frames=total_frames,
-                    )
-                    frames = self._extract_frames_sampled(cap, options)
-
-            cap.release()
-        except Exception as e:
-            self.logger.error(f"Error extracting frames: {e}")
-
-        return frames
-
-    def _extract_frames_sequential(
-        self, cap, max_frames: int, max_dim: int
-    ) -> List[np.ndarray]:
-        """Extract frames sequentially without seeking."""
-        frames = []
-        count = 0
-        while count < max_frames:
-            success, frame = cap.read()
-            if not success:
-                break
-            if frame is not None:
-                frames.append(self._resize_frame_if_needed(frame, max_dim))
-            count += 1
-        return frames
-
-    def _extract_frames_sampled(
-        self, cap, options: FrameExtractionOptions
-    ) -> List[np.ndarray]:
-        """Extract frames using a hybrid approach of seeking and grabbing for sampling."""
-        frames = []
-        current_frame = 0
-
-        for target_frame in range(0, options.total_frames, options.step):
-            if len(frames) >= options.max_frames:
-                break
-
-            current_frame = self._advance_to_frame(cap, current_frame, target_frame)
-
-            if current_frame != target_frame:
-                break
-
-            success, frame = cap.read()
-            if success and frame is not None:
-                frames.append(self._resize_frame_if_needed(frame, options.max_dim))
-                current_frame += 1
-            else:
-                break
-
-        return frames
-
-    def _advance_to_frame(self, cap, current_frame: int, target_frame: int) -> int:
-        """Advance the video capture to the target frame using a hybrid approach."""
-        try:
-            import cv2
-
-            cap_prop_pos_frames = cv2.CAP_PROP_POS_FRAMES
-        except ImportError:
-            cap_prop_pos_frames = (
-                1  # Fallback to the known integer value for CAP_PROP_POS_FRAMES
-            )
-
-        seek_threshold = 30
-        jump = target_frame - current_frame
-
-        if jump > seek_threshold:
-            cap.set(cap_prop_pos_frames, target_frame)
-            current_frame = target_frame
-
-        while current_frame < target_frame:
-            if not cap.grab():
-                break
-            current_frame += 1
-
-        return current_frame
-
-    def _resize_frame_if_needed(
-        self, frame: np.ndarray, max_dim: int = 1920
-    ) -> np.ndarray:
-        """Resize frame if it exceeds maximum dimension while maintaining aspect ratio."""
-        try:
-            h, w = frame.shape[:2]
-
-            # Defensive check: guard against malformed/empty frames with non-positive dimensions.
-            # OpenCV's resize requires strictly positive width/height; if we get bad input here,
-            # we log and return the frame unchanged rather than raising and bypassing DoS controls.
-            if h <= 0 or w <= 0:
-                self.logger.warning(
-                    f"Received frame with non-positive dimensions (h={h}, w={w}); skipping resize."
-                )
-                return frame
-
-            if max(h, w) <= max_dim:
-                return frame
-
-            scale = max_dim / max(h, w)
-            # Clamp new dimensions to at least 1 pixel to avoid int() rounding to 0,
-            # which would cause cv2.resize to raise and circumvent the downscaling.
-            new_w = max(1, int(w * scale))
-            new_h = max(1, int(h * scale))
-            return cv2.resize(frame, (new_w, new_h), interpolation=cv2.INTER_AREA)
-        except Exception as e:
-            self.logger.warning(f"Error resizing frame: {e}")
-            return frame
-
-    def _analyze_facial_inconsistencies(
-        self, gray_frames: List[np.ndarray]
-    ) -> Tuple[float, List[str]]:
-        """
-        Analyze frames for facial inconsistencies.
-        Uses OpenCV's Haar cascades for face detection and analyzes face regions.
-
-        Args:
-            gray_frames: List of grayscale frames (numpy arrays)
-
-        """
-        score = 0.0
-        issues = []
-
-        # Load Haar cascade for face detection (lazy loading with caching)
-        if self.face_cascade is None:
-            # Note: In a real environment, ensure the XML file is available or bundled.
-            # We try to load from default OpenCV path or a local path.
-            cascade_path = cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
-            self.face_cascade = cv2.CascadeClassifier(cascade_path)
-
-        if self.face_cascade.empty():
-            self.logger.warning("Haar cascade not found. Skipping facial analysis.")
-            return 0.0, []
-
-        faces_found = 0
-        blurry_faces = 0
-
-        # Optimization: Check a small subset of frames to reduce CPU load.
-        # Heuristic: we sample the first 5 frames assuming persistent issues are likely
-        # to appear early in the clip. Increase this sample size for more thorough analysis.
-        step = max(1, len(gray_frames) // 5)
-        frames_to_check = gray_frames[::step][:5]
-
-        for gray in frames_to_check:
-            faces = self.face_cascade.detectMultiScale(gray, 1.1, 4)
-
-            for x, y, w, h in faces:
-                faces_found += 1
-                face_roi = gray[y : y + h, x : x + w]
-
-                # Check for blurriness using Laplacian variance
-                # Optimization: Using cv2.meanStdDev is significantly faster (~3x)
-                # than falling back to NumPy's .var() method for variance calculation.
-                variance = (
-                    cv2.meanStdDev(cv2.Laplacian(face_roi, cv2.CV_64F))[1][0][0] ** 2
-                )
-                if variance < 100:  # Threshold for blurriness
-                    blurry_faces += 1
-
-        if faces_found > 0:
-            blur_ratio = blurry_faces / faces_found
-            if blur_ratio > 0.5:
-                score += 1.0
-                issues.append(
-                    f"Inconsistent facial clarity detected ({int(blur_ratio*100)}% blurry faces)"
-                )
-
-        return score, issues
-
-    def _check_audio_visual_sync(
-        self, video_path: str, frames: List[np.ndarray]
-    ) -> Tuple[float, List[str]]:
-        """
-        Check for audio-visual synchronization issues.
-        Note: Full A/V sync requires complex analysis (e.g. lip reading vs audio phonemes).
-        This is a lightweight check for stream presence and duration mismatch.
-        """
-        score = 0.0
-        issues = []
-
-        try:
-            cap = cv2.VideoCapture(video_path)
-            if not cap.isOpened():
-                return score, issues
-
-            # Check if we can get duration info (depends on container)
-            # OpenCV doesn't handle audio well directly without ffmpeg backend support explicitly
-            # So we focus on checking if video stream is consistent
-
-            fps = cap.get(cv2.CAP_PROP_FPS)
-            frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-
-            if fps > 0 and frame_count > 0:
-                duration = frame_count / fps
-                # If duration is very short but file size is large, might be suspicious
-                file_size = os.path.getsize(video_path)
-                if duration < 1.0 and file_size > 5 * 1024 * 1024:
-                    score += 0.5
-                    issues.append(
-                        "Video duration vs file size mismatch (potential stream embedding issue)"
-                    )
-
-            cap.release()
-        except Exception as e:
-            self.logger.warning(f"Error in A/V sync check: {e}")
-
-        return score, issues
-
-    def _check_compression_artifacts(
-        self, gray_frames: List[np.ndarray]
-    ) -> Tuple[float, List[str]]:
-        """
-        Check for double compression artifacts or unusual frequency patterns.
-
-        Args:
-            gray_frames: List of grayscale frames (numpy arrays)
-
-        """
-        score = 0.0
-        issues = []
-
-        high_freq_noise_count = 0
-
-        # Optimization: Check a subset of frames to reduce CPU load
-        # Checking 5 frames is statistically sufficient to detect persistent artifacts
-        # while reducing FFT computations by up to 75%
-        frames_to_check = gray_frames[:5]
-
-        for gray in frames_to_check:
-            # Optimization: Use OpenCV DFT instead of Numpy FFT
-            # cv2.dft is typically 2-3x faster than np.fft.fft2
-            dft = cv2.dft(np.float32(gray), flags=cv2.DFT_COMPLEX_OUTPUT)
-
-            # Optimization: Avoid fftshift by masking corners (low frequencies) directly
-            # This saves ~16MB allocation per frame (1080p) and avoids array copy
-            magnitude = cv2.magnitude(dft[:, :, 0], dft[:, :, 1])
-            magnitude_spectrum = 20 * np.log(magnitude + 1)
-
-            # Simple heuristic: Check for unusual spikes in high frequencies
-            # often seen in GAN-generated images or poor compression re-encoding
-            h, w = gray.shape
-            # Mask out low frequencies (which are at the corners in unshifted spectrum)
-            mask_size = min(h, w) // 8
-
-            magnitude_spectrum[:mask_size, :mask_size] = 0
-            magnitude_spectrum[:mask_size, -mask_size:] = 0
-            magnitude_spectrum[-mask_size:, :mask_size] = 0
-            magnitude_spectrum[-mask_size:, -mask_size:] = 0
-
-            # Optimization: Use cv2.mean instead of np.mean
-            # cv2.mean is ~2x faster than np.mean for these arrays and avoids internal numpy overhead
-            if cv2.mean(magnitude_spectrum)[0] > self.HIGH_FREQ_NOISE_THRESHOLD:
-                high_freq_noise_count += 1
-
-        if len(frames_to_check) > 0 and (
-            high_freq_noise_count / len(frames_to_check) > 0.6
-        ):
-            score += 1.0
-            issues.append("Unusual high-frequency noise patterns detected")
-
-        return score, issues
-
-    def _run_deepfake_model(
-        self, frames: List[np.ndarray], gray_frames: List[np.ndarray], content_type: str
-    ) -> float:
-        """
-        Run deepfake detection model (Simulated).
-
-        In a full implementation, this would pass frames to a loaded Torch/TensorFlow model.
-        Here we simulate a model score based on frame properties to mimic the interface.
-        """
-        if not frames:
-            return 0.0
-
-        # Simulation of a scoring model:
-        # Generate a score that can actually span the 0.0 - 1.0 range based on image statistics.
-        # High variance + low brightness might suggest tampering in some contexts, or high saturation.
-        # This is a heuristic proxy.
-
-        avg_scores = []
-        for frame, gray in zip(frames, gray_frames, strict=False):
-            # Calculate standard deviation of color channels (saturation variance)
-            # Optimization: Use cv2.meanStdDev instead of np.std(frame.astype(float))
-            # This avoids creating a large float copy (saving ~48MB per 1080p frame)
-            # and is ~28x faster in benchmarks.
-            mean, std = cv2.meanStdDev(frame)
-            # Optimization: Use float(std.sum()) / std.size instead of np.mean(std)
-            # This avoids the ~10x slower np.mean dispatch overhead for small arrays.
-            std_dev = float(std.sum()) / std.size
-
-            # Calculate edge density using Canny
-            # Optimization: Use cv2.countNonZero instead of np.sum(edges) / edges.size
-            # This is ~12x faster as it operates on the sparse edge map.
-            # Optimization: Use pre-computed grayscale frame
-            edges = cv2.Canny(gray, 100, 200)
-            edge_count = cv2.countNonZero(edges)
-            edge_density = (edge_count * 255.0) / edges.size
-
-            # Synthetic score combination
-            # Normalize to 0-1 loosely
-            score = (std_dev / 100.0) * 0.5 + (edge_density * 5)
-            avg_scores.append(min(score, 1.0))
-
-        # Optimization: sum/len on native Python lists is ~6x faster than np.mean
-        final_score = sum(avg_scores) / len(avg_scores) if avg_scores else 0.0
-
-        # Clip to 0.0 - 1.0
-        return min(max(final_score, 0.0), 1.0)
 
     def _calculate_risk_level(self, score: float) -> str:
         """Calculate risk level based on media threat score."""
@@ -1509,6 +524,7 @@ class MediaAuthenticityAnalyzer:
             self.MEDIA_RISK_LOW_THRESHOLD,
             self.MEDIA_RISK_HIGH_THRESHOLD,
         )
+
 
     def shutdown(self):
         """Shutdown the thread pool executor."""

--- a/src/modules/media_analyzer.py
+++ b/src/modules/media_analyzer.py
@@ -21,6 +21,9 @@ from . import media_deepfake
 # tests patching src.modules.media_analyzer.cv2 continue to work.
 media_deepfake.cv2 = cv2
 
+# Re-export the frame-extraction options dataclass for backwards compatibility.
+FrameExtractionOptions = media_deepfake.FrameExtractionOptions
+
 
 @dataclass
 class MediaAnalysisResult:

--- a/src/modules/media_archive.py
+++ b/src/modules/media_archive.py
@@ -3,7 +3,7 @@
 import io
 import tarfile
 import zipfile
-from typing import Callable, List, Optional, Tuple
+from typing import List, Tuple
 
 from ..utils.sanitization import sanitize_for_logging
 from ..utils.security_validators import sanitize_filename

--- a/src/modules/media_archive.py
+++ b/src/modules/media_archive.py
@@ -1,0 +1,422 @@
+"""Archive inspection helpers for ZIP and TAR files."""
+
+import io
+import tarfile
+import zipfile
+from typing import Callable, List, Optional, Tuple
+
+from ..utils.sanitization import sanitize_for_logging
+from ..utils.security_validators import sanitize_filename
+
+def _inspect_zip_contents(
+    self, filename: str, data: bytes, depth: int = 0
+) -> Tuple[float, List[str]]:
+    """Inspect contents of zip file for dangerous files, with recursion."""
+    score = 0.0
+    warnings = []
+
+    # Max recursion depth to prevent zip bombs
+    if depth > 2:
+        return score, warnings
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            file_list = zf.namelist()
+            score, warnings = self._check_file_count(
+                filename, file_list, score, warnings
+            )
+
+            # Always cap the number of files we inspect to MAX_ZIP_FILE_COUNT to limit processing
+            files_to_check = file_list[: self.MAX_ZIP_FILE_COUNT]
+
+            for contained_file in files_to_check:
+                member_score, member_warnings = (
+                    self._inspect_zip_member_and_check_traversal(
+                        zf, contained_file, filename, depth
+                    )
+                )
+                score += member_score
+                warnings.extend(member_warnings)
+
+                if score >= 5.0:
+                    return score, warnings
+
+    except zipfile.BadZipFile as e:
+        self.logger.warning(f"Bad zip file {filename}: {e}")
+    except Exception as e:
+        self.logger.warning(f"Error inspecting zip {filename}: {e}")
+
+    return score, warnings
+
+def _check_file_count(
+    self, filename: str, file_list: List[str], score: float, warnings: List[str]
+) -> Tuple[float, List[str]]:
+    """Check if archive contains too many files."""
+    if len(file_list) > self.MAX_ZIP_FILE_COUNT:
+        score += 1.0
+        warnings.append(
+            f"Archive {filename} contains too many files ({len(file_list)})"
+        )
+    return score, warnings
+
+def _inspect_zip_member_and_check_traversal(
+    self, zf: zipfile.ZipFile, contained_file: str, filename: str, depth: int
+) -> Tuple[float, List[str]]:
+    score = 0.0
+    warnings = []
+    if self._is_path_traversal_attempt(contained_file):
+        score += 5.0
+        safe_contained_file = sanitize_for_logging(
+            sanitize_filename(contained_file)
+        )
+        warnings.append(
+            f"Zip file {filename} contains path traversal attempt: {safe_contained_file}"
+        )
+
+    member_score, member_warnings = self._inspect_archive_member(
+        filename,
+        contained_file,
+        lambda: self._handle_nested_zip_member(zf, contained_file, filename, depth),
+    )
+    score += member_score
+    warnings.extend(member_warnings)
+    return score, warnings
+
+def _inspect_archive_member(
+    self, parent_filename: str, member_name: str, nested_handler_fn
+) -> Tuple[float, List[str]]:
+    """
+    Inspect a single member of an archive.
+
+    Args:
+        parent_filename: Name of the parent archive
+        member_name: Name of the member file
+        nested_handler_fn: Function to call if member is a nested archive
+
+    Returns:
+        Tuple of (score, warnings)
+
+    """
+    score = 0.0
+    warnings = []
+
+    # SECURITY: Sanitize member name to prevent path traversal and log injection
+    safe_member_name = sanitize_for_logging(sanitize_filename(member_name))
+    member_lower = safe_member_name.lower()
+
+    # Check for dangerous extensions
+    # Optimization: O(1) loop iteration using tuple-based endswith() check
+    if member_lower.endswith(self.DANGEROUS_EXTENSIONS):
+        score += 5.0
+        warnings.append(
+            f"Archive {parent_filename} contains dangerous file: {safe_member_name}"
+        )
+        return score, warnings
+
+    # Check for nested archives
+    is_nested = self._is_nested_archive(member_lower)
+    if is_nested:
+        score += 2.0
+        warnings.append(
+            f"Archive {parent_filename} contains nested archive: {safe_member_name}"
+        )
+
+        # Recurse
+        nested_score, nested_warnings = nested_handler_fn()
+        score += nested_score
+        warnings.extend(nested_warnings)
+
+        if score >= 5.0:
+            return score, warnings
+
+    # Check for suspicious extensions
+    # Optimization: O(1) loop iteration using tuple-based endswith() check
+    if member_lower.endswith(self.SUSPICIOUS_EXTENSIONS):
+        score += 3.0
+        warnings.append(
+            f"Archive {parent_filename} contains suspicious file: {safe_member_name}"
+        )
+
+    return score, warnings
+
+def _handle_nested_zip_member(
+    self, zf: zipfile.ZipFile, member_name: str, parent_filename: str, depth: int
+) -> Tuple[float, List[str]]:
+    """Handle nested archive found inside a zip file."""
+    score = 0.0
+    warnings = []
+
+    # SECURITY: Sanitize member name for logging and recursive path building
+    safe_member_name = sanitize_for_logging(sanitize_filename(member_name))
+    member_lower = safe_member_name.lower()
+
+    # Only recurse into supported formats
+    if (
+        not (
+            member_lower.endswith(".zip")
+            or member_lower.endswith((".tar", ".tar.gz", ".tgz", ".gz"))
+        )
+        or depth >= 2
+    ):
+        return score, warnings
+
+    try:
+        # Check declared size
+        info = zf.getinfo(member_name)
+        if info.file_size >= self.MAX_NESTED_ZIP_SIZE:
+            self.logger.warning(
+                f"Skipping nested archive {safe_member_name} (declared size {info.file_size} > limit)"
+            )
+            return score, warnings
+
+        # Extract securely
+        nested_data = self._read_zip_member_securely(
+            zf, member_name, self.MAX_NESTED_ZIP_SIZE
+        )
+
+        # Recurse based on type
+        if member_lower.endswith(".zip"):
+            return self._inspect_zip_contents(
+                f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
+            )
+        else:
+            return self._inspect_tar_contents(
+                f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
+            )
+
+    except ValueError as e:
+        score += 5.0
+        warnings.append(
+            f"Zip bomb detected: {parent_filename}/{safe_member_name} ({str(e)})"
+        )
+    except Exception as e:
+        self.logger.warning(
+            f"Error inspecting nested archive {safe_member_name}: {e}"
+        )
+        score += 3.0
+        warnings.append(
+            f"Failed to inspect nested archive {safe_member_name}: {str(e)}"
+        )
+
+    return score, warnings
+
+def _inspect_tar_contents(
+    self, filename: str, data: bytes, depth: int = 0
+) -> Tuple[float, List[str]]:
+    """Inspect contents of tar file for dangerous files, with recursion."""
+    if depth > 2:
+        return 0.0, []
+
+    try:
+        return self._inspect_tar_contents_safe(filename, data)
+    except tarfile.TarError as e:
+        self.logger.warning(f"Error inspecting tar {filename}: {e}")
+    except Exception as e:
+        self.logger.warning(f"Error inspecting tar {filename}: {e}")
+
+    return 0.0, []
+
+def _inspect_tar_contents_safe(
+    self, filename: str, data: bytes
+) -> Tuple[float, List[str]]:
+    """Safely inspect tar contents with proper filtering and member processing."""
+    score = 0.0
+    warnings = []
+
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:*") as tf:
+        self._apply_tar_filter(tf)
+        members = self._get_tar_members_safely(tf)
+
+        score, warnings = self._check_file_count(
+            filename, [m.name for m in members], score, warnings
+        )
+
+        for member in members[: self.MAX_ZIP_FILE_COUNT]:
+            member_score, member_warnings = self._process_tar_member(
+                tf, member, filename
+            )
+            score += member_score
+            warnings.extend(member_warnings)
+            if score >= 5.0:
+                return score, warnings
+
+    return score, warnings
+
+def _apply_tar_filter(self, tf: tarfile.TarFile) -> None:
+    """Apply PEP-706 data filter if available to prevent extraction traversal."""
+    if hasattr(tarfile, "data_filter"):
+        tf.extraction_filter = getattr(
+            tarfile, "data_filter", (lambda member, path: member)
+        )
+
+def _get_tar_members_safely(self, tf: tarfile.TarFile) -> List[tarfile.TarInfo]:
+    """Get tar members safely with count limit."""
+    members = []
+    for m in tf:
+        members.append(m)
+        if len(members) > self.MAX_ZIP_FILE_COUNT:
+            break
+    return members
+
+def _process_tar_member(
+    self, tf: tarfile.TarFile, member: tarfile.TarInfo, filename: str
+) -> Tuple[float, List[str]]:
+    """Process a single tar member for threats."""
+    safe_member_name = sanitize_for_logging(sanitize_filename(member.name))
+    member_lower = safe_member_name.lower()
+
+    if member_lower.endswith(self.DANGEROUS_EXTENSIONS):
+        return 5.0, [
+            f"Archive {filename} contains dangerous file: {safe_member_name}"
+        ]
+
+    if self._is_path_traversal_attempt(member.name):
+        safe_member_name_traversal = sanitize_for_logging(
+            sanitize_filename(member.name)
+        )
+        return 5.0, [
+            f"Tar file {filename} contains path traversal attempt: {safe_member_name_traversal}"
+        ]
+
+    if member.issym() or member.islnk():
+        if self._is_path_traversal_attempt(member.linkname):
+            safe_linkname_traversal = sanitize_for_logging(
+                sanitize_filename(member.linkname)
+            )
+            return 5.0, [
+                f"Tar file {filename} contains link with path traversal attempt: {safe_linkname_traversal}"
+            ]
+
+    member_score, member_warnings = self._inspect_archive_member(
+        filename,
+        member.name,
+        lambda: self._handle_nested_tar_member(tf, member, filename, 0),
+    )
+    return member_score, member_warnings
+
+def _handle_nested_tar_member(
+    self,
+    tf: tarfile.TarFile,
+    member: tarfile.TarInfo,
+    parent_filename: str,
+    depth: int,
+) -> Tuple[float, List[str]]:
+    """Handle nested archive found inside a tar file."""
+    score = 0.0
+    warnings = []
+    member_name = member.name
+
+    # SECURITY: Sanitize member name for logging and recursive path building
+    safe_member_name = sanitize_for_logging(sanitize_filename(member_name))
+    member_lower = safe_member_name.lower()
+
+    if (
+        not (
+            member_lower.endswith(".zip")
+            or member_lower.endswith((".tar", ".tar.gz", ".tgz", ".gz"))
+        )
+        or depth >= 2
+    ):
+        return score, warnings
+
+    # Skip if declared size is too large
+    if member.size >= self.MAX_NESTED_ZIP_SIZE:
+        self.logger.warning(
+            f"Skipping nested archive {safe_member_name} (declared size {member.size} > limit)"
+        )
+        return score, warnings
+
+    try:
+        f = tf.extractfile(member)
+        if f:
+            nested_data = self._read_file_securely(
+                f, member_name, self.MAX_NESTED_ZIP_SIZE
+            )
+
+            if member_lower.endswith(".zip"):
+                return self._inspect_zip_contents(
+                    f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
+                )
+            else:
+                return self._inspect_tar_contents(
+                    f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
+                )
+
+    except Exception as e:
+        self.logger.warning(
+            f"Error inspecting nested archive {safe_member_name} inside tar: {e}"
+        )
+        score += 3.0
+        warnings.append(
+            f"Failed to inspect nested archive {safe_member_name}: {str(e)}"
+        )
+
+    return score, warnings
+
+def _read_file_securely(self, f, filename: str, max_size: int) -> bytes:
+    """
+    Read a file-like object securely with a size limit.
+    """
+    content = io.BytesIO()
+    total_read = 0
+    chunk_size = 8192
+
+    while True:
+        chunk = f.read(chunk_size)
+        if not chunk:
+            break
+        total_read += len(chunk)
+        if total_read > max_size:
+            raise ValueError(
+                f"File {filename} exceeds maximum size of {max_size} bytes"
+            )
+        content.write(chunk)
+
+    return content.getvalue()
+
+def _read_zip_member_securely(
+    self, zf: zipfile.ZipFile, filename: str, max_size: int
+) -> bytes:
+    """
+    Read a zip member securely with a size limit to prevent zip bombs.
+
+    Args:
+        zf: ZipFile object
+        filename: Name of the file to read
+        max_size: Maximum allowed size in bytes
+
+    Returns:
+        Decompressed bytes
+
+    Raises:
+        ValueError: If decompressed size exceeds max_size
+
+    """
+    content = io.BytesIO()
+    total_read = 0
+    chunk_size = 8192
+
+    # Don't use 'with' to avoid implicit close() which might trigger CRC check on partial read
+    # causing the ValueError to be masked by BadZipFile exception
+    f = zf.open(filename)
+    try:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            total_read += len(chunk)
+            if total_read > max_size:
+                raise ValueError(
+                    f"Zip member {filename} exceeds maximum size of {max_size} bytes"
+                )
+            content.write(chunk)
+    finally:
+        try:
+            f.close()
+        except zipfile.BadZipFile as e:
+            # Ignore errors on close (like CRC mismatch due to partial read)
+            self.logger.debug(
+                f"Ignored error closing zip stream for {filename}: {e}"
+            )
+
+    return content.getvalue()

--- a/src/modules/media_archive.py
+++ b/src/modules/media_archive.py
@@ -139,6 +139,23 @@ def _inspect_archive_member(
 
     return score, warnings
 
+def _is_supported_nested_archive(member_lower: str, depth: int) -> bool:
+    """Check if the nested archive is supported and within depth limit."""
+    if depth >= 2:
+        return False
+    supported_extensions = (".zip", ".tar", ".tar.gz", ".tgz", ".gz")
+    return member_lower.endswith(supported_extensions)
+
+
+def _inspect_nested_data(
+    self, member_lower: str, nested_path: str, nested_data: bytes, depth: int
+) -> Tuple[float, List[str]]:
+    """Inspect nested archive data recursively based on file type."""
+    if member_lower.endswith(".zip"):
+        return self._inspect_zip_contents(nested_path, nested_data, depth + 1)
+    return self._inspect_tar_contents(nested_path, nested_data, depth + 1)
+
+
 def _handle_nested_zip_member(
     self, zf: zipfile.ZipFile, member_name: str, parent_filename: str, depth: int
 ) -> Tuple[float, List[str]]:
@@ -151,13 +168,7 @@ def _handle_nested_zip_member(
     member_lower = safe_member_name.lower()
 
     # Only recurse into supported formats
-    if (
-        not (
-            member_lower.endswith(".zip")
-            or member_lower.endswith((".tar", ".tar.gz", ".tgz", ".gz"))
-        )
-        or depth >= 2
-    ):
+    if not _is_supported_nested_archive(member_lower, depth):
         return score, warnings
 
     try:
@@ -175,14 +186,10 @@ def _handle_nested_zip_member(
         )
 
         # Recurse based on type
-        if member_lower.endswith(".zip"):
-            return self._inspect_zip_contents(
-                f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
-            )
-        else:
-            return self._inspect_tar_contents(
-                f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
-            )
+        nested_path = f"{parent_filename}/{safe_member_name}"
+        return _inspect_nested_data(
+            self, member_lower, nested_path, nested_data, depth
+        )
 
     except ValueError as e:
         score += 5.0
@@ -310,13 +317,7 @@ def _handle_nested_tar_member(
     safe_member_name = sanitize_for_logging(sanitize_filename(member_name))
     member_lower = safe_member_name.lower()
 
-    if (
-        not (
-            member_lower.endswith(".zip")
-            or member_lower.endswith((".tar", ".tar.gz", ".tgz", ".gz"))
-        )
-        or depth >= 2
-    ):
+    if not _is_supported_nested_archive(member_lower, depth):
         return score, warnings
 
     # Skip if declared size is too large
@@ -333,14 +334,10 @@ def _handle_nested_tar_member(
                 f, member_name, self.MAX_NESTED_ZIP_SIZE
             )
 
-            if member_lower.endswith(".zip"):
-                return self._inspect_zip_contents(
-                    f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
-                )
-            else:
-                return self._inspect_tar_contents(
-                    f"{parent_filename}/{safe_member_name}", nested_data, depth + 1
-                )
+            nested_path = f"{parent_filename}/{safe_member_name}"
+            return _inspect_nested_data(
+                self, member_lower, nested_path, nested_data, depth
+            )
 
     except Exception as e:
         self.logger.warning(

--- a/src/modules/media_deepfake.py
+++ b/src/modules/media_deepfake.py
@@ -122,7 +122,7 @@ def _extract_frames_sampled(
 def _advance_to_frame(self, cap, current_frame: int, target_frame: int) -> int:
     """Advance the video capture to the target frame using a hybrid approach."""
     try:
-    
+
         cap_prop_pos_frames = cv2.CAP_PROP_POS_FRAMES
     except ImportError:
         cap_prop_pos_frames = (

--- a/src/modules/media_deepfake.py
+++ b/src/modules/media_deepfake.py
@@ -1,5 +1,6 @@
 """Deepfake and media frame analysis helpers."""
 
+import os
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
@@ -122,9 +123,8 @@ def _extract_frames_sampled(
 def _advance_to_frame(self, cap, current_frame: int, target_frame: int) -> int:
     """Advance the video capture to the target frame using a hybrid approach."""
     try:
-
         cap_prop_pos_frames = cv2.CAP_PROP_POS_FRAMES
-    except ImportError:
+    except (ImportError, AttributeError):
         cap_prop_pos_frames = (
             1  # Fallback to the known integer value for CAP_PROP_POS_FRAMES
         )

--- a/src/modules/media_deepfake.py
+++ b/src/modules/media_deepfake.py
@@ -1,0 +1,416 @@
+"""Deepfake and media frame analysis helpers."""
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+# Injected by MediaAuthenticityAnalyzer at import time to preserve
+# test patches on src.modules.media_analyzer.cv2.
+cv2 = None
+
+@dataclass
+class FrameExtractionOptions:
+    """Options for frame extraction."""
+
+    max_frames: int = 10
+    max_dim: int = 1920
+    step: int = 1
+    total_frames: int = 0
+
+def _extract_frames_from_video(
+    self, video_path: str, max_frames: int = 10, max_dim: int = 1920
+) -> List[np.ndarray]:
+    """
+    Extract a sample of frames from the video.
+
+    Frames are sampled up to ``max_frames`` times, distributed across the video
+    when the total frame count is known, or sequentially from the start if it is not.
+
+    Each extracted frame is optionally resized via ``_resize_frame_if_needed`` so
+    that its longest side does not exceed ``max_dim`` pixels, while preserving
+    aspect ratio. Frames smaller than ``max_dim`` are left at their original size.
+
+    Args:
+        video_path: Path to the video file to sample.
+        max_frames: Maximum number of frames to extract from the video.
+        max_dim: Maximum allowed dimension (in pixels) for the width or height
+            of each returned frame. The frame is downscaled if necessary so its
+            longest side is at most this value, preserving aspect ratio.
+
+    """
+    frames = []
+    try:
+        cap = cv2.VideoCapture(video_path)
+        if not cap.isOpened():
+            return frames
+
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+
+        if total_frames <= 0:
+            # Fallback if frame count is unknown
+            frames = self._extract_frames_sequential(cap, max_frames, max_dim)
+        else:
+            # Sample evenly distributed frames
+            step = max(1, total_frames // max_frames)
+
+            # Optimization: For step=1 (sequential reading), avoid expensive seek operations
+            if step == 1:
+                count = 0
+                while count < max_frames:
+                    success, frame = cap.read()
+                    if not success:
+                        break
+                    if frame is not None:
+                        frames.append(self._resize_frame_if_needed(frame, max_dim))
+                    count += 1
+            else:
+                options = FrameExtractionOptions(
+                    max_frames=max_frames,
+                    max_dim=max_dim,
+                    step=step,
+                    total_frames=total_frames,
+                )
+                frames = self._extract_frames_sampled(cap, options)
+
+        cap.release()
+    except Exception as e:
+        self.logger.error(f"Error extracting frames: {e}")
+
+    return frames
+
+def _extract_frames_sequential(
+    self, cap, max_frames: int, max_dim: int
+) -> List[np.ndarray]:
+    """Extract frames sequentially without seeking."""
+    frames = []
+    count = 0
+    while count < max_frames:
+        success, frame = cap.read()
+        if not success:
+            break
+        if frame is not None:
+            frames.append(self._resize_frame_if_needed(frame, max_dim))
+        count += 1
+    return frames
+
+def _extract_frames_sampled(
+    self, cap, options: FrameExtractionOptions
+) -> List[np.ndarray]:
+    """Extract frames using a hybrid approach of seeking and grabbing for sampling."""
+    frames = []
+    current_frame = 0
+
+    for target_frame in range(0, options.total_frames, options.step):
+        if len(frames) >= options.max_frames:
+            break
+
+        current_frame = self._advance_to_frame(cap, current_frame, target_frame)
+
+        if current_frame != target_frame:
+            break
+
+        success, frame = cap.read()
+        if success and frame is not None:
+            frames.append(self._resize_frame_if_needed(frame, options.max_dim))
+            current_frame += 1
+        else:
+            break
+
+    return frames
+
+def _advance_to_frame(self, cap, current_frame: int, target_frame: int) -> int:
+    """Advance the video capture to the target frame using a hybrid approach."""
+    try:
+    
+        cap_prop_pos_frames = cv2.CAP_PROP_POS_FRAMES
+    except ImportError:
+        cap_prop_pos_frames = (
+            1  # Fallback to the known integer value for CAP_PROP_POS_FRAMES
+        )
+
+    seek_threshold = 30
+    jump = target_frame - current_frame
+
+    if jump > seek_threshold:
+        cap.set(cap_prop_pos_frames, target_frame)
+        current_frame = target_frame
+
+    while current_frame < target_frame:
+        if not cap.grab():
+            break
+        current_frame += 1
+
+    return current_frame
+
+def _resize_frame_if_needed(
+    self, frame: np.ndarray, max_dim: int = 1920
+) -> np.ndarray:
+    """Resize frame if it exceeds maximum dimension while maintaining aspect ratio."""
+    try:
+        h, w = frame.shape[:2]
+
+        # Defensive check: guard against malformed/empty frames with non-positive dimensions.
+        # OpenCV's resize requires strictly positive width/height; if we get bad input here,
+        # we log and return the frame unchanged rather than raising and bypassing DoS controls.
+        if h <= 0 or w <= 0:
+            self.logger.warning(
+                f"Received frame with non-positive dimensions (h={h}, w={w}); skipping resize."
+            )
+            return frame
+
+        if max(h, w) <= max_dim:
+            return frame
+
+        scale = max_dim / max(h, w)
+        # Clamp new dimensions to at least 1 pixel to avoid int() rounding to 0,
+        # which would cause cv2.resize to raise and circumvent the downscaling.
+        new_w = max(1, int(w * scale))
+        new_h = max(1, int(h * scale))
+        return cv2.resize(frame, (new_w, new_h), interpolation=cv2.INTER_AREA)
+    except Exception as e:
+        self.logger.warning(f"Error resizing frame: {e}")
+        return frame
+
+def _analyze_facial_inconsistencies(
+    self, gray_frames: List[np.ndarray]
+) -> Tuple[float, List[str]]:
+    """
+    Analyze frames for facial inconsistencies.
+    Uses OpenCV's Haar cascades for face detection and analyzes face regions.
+
+    Args:
+        gray_frames: List of grayscale frames (numpy arrays)
+
+    """
+    score = 0.0
+    issues = []
+
+    # Load Haar cascade for face detection (lazy loading with caching)
+    if self.face_cascade is None:
+        # Note: In a real environment, ensure the XML file is available or bundled.
+        # We try to load from default OpenCV path or a local path.
+        cascade_path = cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
+        self.face_cascade = cv2.CascadeClassifier(cascade_path)
+
+    if self.face_cascade.empty():
+        self.logger.warning("Haar cascade not found. Skipping facial analysis.")
+        return 0.0, []
+
+    faces_found = 0
+    blurry_faces = 0
+
+    # Optimization: Check a small subset of frames to reduce CPU load.
+    # Heuristic: we sample the first 5 frames assuming persistent issues are likely
+    # to appear early in the clip. Increase this sample size for more thorough analysis.
+    step = max(1, len(gray_frames) // 5)
+    frames_to_check = gray_frames[::step][:5]
+
+    for gray in frames_to_check:
+        faces = self.face_cascade.detectMultiScale(gray, 1.1, 4)
+
+        for x, y, w, h in faces:
+            faces_found += 1
+            face_roi = gray[y : y + h, x : x + w]
+
+            # Check for blurriness using Laplacian variance
+            # Optimization: Using cv2.meanStdDev is significantly faster (~3x)
+            # than falling back to NumPy's .var() method for variance calculation.
+            variance = (
+                cv2.meanStdDev(cv2.Laplacian(face_roi, cv2.CV_64F))[1][0][0] ** 2
+            )
+            if variance < 100:  # Threshold for blurriness
+                blurry_faces += 1
+
+    if faces_found > 0:
+        blur_ratio = blurry_faces / faces_found
+        if blur_ratio > 0.5:
+            score += 1.0
+            issues.append(
+                f"Inconsistent facial clarity detected ({int(blur_ratio*100)}% blurry faces)"
+            )
+
+    return score, issues
+
+def _check_audio_visual_sync(
+    self, video_path: str, frames: List[np.ndarray]
+) -> Tuple[float, List[str]]:
+    """
+    Check for audio-visual synchronization issues.
+    Note: Full A/V sync requires complex analysis (e.g. lip reading vs audio phonemes).
+    This is a lightweight check for stream presence and duration mismatch.
+    """
+    score = 0.0
+    issues = []
+
+    try:
+        cap = cv2.VideoCapture(video_path)
+        if not cap.isOpened():
+            return score, issues
+
+        # Check if we can get duration info (depends on container)
+        # OpenCV doesn't handle audio well directly without ffmpeg backend support explicitly
+        # So we focus on checking if video stream is consistent
+
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+
+        if fps > 0 and frame_count > 0:
+            duration = frame_count / fps
+            # If duration is very short but file size is large, might be suspicious
+            file_size = os.path.getsize(video_path)
+            if duration < 1.0 and file_size > 5 * 1024 * 1024:
+                score += 0.5
+                issues.append(
+                    "Video duration vs file size mismatch (potential stream embedding issue)"
+                )
+
+        cap.release()
+    except Exception as e:
+        self.logger.warning(f"Error in A/V sync check: {e}")
+
+    return score, issues
+
+def _check_compression_artifacts(
+    self, gray_frames: List[np.ndarray]
+) -> Tuple[float, List[str]]:
+    """
+    Check for double compression artifacts or unusual frequency patterns.
+
+    Args:
+        gray_frames: List of grayscale frames (numpy arrays)
+
+    """
+    score = 0.0
+    issues = []
+
+    high_freq_noise_count = 0
+
+    # Optimization: Check a subset of frames to reduce CPU load
+    # Checking 5 frames is statistically sufficient to detect persistent artifacts
+    # while reducing FFT computations by up to 75%
+    frames_to_check = gray_frames[:5]
+
+    for gray in frames_to_check:
+        # Optimization: Use OpenCV DFT instead of Numpy FFT
+        # cv2.dft is typically 2-3x faster than np.fft.fft2
+        dft = cv2.dft(np.float32(gray), flags=cv2.DFT_COMPLEX_OUTPUT)
+
+        # Optimization: Avoid fftshift by masking corners (low frequencies) directly
+        # This saves ~16MB allocation per frame (1080p) and avoids array copy
+        magnitude = cv2.magnitude(dft[:, :, 0], dft[:, :, 1])
+        magnitude_spectrum = 20 * np.log(magnitude + 1)
+
+        # Simple heuristic: Check for unusual spikes in high frequencies
+        # often seen in GAN-generated images or poor compression re-encoding
+        h, w = gray.shape
+        # Mask out low frequencies (which are at the corners in unshifted spectrum)
+        mask_size = min(h, w) // 8
+
+        magnitude_spectrum[:mask_size, :mask_size] = 0
+        magnitude_spectrum[:mask_size, -mask_size:] = 0
+        magnitude_spectrum[-mask_size:, :mask_size] = 0
+        magnitude_spectrum[-mask_size:, -mask_size:] = 0
+
+        # Optimization: Use cv2.mean instead of np.mean
+        # cv2.mean is ~2x faster than np.mean for these arrays and avoids internal numpy overhead
+        if cv2.mean(magnitude_spectrum)[0] > self.HIGH_FREQ_NOISE_THRESHOLD:
+            high_freq_noise_count += 1
+
+    if len(frames_to_check) > 0 and (
+        high_freq_noise_count / len(frames_to_check) > 0.6
+    ):
+        score += 1.0
+        issues.append("Unusual high-frequency noise patterns detected")
+
+    return score, issues
+
+def _run_deepfake_model(
+    self, frames: List[np.ndarray], gray_frames: List[np.ndarray], content_type: str
+) -> float:
+    """
+    Run deepfake detection model (Simulated).
+
+    In a full implementation, this would pass frames to a loaded Torch/TensorFlow model.
+    Here we simulate a model score based on frame properties to mimic the interface.
+    """
+    if not frames:
+        return 0.0
+
+    # Simulation of a scoring model:
+    # Generate a score that can actually span the 0.0 - 1.0 range based on image statistics.
+    # High variance + low brightness might suggest tampering in some contexts, or high saturation.
+    # This is a heuristic proxy.
+
+    avg_scores = []
+    for frame, gray in zip(frames, gray_frames, strict=False):
+        # Calculate standard deviation of color channels (saturation variance)
+        # Optimization: Use cv2.meanStdDev instead of np.std(frame.astype(float))
+        # This avoids creating a large float copy (saving ~48MB per 1080p frame)
+        # and is ~28x faster in benchmarks.
+        mean, std = cv2.meanStdDev(frame)
+        # Optimization: Use float(std.sum()) / std.size instead of np.mean(std)
+        # This avoids the ~10x slower np.mean dispatch overhead for small arrays.
+        std_dev = float(std.sum()) / std.size
+
+        # Calculate edge density using Canny
+        # Optimization: Use cv2.countNonZero instead of np.sum(edges) / edges.size
+        # This is ~12x faster as it operates on the sparse edge map.
+        # Optimization: Use pre-computed grayscale frame
+        edges = cv2.Canny(gray, 100, 200)
+        edge_count = cv2.countNonZero(edges)
+        edge_density = (edge_count * 255.0) / edges.size
+
+        # Synthetic score combination
+        # Normalize to 0-1 loosely
+        score = (std_dev / 100.0) * 0.5 + (edge_density * 5)
+        avg_scores.append(min(score, 1.0))
+
+    # Optimization: sum/len on native Python lists is ~6x faster than np.mean
+    final_score = sum(avg_scores) / len(avg_scores) if avg_scores else 0.0
+
+    # Clip to 0.0 - 1.0
+    return min(max(final_score, 0.0), 1.0)
+
+def _analyze_video_frames(
+    self, filename: str, temp_file_path: str, frames: list, content_type: str
+) -> Tuple[float, List[str]]:
+    """
+    Analyze extracted video frames for deepfake indicators.
+    """
+    score = 0.0
+    indicators = []
+
+    # Optimization: Convert frames to grayscale once to avoid repeated conversions
+    # This saves CPU time in subsequent analysis steps
+    gray_frames = [cv2.cvtColor(f, cv2.COLOR_BGR2GRAY) for f in frames]
+
+    # 2. Analyze for facial inconsistencies
+    facial_score, facial_issues = self._analyze_facial_inconsistencies(gray_frames)
+    if facial_score > 0:
+        score += facial_score
+        indicators.extend([f"{filename}: {issue}" for issue in facial_issues])
+
+    # 3. Check audio-visual synchronization
+    sync_score, sync_issues = self._check_audio_visual_sync(temp_file_path, frames)
+    if sync_score > 0:
+        score += sync_score
+        indicators.extend([f"{filename}: {issue}" for issue in sync_issues])
+
+    # 4. Look for compression artifacts typical of deepfakes
+    compression_score, compression_issues = self._check_compression_artifacts(
+        gray_frames
+    )
+    if compression_score > 0:
+        score += compression_score
+        indicators.extend([f"{filename}: {issue}" for issue in compression_issues])
+
+    # 5. Use specialized deepfake detection models (Simulated)
+    model_score = self._run_deepfake_model(frames, gray_frames, content_type)
+    if model_score > 0.7:
+        score += 3.0
+        indicators.append(
+            f"High probability of deepfake detected by model: {filename}"
+        )
+
+    return score, indicators

--- a/src/modules/media_deepfake.py
+++ b/src/modules/media_deepfake.py
@@ -2,7 +2,7 @@
 
 import os
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import numpy as np
 
@@ -57,14 +57,7 @@ def _extract_frames_from_video(
 
             # Optimization: For step=1 (sequential reading), avoid expensive seek operations
             if step == 1:
-                count = 0
-                while count < max_frames:
-                    success, frame = cap.read()
-                    if not success:
-                        break
-                    if frame is not None:
-                        frames.append(self._resize_frame_if_needed(frame, max_dim))
-                    count += 1
+                frames = self._extract_frames_sequential(cap, max_frames, max_dim)
             else:
                 options = FrameExtractionOptions(
                     max_frames=max_frames,
@@ -80,6 +73,16 @@ def _extract_frames_from_video(
 
     return frames
 
+def _read_next_frame(cap: Any) -> Tuple[bool, Optional[np.ndarray]]:
+    """Read the next frame from the video capture."""
+    return cap.read()
+
+
+def _is_video_capture_open(cap: Any) -> bool:
+    """Check if the video capture is opened successfully."""
+    return cap.isOpened()
+
+
 def _extract_frames_sequential(
     self, cap, max_frames: int, max_dim: int
 ) -> List[np.ndarray]:
@@ -87,7 +90,7 @@ def _extract_frames_sequential(
     frames = []
     count = 0
     while count < max_frames:
-        success, frame = cap.read()
+        success, frame = _read_next_frame(cap)
         if not success:
             break
         if frame is not None:
@@ -172,6 +175,25 @@ def _resize_frame_if_needed(
         self.logger.warning(f"Error resizing frame: {e}")
         return frame
 
+def _process_faces_in_frame(self, gray: np.ndarray) -> Tuple[int, int]:
+    """Detect faces and count blurry faces in a frame."""
+    faces_found = 0
+    blurry_faces = 0
+    faces = self.face_cascade.detectMultiScale(gray, 1.1, 4)
+    for x, y, w, h in faces:
+        faces_found += 1
+        face_roi = gray[y : y + h, x : x + w]
+        # Check for blurriness using Laplacian variance
+        # Optimization: Using cv2.meanStdDev is significantly faster (~3x)
+        # than falling back to NumPy's .var() method for variance calculation.
+        variance = (
+            cv2.meanStdDev(cv2.Laplacian(face_roi, cv2.CV_64F))[1][0][0] ** 2
+        )
+        if variance < 100:  # Threshold for blurriness
+            blurry_faces += 1
+    return faces_found, blurry_faces
+
+
 def _analyze_facial_inconsistencies(
     self, gray_frames: List[np.ndarray]
 ) -> Tuple[float, List[str]]:
@@ -207,20 +229,9 @@ def _analyze_facial_inconsistencies(
     frames_to_check = gray_frames[::step][:5]
 
     for gray in frames_to_check:
-        faces = self.face_cascade.detectMultiScale(gray, 1.1, 4)
-
-        for x, y, w, h in faces:
-            faces_found += 1
-            face_roi = gray[y : y + h, x : x + w]
-
-            # Check for blurriness using Laplacian variance
-            # Optimization: Using cv2.meanStdDev is significantly faster (~3x)
-            # than falling back to NumPy's .var() method for variance calculation.
-            variance = (
-                cv2.meanStdDev(cv2.Laplacian(face_roi, cv2.CV_64F))[1][0][0] ** 2
-            )
-            if variance < 100:  # Threshold for blurriness
-                blurry_faces += 1
+        found, blurry = _process_faces_in_frame(self, gray)
+        faces_found += found
+        blurry_faces += blurry
 
     if faces_found > 0:
         blur_ratio = blurry_faces / faces_found
@@ -231,6 +242,21 @@ def _analyze_facial_inconsistencies(
             )
 
     return score, issues
+
+def _check_video_metadata_sync(self, video_path: str, fps: float, frame_count: float) -> Tuple[float, List[str]]:
+    """Verify video metadata and check for duration mismatch anomalies."""
+    score = 0.0
+    issues = []
+    if fps > 0 and frame_count > 0:
+        duration = frame_count / fps
+        file_size = os.path.getsize(video_path)
+        if duration < 1.0 and file_size > 5 * 1024 * 1024:
+            score += 0.5
+            issues.append(
+                "Video duration vs file size mismatch (potential stream embedding issue)"
+            )
+    return score, issues
+
 
 def _check_audio_visual_sync(
     self, video_path: str, frames: List[np.ndarray]
@@ -255,21 +281,31 @@ def _check_audio_visual_sync(
         fps = cap.get(cv2.CAP_PROP_FPS)
         frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
 
-        if fps > 0 and frame_count > 0:
-            duration = frame_count / fps
-            # If duration is very short but file size is large, might be suspicious
-            file_size = os.path.getsize(video_path)
-            if duration < 1.0 and file_size > 5 * 1024 * 1024:
-                score += 0.5
-                issues.append(
-                    "Video duration vs file size mismatch (potential stream embedding issue)"
-                )
+        score_diff, sync_issues = _check_video_metadata_sync(self, video_path, fps, frame_count)
+        score += score_diff
+        issues.extend(sync_issues)
 
         cap.release()
     except Exception as e:
         self.logger.warning(f"Error in A/V sync check: {e}")
 
     return score, issues
+
+def _analyze_frame_high_frequency_noise(self, gray: np.ndarray) -> bool:
+    """Analyze a single frame for high-frequency noise spikes."""
+    dft = cv2.dft(np.float32(gray), flags=cv2.DFT_COMPLEX_OUTPUT)
+    magnitude = cv2.magnitude(dft[:, :, 0], dft[:, :, 1])
+    magnitude_spectrum = 20 * np.log(magnitude + 1)
+    h, w = gray.shape
+    mask_size = min(h, w) // 8
+
+    magnitude_spectrum[:mask_size, :mask_size] = 0
+    magnitude_spectrum[:mask_size, -mask_size:] = 0
+    magnitude_spectrum[-mask_size:, :mask_size] = 0
+    magnitude_spectrum[-mask_size:, -mask_size:] = 0
+
+    return cv2.mean(magnitude_spectrum)[0] > self.HIGH_FREQ_NOISE_THRESHOLD
+
 
 def _check_compression_artifacts(
     self, gray_frames: List[np.ndarray]
@@ -292,29 +328,7 @@ def _check_compression_artifacts(
     frames_to_check = gray_frames[:5]
 
     for gray in frames_to_check:
-        # Optimization: Use OpenCV DFT instead of Numpy FFT
-        # cv2.dft is typically 2-3x faster than np.fft.fft2
-        dft = cv2.dft(np.float32(gray), flags=cv2.DFT_COMPLEX_OUTPUT)
-
-        # Optimization: Avoid fftshift by masking corners (low frequencies) directly
-        # This saves ~16MB allocation per frame (1080p) and avoids array copy
-        magnitude = cv2.magnitude(dft[:, :, 0], dft[:, :, 1])
-        magnitude_spectrum = 20 * np.log(magnitude + 1)
-
-        # Simple heuristic: Check for unusual spikes in high frequencies
-        # often seen in GAN-generated images or poor compression re-encoding
-        h, w = gray.shape
-        # Mask out low frequencies (which are at the corners in unshifted spectrum)
-        mask_size = min(h, w) // 8
-
-        magnitude_spectrum[:mask_size, :mask_size] = 0
-        magnitude_spectrum[:mask_size, -mask_size:] = 0
-        magnitude_spectrum[-mask_size:, :mask_size] = 0
-        magnitude_spectrum[-mask_size:, -mask_size:] = 0
-
-        # Optimization: Use cv2.mean instead of np.mean
-        # cv2.mean is ~2x faster than np.mean for these arrays and avoids internal numpy overhead
-        if cv2.mean(magnitude_spectrum)[0] > self.HIGH_FREQ_NOISE_THRESHOLD:
+        if _analyze_frame_high_frequency_noise(self, gray):
             high_freq_noise_count += 1
 
     if len(frames_to_check) > 0 and (
@@ -324,6 +338,18 @@ def _check_compression_artifacts(
         issues.append("Unusual high-frequency noise patterns detected")
 
     return score, issues
+
+
+def _calculate_simulated_frame_score(self, frame: np.ndarray, gray: np.ndarray) -> float:
+    """Calculate simulated deepfake score for a single frame."""
+    mean, std = cv2.meanStdDev(frame)
+    std_dev = float(std.sum()) / std.size
+    edges = cv2.Canny(gray, 100, 200)
+    edge_count = cv2.countNonZero(edges)
+    edge_density = (edge_count * 255.0) / edges.size
+    score = (std_dev / 100.0) * 0.5 + (edge_density * 5)
+    return min(score, 1.0)
+
 
 def _run_deepfake_model(
     self, frames: List[np.ndarray], gray_frames: List[np.ndarray], content_type: str
@@ -337,34 +363,10 @@ def _run_deepfake_model(
     if not frames:
         return 0.0
 
-    # Simulation of a scoring model:
-    # Generate a score that can actually span the 0.0 - 1.0 range based on image statistics.
-    # High variance + low brightness might suggest tampering in some contexts, or high saturation.
-    # This is a heuristic proxy.
-
-    avg_scores = []
-    for frame, gray in zip(frames, gray_frames, strict=False):
-        # Calculate standard deviation of color channels (saturation variance)
-        # Optimization: Use cv2.meanStdDev instead of np.std(frame.astype(float))
-        # This avoids creating a large float copy (saving ~48MB per 1080p frame)
-        # and is ~28x faster in benchmarks.
-        mean, std = cv2.meanStdDev(frame)
-        # Optimization: Use float(std.sum()) / std.size instead of np.mean(std)
-        # This avoids the ~10x slower np.mean dispatch overhead for small arrays.
-        std_dev = float(std.sum()) / std.size
-
-        # Calculate edge density using Canny
-        # Optimization: Use cv2.countNonZero instead of np.sum(edges) / edges.size
-        # This is ~12x faster as it operates on the sparse edge map.
-        # Optimization: Use pre-computed grayscale frame
-        edges = cv2.Canny(gray, 100, 200)
-        edge_count = cv2.countNonZero(edges)
-        edge_density = (edge_count * 255.0) / edges.size
-
-        # Synthetic score combination
-        # Normalize to 0-1 loosely
-        score = (std_dev / 100.0) * 0.5 + (edge_density * 5)
-        avg_scores.append(min(score, 1.0))
+    avg_scores = [
+        _calculate_simulated_frame_score(self, frame, gray)
+        for frame, gray in zip(frames, gray_frames, strict=False)
+    ]
 
     # Optimization: sum/len on native Python lists is ~6x faster than np.mean
     final_score = sum(avg_scores) / len(avg_scores) if avg_scores else 0.0
@@ -385,25 +387,20 @@ def _analyze_video_frames(
     # This saves CPU time in subsequent analysis steps
     gray_frames = [cv2.cvtColor(f, cv2.COLOR_BGR2GRAY) for f in frames]
 
-    # 2. Analyze for facial inconsistencies
     facial_score, facial_issues = self._analyze_facial_inconsistencies(gray_frames)
-    if facial_score > 0:
-        score += facial_score
-        indicators.extend([f"{filename}: {issue}" for issue in facial_issues])
-
-    # 3. Check audio-visual synchronization
     sync_score, sync_issues = self._check_audio_visual_sync(temp_file_path, frames)
-    if sync_score > 0:
-        score += sync_score
-        indicators.extend([f"{filename}: {issue}" for issue in sync_issues])
-
-    # 4. Look for compression artifacts typical of deepfakes
     compression_score, compression_issues = self._check_compression_artifacts(
         gray_frames
     )
-    if compression_score > 0:
-        score += compression_score
-        indicators.extend([f"{filename}: {issue}" for issue in compression_issues])
+
+    for f_score, f_issues in [
+        (facial_score, facial_issues),
+        (sync_score, sync_issues),
+        (compression_score, compression_issues),
+    ]:
+        if f_score > 0:
+            score += f_score
+            indicators.extend([f"{filename}: {issue}" for issue in f_issues])
 
     # 5. Use specialized deepfake detection models (Simulated)
     model_score = self._run_deepfake_model(frames, gray_frames, content_type)

--- a/src/modules/media_file_type.py
+++ b/src/modules/media_file_type.py
@@ -57,6 +57,15 @@ def _check_riff_container(self, data: bytes) -> Optional[str]:
             return "webp"
     return None
 
+def _detect_magic_signature_offset_0(self, data: bytes) -> Optional[str]:
+    """Check magic signatures with offset 0."""
+    if data.startswith(self.MAGIC_PREFIXES_OFFSET_0):
+        for sig, name in self.MAGIC_SIGNATURES_OFFSET_0:
+            if data.startswith(sig):
+                return name
+    return None
+
+
 def _detect_file_type(self, data: bytes) -> Optional[str]:
     """Detect file type from magic bytes."""
     if not data or len(data) < 4:
@@ -67,10 +76,9 @@ def _detect_file_type(self, data: bytes) -> Optional[str]:
         return self._check_riff_container(data)
 
     # Optimization: Fast check for all signatures with offset 0
-    if data.startswith(self.MAGIC_PREFIXES_OFFSET_0):
-        for sig, name in self.MAGIC_SIGNATURES_OFFSET_0:
-            if data.startswith(sig):
-                return name
+    name = _detect_magic_signature_offset_0(self, data)
+    if name:
+        return name
 
     # Check signatures with non-zero offset
     if len(data) >= 8 and data[4:8] == b"ftyp":  # Common for MP4/MOV
@@ -174,32 +182,63 @@ def _validate_missing_signature(self, filename: str) -> Tuple[float, str]:
 
     return 0.0, ""
 
-def _check_size_anomaly(self, filename: str, size: int) -> Tuple[float, str]:
-    """Check for unusual file sizes."""
-    score = 0.0
-    warning = ""
-
-    # Very large attachments (potential data exfiltration)
+def _check_large_size_anomaly(self, filename: str, size: int) -> Tuple[float, str]:
+    """Check for unusually large file size anomalies."""
     if size > self.MAX_ATTACHMENT_SIZE_MB * 1024 * 1024:
-        score += 1.5
-        warning = (
-            f"Unusually large attachment: {filename} ({size / (1024*1024):.1f}MB)"
-        )
+        return 1.5, f"Unusually large attachment: {filename} ({size / (1024*1024):.1f}MB)"
+    return 0.0, ""
 
-    # Suspiciously small media files
+
+def _check_small_media_size_anomaly(self, filename: str, size: int) -> Tuple[float, str]:
+    """Check for suspiciously small media files."""
     filename_lower = filename.lower()
-    # Optimization: O(1) loop iteration using tuple-based endswith() check
     if filename_lower.endswith(self.MEDIA_EXTENSIONS):
         if size < self.MIN_MEDIA_FILE_SIZE_BYTES:
-            score += 1.0
-            warning = f"Suspiciously small media file: {filename} ({size} bytes)"
+            return 1.0, f"Suspiciously small media file: {filename} ({size} bytes)"
+    return 0.0, ""
 
-    return score, warning
+
+def _check_size_anomaly(self, filename: str, size: int) -> Tuple[float, str]:
+    """Check for unusual file sizes."""
+    large_score, large_warning = _check_large_size_anomaly(self, filename, size)
+    if large_warning:
+        return large_score, large_warning
+
+    small_score, small_warning = _check_small_media_size_anomaly(self, filename, size)
+    if small_warning:
+        return small_score, small_warning
+
+    return 0.0, ""
 
 def _is_nested_archive(self, filename_lower: str) -> bool:
     """Check if filename is a nested archive type. Assumes filename_lower is already lowercase."""
     # Optimization: O(1) loop iteration using tuple-based endswith() check
     return filename_lower.endswith(self.ARCHIVE_EXTENSIONS)
+
+def _is_zip_magic_or_extension(filename_lower: str, data: bytes) -> bool:
+    """Check if file starts with ZIP magic bytes or has .zip extension."""
+    if data and data.startswith(b"PK\x03\x04"):
+        return True
+    return filename_lower.endswith(".zip")
+
+
+def _inspect_zip_archive(self, filename: str, filename_lower: str, data: bytes, result: dict) -> None:
+    """Inspect Zip archive if applicable."""
+    if not _is_zip_magic_or_extension(filename_lower, data):
+        return
+    zip_score, zip_warnings = self._inspect_zip_contents(filename, data)
+    result["score"] += zip_score
+    result["suspicious_attachments"].extend(zip_warnings)
+
+
+def _inspect_tar_archive(self, filename: str, filename_lower: str, data: bytes, result: dict) -> None:
+    """Inspect Tar archive if applicable."""
+    if not filename_lower.endswith((".tar", ".tar.gz", ".tgz", ".gz")):
+        return
+    tar_score, tar_warnings = self._inspect_tar_contents(filename, data)
+    result["score"] += tar_score
+    result["suspicious_attachments"].extend(tar_warnings)
+
 
 def _analyze_attachment_metadata(self, attachment: dict) -> dict:
     """
@@ -243,29 +282,8 @@ def _analyze_attachment_metadata(self, attachment: dict) -> dict:
     if size_warning:
         result["size_anomalies"].append(size_warning)
 
-    # Check for dangerous contents in archives (e.g. Zip files)
     filename_lower = filename.lower()
-    is_zip = False
-    if data and data.startswith(b"PK\x03\x04"):
-        is_zip = True
-    elif filename_lower.endswith(".zip"):
-        is_zip = True
-
-    if is_zip:
-        zip_score, zip_warnings = self._inspect_zip_contents(filename, data)
-        result["score"] += zip_score
-        if zip_warnings:
-            result["suspicious_attachments"].extend(zip_warnings)
-
-    # Check for tar archives
-    is_tar = False
-    if filename_lower.endswith((".tar", ".tar.gz", ".tgz", ".gz")):
-        is_tar = True
-
-    if is_tar:
-        tar_score, tar_warnings = self._inspect_tar_contents(filename, data)
-        result["score"] += tar_score
-        if tar_warnings:
-            result["suspicious_attachments"].extend(tar_warnings)
+    _inspect_zip_archive(self, filename, filename_lower, data, result)
+    _inspect_tar_archive(self, filename, filename_lower, data, result)
 
     return result

--- a/src/modules/media_file_type.py
+++ b/src/modules/media_file_type.py
@@ -1,0 +1,271 @@
+"""Media file type and metadata analysis helpers."""
+
+from typing import List, Optional, Tuple
+
+def _is_path_traversal_attempt(self, path: str) -> bool:
+    """Check if a path string contains traversal attempts or absolute paths."""
+    if path.startswith(("/", "\\")):
+        return True
+    if ".." in path:
+        return True
+
+    # Simplifies the Windows drive check to avoid "Complex Conditional" flag
+    # We only check the first two chars if the string is long enough
+    if len(path) < 2:
+        return False
+
+    return path[0].isalpha() and path[1] == ":"
+
+def _check_file_extension(self, filename: str) -> Tuple[float, List[str]]:
+    """Check if file extension is dangerous."""
+    score = 0.0
+    warnings = []
+
+    # Sanitize filename (strip whitespace and null bytes for check)
+    # Also strip trailing dots which can bypass extension checks but still be executable on Windows
+    filename_lower = filename.lower().strip().replace("\0", "").rstrip(".")
+
+    # Check for dangerous extensions
+    # Optimization: tuple-based endswith() is ~10-15x faster than looping
+    if filename_lower.endswith(self.DANGEROUS_EXTENSIONS):
+        score += 5.0  # Very high score for dangerous files
+        warnings.append(f"Dangerous file type: {filename}")
+
+    # Check for suspicious extensions
+    # Optimization: tuple-based endswith() avoids slow Python looping overhead
+    if filename_lower.endswith(self.SUSPICIOUS_EXTENSIONS):
+        score += 3.0
+        warnings.append(f"Suspicious file extension: {filename}")
+
+    # Check for double extensions
+    parts = filename_lower.split(".")
+    if len(parts) > 2:
+        score += 1.5
+        warnings.append(f"Multiple extensions detected: {filename}")
+
+    return score, warnings
+
+def _check_riff_container(self, data: bytes) -> Optional[str]:
+    """Check for specific media types within a RIFF container."""
+    if len(data) >= 12:
+        format_type = data[8:12]
+        if format_type == b"AVI ":
+            return "avi"
+        elif format_type == b"WAVE":
+            return "wav"
+        elif format_type == b"WEBP":
+            return "webp"
+    return None
+
+def _detect_file_type(self, data: bytes) -> Optional[str]:
+    """Detect file type from magic bytes."""
+    if not data or len(data) < 4:
+        return None
+
+    # Check RIFF container (AVI, WAV, WEBP)
+    if data.startswith(b"RIFF"):
+        return self._check_riff_container(data)
+
+    # Optimization: Fast check for all signatures with offset 0
+    if data.startswith(self.MAGIC_PREFIXES_OFFSET_0):
+        for sig, name in self.MAGIC_SIGNATURES_OFFSET_0:
+            if data.startswith(sig):
+                return name
+
+    # Check signatures with non-zero offset
+    if len(data) >= 8 and data[4:8] == b"ftyp":  # Common for MP4/MOV
+        return "mp4"
+
+    return None
+
+def _check_content_type_mismatch(
+    self, filename: str, content_type: str, data: bytes
+) -> Tuple[float, str]:
+    """Check if actual file content matches declared content type."""
+    actual_type = self._detect_file_type(data)
+
+    if actual_type:
+        return self._validate_signature_match(filename, actual_type)
+    else:
+        return self._validate_missing_signature(filename)
+
+def _validate_signature_match(
+    self, filename: str, actual_type: str
+) -> Tuple[float, str]:
+    """Check if file extension matches the detected signature."""
+    filename_lower = filename.lower().strip().replace("\0", "").rstrip(".")
+
+    # Special case for executables disguised as documents
+    if actual_type == "exe" and not filename_lower.endswith(".exe"):
+        return 5.0, "Executable disguised as another file type"
+
+    # Check for general mismatches
+    expected_exts = self.EXPECTED_EXTENSIONS.get(actual_type)
+    if expected_exts and not filename_lower.endswith(expected_exts):
+        return 2.0, f"File type mismatch: {filename} (detected {actual_type})"
+
+    return 0.0, ""
+
+def _validate_missing_signature(self, filename: str) -> Tuple[float, str]:
+    """Check if missing signature violates strict extension rules."""
+    # Type not detected. Validate that if extension claims a known type, it matches.
+    # This prevents processing invalid/corrupt media files.
+    filename_lower = filename.lower().strip().replace("\0", "").rstrip(".")
+
+    # Lazily initialize strict validation configuration on the class so we don't
+    # rebuild it on every call. This keeps the mapping centralized and efficient.
+    cls = self.__class__
+
+    if not hasattr(cls, "_STRICT_VALIDATION_EXTS"):
+        # Map extensions to their expected descriptions for error messages
+        cls._STRICT_VALIDATION_EXTS = {
+            # Note: '.exe' and '.dll' are also handled earlier when a valid PE signature
+            # is detected (actual_type == 'exe'). They are included here as a fallback
+            # for cases where signature detection fails but the extension claims an executable.
+            ".exe": "executable",
+            ".dll": "executable",
+            ".zip": "archive",
+            ".pdf": "PDF",
+            ".png": "PNG image",
+            ".jpg": "JPEG image",
+            ".jpeg": "JPEG image",
+            ".gif": "GIF image",
+            ".mp4": "MP4 video",
+            ".avi": "AVI video",
+            ".mkv": "MKV video",
+            ".wav": "WAV audio",
+            # Additional strict validation for media types processed by OpenCV
+            ".mov": "QuickTime video",
+            ".wmv": "WMV video",
+            ".flv": "FLV video",
+            ".ogg": "Ogg audio/video",
+            ".flac": "FLAC audio",
+            ".m4a": "M4A audio",
+        }
+
+    if not hasattr(cls, "_CRITICAL_MEDIA_EXTS"):
+        # Treat all known media extensions (and WAV) as critical when their signatures are invalid,
+        # to prevent them from reaching deepfake/OpenCV processing. Use getattr so we degrade
+        # safely if MEDIA_EXTENSIONS is not defined on this instance.
+        media_exts = getattr(self, "MEDIA_EXTENSIONS", [])
+        cls._CRITICAL_MEDIA_EXTS = {
+            ext
+            for ext in cls._STRICT_VALIDATION_EXTS.keys()
+            if ext in media_exts or ext == ".wav"
+        }
+
+    strict_validation_exts = cls._STRICT_VALIDATION_EXTS
+    critical_media_exts = cls._CRITICAL_MEDIA_EXTS
+    for ext, type_desc in strict_validation_exts.items():
+        if filename_lower.endswith(ext):
+            # Return 5.0 (Critical) for media files to ensure they don't reach deepfake analysis
+            # which could trigger vulnerabilities in processing libraries (e.g., OpenCV)
+            # Note: 5.0 is intentionally chosen to fail the `threat_score < 5.0` gate (see earlier check),
+            # so that invalid media never reaches the deepfake/OpenCV processing pipeline.
+            if ext in critical_media_exts:
+                return (
+                    5.0,
+                    f"Invalid file signature for {ext}: expected {type_desc} signature but none found",
+                )
+            return (
+                2.0,
+                f"Invalid file signature for {ext}: expected {type_desc} signature but none found",
+            )
+
+    return 0.0, ""
+
+def _check_size_anomaly(self, filename: str, size: int) -> Tuple[float, str]:
+    """Check for unusual file sizes."""
+    score = 0.0
+    warning = ""
+
+    # Very large attachments (potential data exfiltration)
+    if size > self.MAX_ATTACHMENT_SIZE_MB * 1024 * 1024:
+        score += 1.5
+        warning = (
+            f"Unusually large attachment: {filename} ({size / (1024*1024):.1f}MB)"
+        )
+
+    # Suspiciously small media files
+    filename_lower = filename.lower()
+    # Optimization: O(1) loop iteration using tuple-based endswith() check
+    if filename_lower.endswith(self.MEDIA_EXTENSIONS):
+        if size < self.MIN_MEDIA_FILE_SIZE_BYTES:
+            score += 1.0
+            warning = f"Suspiciously small media file: {filename} ({size} bytes)"
+
+    return score, warning
+
+def _is_nested_archive(self, filename_lower: str) -> bool:
+    """Check if filename is a nested archive type. Assumes filename_lower is already lowercase."""
+    # Optimization: O(1) loop iteration using tuple-based endswith() check
+    return filename_lower.endswith(self.ARCHIVE_EXTENSIONS)
+
+def _analyze_attachment_metadata(self, attachment: dict) -> dict:
+    """
+    Analyze attachment metadata and basic properties.
+    Returns a dict with scores and warnings.
+    """
+    filename = attachment.get("filename", "")
+    content_type = attachment.get("content_type", "")
+    size = attachment.get("size", 0)
+    data = attachment.get("data", b"")
+    truncated = attachment.get("truncated", False)
+
+    result = {
+        "score": 0.0,
+        "size_anomalies": [],
+        "file_type_warnings": [],
+        "suspicious_attachments": [],
+    }
+
+    if truncated:
+        result["size_anomalies"].append(
+            f"Attachment truncated for scanning: {filename}"
+        )
+
+    # Check file extension
+    ext_score, ext_warnings = self._check_file_extension(filename)
+    result["score"] += ext_score
+    result["file_type_warnings"].extend(ext_warnings)
+
+    # Check content type mismatch
+    mismatch_score, mismatch_warnings = self._check_content_type_mismatch(
+        filename, content_type, data
+    )
+    result["score"] += mismatch_score
+    if mismatch_warnings:
+        result["suspicious_attachments"].append(f"{filename}: {mismatch_warnings}")
+
+    # Check file size anomalies
+    size_score, size_warning = self._check_size_anomaly(filename, size)
+    result["score"] += size_score
+    if size_warning:
+        result["size_anomalies"].append(size_warning)
+
+    # Check for dangerous contents in archives (e.g. Zip files)
+    filename_lower = filename.lower()
+    is_zip = False
+    if data and data.startswith(b"PK\x03\x04"):
+        is_zip = True
+    elif filename_lower.endswith(".zip"):
+        is_zip = True
+
+    if is_zip:
+        zip_score, zip_warnings = self._inspect_zip_contents(filename, data)
+        result["score"] += zip_score
+        if zip_warnings:
+            result["suspicious_attachments"].extend(zip_warnings)
+
+    # Check for tar archives
+    is_tar = False
+    if filename_lower.endswith((".tar", ".tar.gz", ".tgz", ".gz")):
+        is_tar = True
+
+    if is_tar:
+        tar_score, tar_warnings = self._inspect_tar_contents(filename, data)
+        result["score"] += tar_score
+        if tar_warnings:
+            result["suspicious_attachments"].extend(tar_warnings)
+
+    return result

--- a/tests/test_alert_system_generate_report.py
+++ b/tests/test_alert_system_generate_report.py
@@ -56,7 +56,7 @@ class TestGenerateThreatReport(unittest.TestCase):
             risk_level="low",
         )
 
-    @patch("src.modules.alert_system.AlertSystem._generate_recommendations")
+    @patch("src.modules.alert_report.generate_recommendations")
     def test_generate_threat_report_low_risk(self, mock_generate_recommendations):
         mock_generate_recommendations.return_value = ["mocked recommendation"]
 


### PR DESCRIPTION
<!--
  Thank you for contributing to the Email Security Pipeline!
  Please fill in as much of the template as possible. Reviewers use this
  information to understand the purpose and safety of your changes.
-->

## Summary

Refactors the `media_analyzer.py` and `alert_system.py` god modules into focused, cohesive submodules while preserving all public imports and test-patch points. No intentional behavior change.

Relates to Linear ABHI-1618.

---

## Type of Change

<!-- Check all that apply. -->

- [ ] `feat` – new feature
- [ ] `fix` – bug fix
- [ ] `docs` – documentation only
- [ ] `chore` – maintenance (deps, config, CI)
- [ ] `test` – test additions or improvements
- [ ] `perf` – performance improvement
- [x] `refactor` – code restructuring, no behaviour change

---

## What Changed and Why

- **Alert modules (`alert_recommendations.py`, `alert_report.py`)** – extracted in Phase 1. Recommendation logic and threat-report/dict builders are now standalone, breaking the `generate_threat_report` ↔ `AlertSystem` cycle. `AlertSystem` re-exports the public names.
- **Alert console/channels (`alert_console.py`, `alert_channels.py`)** – extracted in Phase 2. All console rendering, payload construction, redaction, and sanitization helpers moved out, while `requests.post` calls, `is_safe_webhook_url` SSRF checks, and public redaction helpers remain on the facade.
- **Media modules (`media_file_type.py`, `media_archive.py`, `media_deepfake.py`)** – extracted in Phases 4 & 5.
  - File-type/metadata helpers live in `media_file_type.py`.
  - ZIP/TAR inspection and secure-read helpers live in `media_archive.py`.
  - Frame extraction, facial/sync/compression analysis, and simulated deepfake model logic live in `media_deepfake.py`.
  - `cv2` is injected from the facade into `media_deepfake` so existing test patches on `src.modules.media_analyzer.cv2` continue to work.
- **Facades (`alert_system.py`, `media_analyzer.py`)** kept as thin public APIs. All class constants, `MediaAnalysisResult`, `FrameExtractionOptions`, and worker attributes remain in place.
- **`alert_dispatcher` extraction deferred** per plan, because the worker/queue state is heavily inspected by tests.
- **Stale remote-branch cleanup remains out of scope** for this PR.

---

## How Was This Tested?

- `python3 -m pytest -q` passes locally: **726 passed, 27 subtests passed**.
- `python3 -m pre_commit run --all-files` passes locally.
- Security-sensitive paths were regression-tested by the existing suite: archive zip-bomb/path-traversal/tar symlink guards, webhook SSRF blocking, Slack/Discord token and URL redaction, and deepfake temp-file cleanup.

---

## Security Implications

- [x] No secrets or credentials are introduced or exposed by this change
- Security notes: This change moves code but preserves all existing security gates. `requests.post` and `is_safe_webhook_url` are still called from `alert_system.py`; `cv2`/`tempfile`/`os` usage remains facade-local where test patches depend on it; archive recursion, size limits, and tar filters are unchanged.

---

## Checklist

- [x] Branch follows naming convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages are clear and descriptive
- [x] New or modified code includes relevant tests
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Documentation updated if behaviour changed (README, docstrings, etc.)
- [x] No secrets, credentials, or `.env` files are included in this PR

Link to Devin session: https://app.devin.ai/sessions/1f8d1c220ac949ebb94ad11b82794187
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->