### PR TITLE
🧪 Add test for Media Analyzer Timeout Handler

### DIFF
--- a/tests/test_media_analyzer_error_handling.py
+++ b/tests/test_media_analyzer_error_handling.py
@@ -75,5 +75,80 @@ class TestMediaAnalyzerBug(unittest.TestCase):
         analyzer.logger.warning.assert_called()
 
 
+
+    def test_analyze_deepfake_threat_timeout(self):
+        config = MagicMock()
+        config.media_analysis_timeout = 0.1
+
+        analyzer = MediaAuthenticityAnalyzer(config)
+        analyzer.logger = MagicMock()
+
+        # Mock the executor and future
+        mock_future = MagicMock()
+        import concurrent.futures
+        mock_future.result.side_effect = concurrent.futures.TimeoutError("Timed out")
+
+        analyzer._deepfake_executor = MagicMock()
+        analyzer._deepfake_executor.submit.return_value = mock_future
+
+        result = analyzer._analyze_deepfake_threat("test.mp4", b"data", "video/mp4")
+
+        self.assertEqual(result["score"], 0.0)
+        self.assertIn("Deepfake analysis timed out: test.mp4", result["errors"])
+        analyzer.logger.warning.assert_called()
+        args, _ = analyzer.logger.warning.call_args
+        self.assertIn("Deepfake analysis timed out for test.mp4", args[0])
+
+
+    def test_analyze_deepfake_threat_timeout(self):
+        config = MagicMock()
+        config.media_analysis_timeout = 0.1
+
+        analyzer = MediaAuthenticityAnalyzer(config)
+        analyzer.logger = MagicMock()
+
+        # Mock the executor and future
+        mock_future = MagicMock()
+        import concurrent.futures
+        mock_future.result.side_effect = concurrent.futures.TimeoutError("Timed out")
+
+        analyzer._deepfake_executor = MagicMock()
+        analyzer._deepfake_executor.submit.return_value = mock_future
+
+        result = analyzer._analyze_deepfake_threat("test.mp4", b"data", "video/mp4")
+
+        self.assertEqual(result["score"], 0.0)
+        self.assertIn("Deepfake analysis timed out: test.mp4", result["errors"])
+        analyzer.logger.warning.assert_called()
+        args, _ = analyzer.logger.warning.call_args
+        self.assertIn("Deepfake analysis timed out for test.mp4", args[0])
+
+
+    def test_analyze_deepfake_threat_timeout(self):
+        config = MagicMock()
+        config.media_analysis_timeout = 0.1
+
+        analyzer = MediaAuthenticityAnalyzer(config)
+        analyzer.logger = MagicMock()
+
+        # Mock the executor and future
+        mock_future = MagicMock()
+        import concurrent.futures
+        mock_future.result.side_effect = concurrent.futures.TimeoutError("Timed out")
+
+        analyzer._deepfake_executor = MagicMock()
+        analyzer._deepfake_executor.submit.return_value = mock_future
+
+        result = analyzer._analyze_deepfake_threat("test.mp4", b"data", "video/mp4")
+
+        self.assertEqual(result["score"], 0.0)
+        self.assertIn("Deepfake analysis timed out: test.mp4", result["errors"])
+        analyzer.logger.warning.assert_called()
+        args, _ = analyzer.logger.warning.call_args
+        self.assertIn("Deepfake analysis timed out for test.mp4", args[0])
+
 if __name__ == "__main__":
+
+
+
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added a test for the `TimeoutError` handler in `_analyze_deepfake_threat` which was previously untested. 
 📊 **Coverage:** Mocked `concurrent.futures.TimeoutError` and validated the result errors array and logger warning. 
 ✨ **Result:** Improved test coverage by verifying the timeout logic.

---
*PR created automatically by Jules for task [15554266633349901759](https://jules.google.com/task/15554266633349901759) started by @abhimehro*