### PR TITLE
chore(devin): add environment blueprint for repeatable setup

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -1,0 +1,29 @@
+# https://docs.devin.ai/onboard-devin/environment-yaml
+
+# Bootstrap a working pip for Python 3.12+ (the system pip may be too old
+# for the distutils-less interpreter). This installs pip into the user
+# site-packages so subsequent `python3 -m pip` invocations work.
+initialize: |
+  python3 -m ensurepip --upgrade
+  python3 -m pip install --user --upgrade pip
+
+# Install CI/dev dependencies. This intentionally uses requirements-ci.txt
+# to avoid the optional multi-GB ML stack (torch/transformers).
+maintenance: |
+  python3 -m pip install --user -r requirements-ci.txt
+  python3 -m pre_commit install
+
+knowledge:
+  - name: test
+    contents: |
+      python3 -m pytest
+      Tests mock IMAP/external services; no .env is required for test runs.
+  - name: lint
+    contents: |
+      python3 -m pre_commit run --all-files
+      Use requirements-ci.txt to avoid optional multi-GB ML dependencies.
+  - name: run
+    contents: |
+      cp .env.example .env
+      python3 src/main.py
+      Runtime IMAP credentials are required for the full pipeline.

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -11,7 +11,7 @@ initialize: |
 # to avoid the optional multi-GB ML stack (torch/transformers).
 maintenance: |
   python3 -m pip install --user -r requirements-ci.txt
-  python3 -m pre_commit install
+  python3 -m pre_commit install || true
 
 knowledge:
   - name: test
@@ -24,6 +24,6 @@ knowledge:
       Use requirements-ci.txt to avoid optional multi-GB ML dependencies.
   - name: run
     contents: |
-      cp .env.example .env
+      cp -n .env.example .env
       python3 src/main.py
       Runtime IMAP credentials are required for the full pipeline.

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -1,8 +1,8 @@
 # https://docs.devin.ai/onboard-devin/environment-yaml
 
 # Bootstrap a working pip for Python 3.12+ (the system pip may be too old
-# for the distutils-less interpreter). This installs pip into the user
-# site-packages so subsequent `python3 -m pip` invocations work.
+# for the distutils-less interpreter). `ensurepip` bootstraps pip, then we
+# explicitly upgrade it into the user site-packages so `python3 -m pip` works.
 initialize: |
   python3 -m ensurepip --upgrade
   python3 -m pip install --user --upgrade pip


### PR DESCRIPTION
## Summary

Adds `.devin/blueprint.yaml` so the repository itself contains the verified setup steps as an additional source of truth (mirroring the saved Devin environment blueprint).

---

## Type of Change

- [x] `chore` – maintenance (deps, config, CI)

---

## What Changed and Why

The repo was missing a repo-level environment blueprint. After bootstrapping from scratch, I captured the working steps in `.devin/blueprint.yaml` so future sessions and snapshot builds can install dependencies and run tests reliably.

---

## How Was This Tested

- `python3 -m ensurepip --upgrade` bootstrapped a working pip on the distutils-less Python 3.12 interpreter.
- `python3 -m pip install --user -r requirements-ci.txt` installed all CI/dev dependencies.
- `python3 -m pytest` passed: **726 passed in 9.12s**.
- `python3 -m pre_commit run --all-files` passed.

- [x] `python3 -m pytest` passes locally
- [x] `pre-commit run --all-files` passes locally

---

## Security Implications

- [x] No secrets or credentials are introduced or exposed by this change
- Security notes: This is a public Devin environment configuration file; no `.env` content or credentials are included.

---

## Checklist

- [x] Branch follows naming convention (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commit messages are clear and descriptive
- [ ] New or modified code includes relevant tests
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Documentation updated if behaviour changed (README, docstrings, etc.)
- [x] No secrets, credentials, or `.env` files are included in this PR

Link to Devin session: https://app.devin.ai/sessions/c25b58ee888141c78186119e47ae5f03
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->