### PR TITLE
Clarify comment regarding simple_master_pattern bug

### DIFF
--- a/tests/test_nlp_scan_text_patterns.py
+++ b/tests/test_nlp_scan_text_patterns.py
@@ -7,8 +7,8 @@ optimization and the heterogeneous AU list structure are both regression-prone:
   Phase 1 (fast gate): simple_master_pattern.search(part)
   Phase 2 (full scan): master_pattern.finditer(part) → matches_by_category
 
-A bug in the simple_master_pattern gate (e.g. match vs search) would silently
-produce zero pattern detections for all emails.  The AU category must store
+If a bug were introduced in the simple_master_pattern gate (e.g. using match instead of
+search), it would silently produce zero pattern detections for all emails.  The AU category must store
 lists of matched strings (not counts) because _detect_authority_impersonation
 compares match text against the sender domain; changing AU to use ints would
 silently break impersonation scoring.


### PR DESCRIPTION
Investigation showed that the comment 'A bug in the simple_master_pattern gate...' was just explaining why a specific test exists, not indicating an actual bug in the code. The code correctly uses `.search()`. This PR updates the comment to avoid ambiguity.

---
*PR created automatically by Jules for task [15392422760657732606](https://jules.google.com/task/15392422760657732606) started by @abhimehro*