### PR TITLE
perf(spam): auth/header fast-path helpers (salvages #1399)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -66,3 +66,7 @@ joined strings provides significant performance wins by avoiding iteration
 entirely for common clean cases. **Action:** Replace `any()` generators with
 short-circuiting fast paths on joined strings, and use explicit loops to avoid
 generator overhead when iteration is necessary in hot paths.
+
+## 2026-08-01 — SpamAnalyzer auth/header fast-path (salvage #1399)
+
+Salvaged spam_analyzer.py Bolt fast-path helpers only. Rejected alert_*/media_* module collapse from the original PR.

--- a/src/modules/spam_analyzer.py
+++ b/src/modules/spam_analyzer.py
@@ -566,18 +566,19 @@ class SpamAnalyzer:
 
         # ⚡ BOLT: Optimization - Extract required headers to static tuple to avoid loop reallocation
         required_headers = ("from", "to", "date", "message-id")
-        # Optimization: Pre-calculate display strings to avoid runtime string operations
+
+        # ⚡ BOLT: Optimization - Fast path check using dict subset
+        # Significant speedup for the common case where all required headers are present
+        if len(headers) >= 4 and {"from", "to", "date", "message-id"}.issubset(headers):
+            return 0.0, []
+
+        # Display original case for readability (only needed on the slow path)
         display_headers = {
             "from": "From",
             "to": "To",
             "date": "Date",
             "message-id": "Message-ID",
         }
-
-        # ⚡ BOLT: Optimization - Fast path check using dict subset
-        # Significant speedup for the common case where all required headers are present
-        if len(headers) >= 4 and {"from", "to", "date", "message-id"}.issubset(headers):
-            return 0.0, []
 
         for header in required_headers:
             if header not in headers:

--- a/src/modules/spam_analyzer.py
+++ b/src/modules/spam_analyzer.py
@@ -497,21 +497,9 @@ class SpamAnalyzer:
         # of clean emails that have passing authentication results.
         joined_results = " ".join(auth_results).lower()
 
-        # Extracted check loop into a private method to reduce cyclomatic complexity
-
-        # Fast path check for failure keywords using getattr trick
-        # to satisfy CodeScene's Complex Conditional checks without nesting.
-        auth_props = ("fail", "permerror", "neutral")
-        has_fail_indicator = False
-        for prop in auth_props:
-            if prop in joined_results:
-                has_fail_indicator = True
-                break
-
-        if has_fail_indicator:
-            dkim_auth_fail, spf_auth_fail = self._evaluate_auth_results_loop(
-                auth_results
-            )
+        # ⚡ BOLT: Optimization - Extract fast path parsing check into a private method
+        # to satisfy CodeScene's Complex Conditional checks and remove inlined nested ifs.
+        dkim_auth_fail, spf_auth_fail = self._evaluate_auth_results_fast(joined_results)
 
         if dkim_auth_fail:
             score += 2.5
@@ -524,23 +512,36 @@ class SpamAnalyzer:
 
         return score, issues
 
-    def _evaluate_auth_results_loop(self, auth_results: List[str]) -> Tuple[bool, bool]:
+
+    def _evaluate_auth_results_fast(self, joined_results: str) -> Tuple[bool, bool]:
         """Helper to evaluate auth results loop and reduce cyclomatic complexity."""
-        dkim_auth_fail = False
-        spf_auth_fail = False
-        for result in auth_results:
-            result_lower = result.lower()
+        # ⚡ BOLT: Optimization - Fast path check for failure keywords using getattr trick
+        # to satisfy CodeScene's Complex Conditional checks without nesting.
+        has_fail_indicator = False
+        for prop in ("fail", "permerror", "neutral"):
+            if prop in joined_results:
+                has_fail_indicator = True
+                break
 
-            # Check DKIM results
-            if "dkim=fail" in result_lower or "dkim=permerror" in result_lower:
-                dkim_auth_fail = True
-            elif "dkim=neutral" in result_lower:
-                dkim_auth_fail = True
+        if not has_fail_indicator:
+            return False, False
 
-            # Check SPF results
-            if "spf=fail" in result_lower or "spf=permerror" in result_lower:
-                spf_auth_fail = True
+        dkim_auth_fail = self._check_dkim_fail(joined_results)
+        spf_auth_fail = self._check_spf_fail(joined_results)
+
         return dkim_auth_fail, spf_auth_fail
+
+    def _check_dkim_fail(self, joined_results: str) -> bool:
+        for prop in ("dkim=fail", "dkim=permerror", "dkim=neutral"):
+            if prop in joined_results:
+                return True
+        return False
+
+    def _check_spf_fail(self, joined_results: str) -> bool:
+        for prop in ("spf=fail", "spf=permerror"):
+            if prop in joined_results:
+                return True
+        return False
 
     def _check_dkim_presence(
         self, headers: Dict[str, Union[str, List[str]]]
@@ -563,13 +564,25 @@ class SpamAnalyzer:
         score = 0.0
         issues = []
 
-        required_headers = ["from", "to", "date", "message-id"]
+        # ⚡ BOLT: Optimization - Extract required headers to static tuple to avoid loop reallocation
+        required_headers = ("from", "to", "date", "message-id")
+        # Optimization: Pre-calculate display strings to avoid runtime string operations
+        display_headers = {
+            "from": "From",
+            "to": "To",
+            "date": "Date",
+            "message-id": "Message-ID",
+        }
+
+        # ⚡ BOLT: Optimization - Fast path check using dict subset
+        # Significant speedup for the common case where all required headers are present
+        if len(headers) >= 4 and {"from", "to", "date", "message-id"}.issubset(headers):
+            return 0.0, []
+
         for header in required_headers:
             if header not in headers:
-                # Display original case for readability
-                display_header = header.title().replace("Id", "ID")
                 score += 0.5
-                issues.append(f"Missing {display_header} header")
+                issues.append(f"Missing {display_headers[header]} header")
 
         return score, issues
 


### PR DESCRIPTION
## Summary
Salvages DIRTY [#1399](https://github.com/abhimehro/email-security-pipeline/pull/1399) **spam_analyzer-only**.

### Taken
- Auth-results fast-path helpers (`_evaluate_auth_results_fast`, `_check_dkim_fail`, `_check_spf_fail`)
- Required-header presence fast-path + static display map

### Explicitly rejected
- Collapse of `alert_*` / `media_*` modules into `alert_system.py` / `media_analyzer.py` (net delete of modular files)
- CHANGELOG rewrites from the original PR

CodeScene remediation was requested on #1399 via `/cs-agent skill:fix-code-health-degradations`.

## ELIR
PURPOSE: Keep Bolt spam scoring micro-opts without undoing modular alert/media split.
SECURITY: Scoring heuristics only; no credential/webhook path changes in this salvage.
FAILS IF: Joined-string keyword matching differs from per-result matching on exotic auth headers.
VERIFY: `python3 -m pytest tests/ -k spam -q`
MAINTAIN: Close #1399 as superseded after human merge of this draft.

Autonomous merge: **none** (S1). ESP gate: draft-only.