### PR TITLE
fix(security): unify IMAP/SMTP host allowlist to prevent SSRF via env-controlled servers (ABHI-1685)

### DIFF
--- a/.agents/skills/testing-email-security-pipeline-locally/SKILL.md
+++ b/.agents/skills/testing-email-security-pipeline-locally/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: Testing the Email Security Pipeline locally
+description: How to run the email-security-pipeline config validation, startup, and diagnostic scripts without real IMAP/SMTP credentials.
+---
+
+## Devin Secrets Needed
+- None for config/allowlist validation. Real IMAP/SMTP credentials are required only to test an actual mailbox fetch.
+
+## One-liner
+
+```bash
+python3 -m src.main test_envs/allowed.env
+```
+
+## Common gotchas
+
+- The file `src/app_runner.py` is imported by `src/main.py`; it does **not** have a `__main__` guard, so `python3 -m src.app_runner` exits silently.
+- `diagnose_docker_connectivity.py` lives at the repo root, not in `scripts/`.
+- `scripts/check_mail_connectivity.py` calls `load_dotenv()` and reads `.env` from the current working directory.
+- `diagnose_docker_connectivity.py` calls `load_dotenv(".env")` and also reads the repo-root `.env`.
+- `scripts/diagnose_connectivity.py` does not call `load_dotenv()` itself; it constructs `Config()` which loads the configured env file.
+- Blank `*_IMAP_SERVER` / `*_SMTP_SERVER` values are treated as falsy and fall back to provider defaults (`imap.gmail.com` / `smtp.gmail.com` for Gmail, etc.).
+
+## Minimal allowed-host `.env`
+
+Use a fake Gmail account to exercise the allowlist gate without leaking credentials:
+
+```text
+GMAIL_ENABLED=true
+GMAIL_EMAIL=test@example.com
+GMAIL_IMAP_SERVER=imap.gmail.com
+GMAIL_IMAP_PORT=993
+GMAIL_SMTP_SERVER=smtp.gmail.com
+GMAIL_SMTP_PORT=465
+GMAIL_APP_PASSWORD=<FAKE_PASSWORD>
+GMAIL_FOLDERS=INBOX
+
+OUTLOOK_ENABLED=false
+PROTON_ENABLED=false
+
+# (include the rest of the analysis/alert/system defaults from .env.example)
+```
+
+With this file at `test_envs/allowed.env`, run:
+
+```bash
+python3 -m src.main test_envs/allowed.env
+```
+
+It should pass `Config.validate()`, print `🚀 Starting pipeline...`, and then fail on Gmail authentication. The pipeline must never start if `GMAIL_IMAP_SERVER` is set to a host outside `ALLOWED_MAIL_SERVER_HOSTS`.
+
+## Fixture templates for SSRF gate verification
+
+Create these under `test_envs/` (do not commit them; `.env` is git-ignored, but `*.env` fixtures may not be).
+
+`test_envs/disallowed_imap.env` — same as `allowed.env` but with:
+
+```text
+GMAIL_IMAP_SERVER=169.254.169.254
+```
+
+`test_envs/disallowed_smtp.env` — same as `allowed.env` but with:
+
+```text
+GMAIL_SMTP_SERVER=internal.evil.com
+```
+
+`test_envs/blank.env` — same as `allowed.env` but with:
+
+```text
+GMAIL_IMAP_SERVER=
+GMAIL_SMTP_SERVER=
+```
+
+## Verify the SSRF gate without clobbering the real `.env`
+
+Run the scripts from a scratch directory that contains only the fixture so the real repo-root `.env` is untouched:
+
+```bash
+mkdir -p /tmp/esp-test && cd /tmp/esp-test
+
+# Copy the fixture and any needed source references; source stays in the repo
+# 1. Pipeline with disallowed IMAP host — should exit 1 before "Starting pipeline"
+python3 -m src.main test_envs/disallowed_imap.env
+
+# 2. Connectivity script with blank IMAP/SMTP — should fall back to defaults
+#    (run from repo root so the script finds src/; use a temporary .env copy)
+(
+  cd /tmp/esp-test
+  cp /path/to/repo/test_envs/blank.env .env
+  /path/to/repo/scripts/check_mail_connectivity.py
+  rm -f .env
+)
+
+# 3. Diagnostic scripts with disallowed host
+(
+  cd /tmp/esp-test
+  cp /path/to/repo/test_envs/disallowed_imap.env .env
+  /path/to/repo/scripts/diagnose_connectivity.py test@example.com
+  /path/to/repo/diagnose_docker_connectivity.py
+  rm -f .env
+)
+```
+
+## Unit tests
+
+These tests do not require network access or credentials:
+
+```bash
+python3 -m pytest tests/test_mail_server_validation.py -v
+```
+
+## What "success" looks like
+
+- Disallowed hosts: generic `IMAP/SMTP host '...' is not in the allowed server list` error, no password printed, no network connection attempted.
+- Allowed hosts: validation passes and the app/script proceeds to an authentication failure (or a successful connection if real credentials are supplied).

--- a/diagnose_docker_connectivity.py
+++ b/diagnose_docker_connectivity.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 
 from dotenv import load_dotenv
 
+from src.utils.security_validators import validate_mail_server_host
+
 
 @dataclass
 class ConnectionConfig:
@@ -23,8 +25,42 @@ class ConnectionConfig:
     verify_ssl: bool = True
 
 
+def _create_ssl_context(verify_ssl: bool):
+    """Create an SSL context, optionally disabling certificate verification."""
+    if verify_ssl:
+        return ssl.create_default_context()
+
+    print("⚠️  SSL verification DISABLED")
+    return ssl._create_unverified_context()  # nosec B323
+
+
+def _create_imap_client(config: ConnectionConfig):
+    """Create an IMAP client based on SSL/STARTTLS configuration."""
+    if config.use_ssl:
+        context = _create_ssl_context(config.verify_ssl)
+        print(f"Connecting to {config.host}:{config.port} with SSL...")
+        return imaplib.IMAP4_SSL(
+            config.host, config.port, ssl_context=context, timeout=30
+        )
+
+    print(f"Connecting to {config.host}:{config.port} without SSL...")
+    imap = imaplib.IMAP4(config.host, config.port, timeout=30)
+    print("Upgrading to TLS...")
+    imap.starttls(ssl_context=_create_ssl_context(config.verify_ssl))
+    return imap
+
+
 def test_connection(config: ConnectionConfig):
     """Test IMAP connection with detailed diagnostics."""
+    try:
+        validate_mail_server_host(config.host)
+    except ValueError as e:
+        print(f"\n{'='*60}")
+        print(f"Testing: {config.label}")
+        print(f"❌ Security Error: {e}")
+        print(f"{'='*60}")
+        return False
+
     print(f"\n{'='*60}")
     print(f"Testing: {config.label}")
     print(f"Host: {config.host}:{config.port}")
@@ -33,27 +69,7 @@ def test_connection(config: ConnectionConfig):
     print(f"{'='*60}")
 
     try:
-        if config.use_ssl:
-            if config.verify_ssl:
-                context = ssl.create_default_context()
-            else:
-                context = ssl._create_unverified_context()  # nosec B323
-                print("⚠️  SSL verification DISABLED")
-
-            print(f"Connecting to {config.host}:{config.port} with SSL...")
-            imap = imaplib.IMAP4_SSL(
-                config.host, config.port, ssl_context=context, timeout=30
-            )
-        else:
-            print(f"Connecting to {config.host}:{config.port} without SSL...")
-            imap = imaplib.IMAP4(config.host, config.port, timeout=30)
-            print("Upgrading to TLS...")
-            if config.verify_ssl:
-                context = ssl.create_default_context()
-            else:
-                context = ssl._create_unverified_context()  # nosec B323
-            imap.starttls(ssl_context=context)
-
+        imap = _create_imap_client(config)
         print("✓ Connection established")
         print(f"Logging in as {config.email}...")
 
@@ -70,16 +86,15 @@ def test_connection(config: ConnectionConfig):
 
     except imaplib.IMAP4.error as e:
         print(f"❌ IMAP Error: {e}")
-        return False
     except ssl.SSLError as e:
         print(f"❌ SSL Error: {e}")
         print(f"   Error type: {type(e).__name__}")
         print(f"   Error args: {e.args}")
-        return False
     except Exception as e:
         print(f"❌ Unexpected Error: {e}")
         print(f"   Error type: {type(e).__name__}")
-        return False
+
+    return False
 
 
 def main():

--- a/diagnose_docker_connectivity.py
+++ b/diagnose_docker_connectivity.py
@@ -53,7 +53,7 @@ def _create_imap_client(config: ConnectionConfig):
 def test_connection(config: ConnectionConfig):
     """Test IMAP connection with detailed diagnostics."""
     try:
-        validate_mail_server_host(config.host)
+        config.host = validate_mail_server_host(config.host)
     except ValueError as e:
         print(f"\n{'='*60}")
         print(f"Testing: {config.label}")

--- a/diagnose_docker_connectivity.py
+++ b/diagnose_docker_connectivity.py
@@ -7,6 +7,7 @@ This helps identify whether issues are credential-based or network/SSL-based.
 import imaplib
 import os
 import ssl
+import sys
 from dataclasses import dataclass
 
 from dotenv import load_dotenv
@@ -105,21 +106,25 @@ def main():
     print(f"Python SSL version: {ssl.OPENSSL_VERSION}")
     print(f"TLS support: {ssl.HAS_TLSv1_2}, {ssl.HAS_TLSv1_3}")
 
+    results = []
+
     # Test Gmail
     if os.getenv("GMAIL_ENABLED", "").lower() == "true":
         gmail_email = os.getenv("GMAIL_EMAIL", "")
         gmail_password = os.getenv("GMAIL_APP_PASSWORD", "")
 
         if gmail_email and gmail_password:
-            test_connection(
-                ConnectionConfig(
-                    "Gmail",
-                    os.getenv("GMAIL_IMAP_SERVER", "imap.gmail.com"),
-                    int(os.getenv("GMAIL_IMAP_PORT", "993")),
-                    gmail_email,
-                    gmail_password,
-                    use_ssl=True,
-                    verify_ssl=True,
+            results.append(
+                test_connection(
+                    ConnectionConfig(
+                        "Gmail",
+                        os.getenv("GMAIL_IMAP_SERVER") or "imap.gmail.com",
+                        int(os.getenv("GMAIL_IMAP_PORT", "993")),
+                        gmail_email,
+                        gmail_password,
+                        use_ssl=True,
+                        verify_ssl=True,
+                    )
                 )
             )
         else:
@@ -129,35 +134,39 @@ def main():
     if os.getenv("PROTON_ENABLED", "").lower() == "true":
         proton_email = os.getenv("PROTON_EMAIL", "")
         proton_password = os.getenv("PROTON_APP_PASSWORD", "")
-        proton_server = os.getenv("PROTON_IMAP_SERVER", "127.0.0.1")
+        proton_server = os.getenv("PROTON_IMAP_SERVER") or "127.0.0.1"
         proton_port = int(os.getenv("PROTON_IMAP_PORT", "1143"))
 
         if proton_email and proton_password:
             # First try with verification disabled (as configured)
             verify = os.getenv("PROTON_VERIFY_SSL", "true").lower() != "false"
-            test_connection(
-                ConnectionConfig(
-                    "Proton Mail Bridge (as configured)",
-                    proton_server,
-                    proton_port,
-                    proton_email,
-                    proton_password,
-                    use_ssl=True,
-                    verify_ssl=verify,
+            results.append(
+                test_connection(
+                    ConnectionConfig(
+                        "Proton Mail Bridge (as configured)",
+                        proton_server,
+                        proton_port,
+                        proton_email,
+                        proton_password,
+                        use_ssl=True,
+                        verify_ssl=verify,
+                    )
                 )
             )
 
             # Also try without SSL entirely (STARTTLS fallback)
             print("\n--- Trying Proton without SSL (STARTTLS) ---")
-            test_connection(
-                ConnectionConfig(
-                    "Proton Mail Bridge (STARTTLS fallback)",
-                    proton_server,
-                    proton_port,
-                    proton_email,
-                    proton_password,
-                    use_ssl=False,
-                    verify_ssl=False,
+            results.append(
+                test_connection(
+                    ConnectionConfig(
+                        "Proton Mail Bridge (STARTTLS fallback)",
+                        proton_server,
+                        proton_port,
+                        proton_email,
+                        proton_password,
+                        use_ssl=False,
+                        verify_ssl=False,
+                    )
                 )
             )
         else:
@@ -166,6 +175,8 @@ def main():
     print("\n" + "=" * 60)
     print("Diagnostics complete")
     print("=" * 60)
+
+    sys.exit(0 if all(results) else 1)
 
 
 if __name__ == "__main__":

--- a/scripts/check_mail_connectivity.py
+++ b/scripts/check_mail_connectivity.py
@@ -21,7 +21,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 try:
     from src.utils.colors import Colors
-    from src.utils.security_validators import validate_mail_server_host
 except ImportError:
     # Fallback if src not found or not in path
     class Colors:
@@ -39,6 +38,11 @@ except ImportError:
         @classmethod
         def colorize(cls, text, color):
             return text
+
+
+try:
+    from src.utils.security_validators import validate_mail_server_host
+except ImportError:
 
     def validate_mail_server_host(host: str) -> None:
         """Fallback validator that fails closed if src is unavailable."""

--- a/scripts/check_mail_connectivity.py
+++ b/scripts/check_mail_connectivity.py
@@ -128,20 +128,21 @@ def check_imap(config: ConnectionConfig):
         "error": None,
     }
     try:
-        validate_mail_server_host(config.host)
+        host = validate_mail_server_host(config.host)
+        result["host"] = host
         if config.use_ssl:
             ctx = ssl.create_default_context()
-            with imaplib.IMAP4_SSL(config.host, config.port, ssl_context=ctx) as imap:
+            with imaplib.IMAP4_SSL(host, config.port, ssl_context=ctx) as imap:
                 imap.login(config.user, config.password)
                 imap.noop()
-                print_status("IMAP", config.host, config.port, config.use_ssl, True)
+                print_status("IMAP", host, config.port, config.use_ssl, True)
                 result["success"] = True
         else:
-            with imaplib.IMAP4(config.host, config.port) as imap:
+            with imaplib.IMAP4(host, config.port) as imap:
                 imap.starttls()
                 imap.login(config.user, config.password)
                 imap.noop()
-                print_status("IMAP", config.host, config.port, config.use_ssl, True)
+                print_status("IMAP", host, config.port, config.use_ssl, True)
                 result["success"] = True
     except Exception as e:
         print_status("IMAP", config.host, config.port, config.use_ssl, False, str(e))
@@ -163,20 +164,21 @@ def check_smtp(config: ConnectionConfig):
         "error": None,
     }
     try:
-        validate_mail_server_host(config.host)
+        host = validate_mail_server_host(config.host)
+        result["host"] = host
         if config.use_ssl:
             ctx = ssl.create_default_context()
-            with smtplib.SMTP_SSL(config.host, config.port, context=ctx) as smtp:
+            with smtplib.SMTP_SSL(host, config.port, context=ctx) as smtp:
                 smtp.login(config.user, config.password)
                 smtp.noop()
-                print_status("SMTP", config.host, config.port, config.use_ssl, True)
+                print_status("SMTP", host, config.port, config.use_ssl, True)
                 result["success"] = True
         else:
-            with smtplib.SMTP(config.host, config.port) as smtp:
+            with smtplib.SMTP(host, config.port) as smtp:
                 smtp.starttls()
                 smtp.login(config.user, config.password)
                 smtp.noop()
-                print_status("SMTP", config.host, config.port, config.use_ssl, True)
+                print_status("SMTP", host, config.port, config.use_ssl, True)
                 result["success"] = True
     except Exception as e:
         print_status("SMTP", config.host, config.port, config.use_ssl, False, str(e))

--- a/scripts/check_mail_connectivity.py
+++ b/scripts/check_mail_connectivity.py
@@ -21,6 +21,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 try:
     from src.utils.colors import Colors
+    from src.utils.security_validators import validate_mail_server_host
 except ImportError:
     # Fallback if src not found or not in path
     class Colors:
@@ -38,6 +39,10 @@ except ImportError:
         @classmethod
         def colorize(cls, text, color):
             return text
+
+    def validate_mail_server_host(host: str) -> None:
+        """Fallback validator that fails closed if src is unavailable."""
+        raise RuntimeError("Mail server validator is unavailable")
 
 
 load_dotenv()
@@ -119,6 +124,7 @@ def check_imap(config: ConnectionConfig):
         "error": None,
     }
     try:
+        validate_mail_server_host(config.host)
         if config.use_ssl:
             ctx = ssl.create_default_context()
             with imaplib.IMAP4_SSL(config.host, config.port, ssl_context=ctx) as imap:
@@ -153,6 +159,7 @@ def check_smtp(config: ConnectionConfig):
         "error": None,
     }
     try:
+        validate_mail_server_host(config.host)
         if config.use_ssl:
             ctx = ssl.create_default_context()
             with smtplib.SMTP_SSL(config.host, config.port, context=ctx) as smtp:

--- a/scripts/check_mail_connectivity.py
+++ b/scripts/check_mail_connectivity.py
@@ -202,7 +202,7 @@ def _check_gmail() -> List[dict]:
             check_imap(
                 ConnectionConfig(
                     "Gmail",
-                    os.getenv("GMAIL_IMAP_SERVER", "imap.gmail.com"),
+                    os.getenv("GMAIL_IMAP_SERVER") or "imap.gmail.com",
                     int(os.getenv("GMAIL_IMAP_PORT", "993")),
                     True,
                     email,
@@ -215,7 +215,7 @@ def _check_gmail() -> List[dict]:
             check_smtp(
                 ConnectionConfig(
                     "Gmail",
-                    os.getenv("GMAIL_SMTP_SERVER", "smtp.gmail.com"),
+                    os.getenv("GMAIL_SMTP_SERVER") or "smtp.gmail.com",
                     int(os.getenv("GMAIL_SMTP_PORT", "465")),
                     True,
                     email,
@@ -238,7 +238,7 @@ def _check_outlook() -> List[dict]:
             check_imap(
                 ConnectionConfig(
                     "Outlook",
-                    os.getenv("OUTLOOK_IMAP_SERVER", "outlook.office365.com"),
+                    os.getenv("OUTLOOK_IMAP_SERVER") or "outlook.office365.com",
                     int(os.getenv("OUTLOOK_IMAP_PORT", "993")),
                     True,
                     email,
@@ -252,7 +252,7 @@ def _check_outlook() -> List[dict]:
             check_smtp(
                 ConnectionConfig(
                     "Outlook",
-                    os.getenv("OUTLOOK_SMTP_SERVER", "smtp.office365.com"),
+                    os.getenv("OUTLOOK_SMTP_SERVER") or "smtp.office365.com",
                     int(os.getenv("OUTLOOK_SMTP_PORT", "587")),
                     False,  # Outlook SMTP usually uses STARTTLS
                     email,
@@ -275,7 +275,7 @@ def _check_proton() -> List[dict]:
             check_imap(
                 ConnectionConfig(
                     "Proton",
-                    os.getenv("PROTON_IMAP_SERVER", "127.0.0.1"),
+                    os.getenv("PROTON_IMAP_SERVER") or "127.0.0.1",
                     int(os.getenv("PROTON_IMAP_PORT", "1143")),
                     False,
                     email,
@@ -288,7 +288,7 @@ def _check_proton() -> List[dict]:
             check_smtp(
                 ConnectionConfig(
                     "Proton",
-                    os.getenv("PROTON_SMTP_SERVER", "127.0.0.1"),
+                    os.getenv("PROTON_SMTP_SERVER") or "127.0.0.1",
                     int(os.getenv("PROTON_SMTP_PORT", "1025")),
                     False,
                     email,

--- a/scripts/diagnose_connectivity.py
+++ b/scripts/diagnose_connectivity.py
@@ -13,7 +13,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.modules.email_ingestion import EmailIngestionManager
-from src.utils.config import Config, ConfigurationError
+from src.utils.config import Config
 
 # Set up basic logging
 logging.basicConfig(
@@ -33,10 +33,11 @@ def main():
 
     # Load email configurations from environment variables
     config = Config()
-    try:
-        config.validate()
-    except ConfigurationError as e:
-        logging.error("Configuration validation failed: %s", e)
+    email_errors = config._validate_email_accounts()
+    if email_errors:
+        logging.error("Email account configuration is invalid:")
+        for error in email_errors:
+            logging.error("  - %s", error)
         sys.exit(1)
 
     email_accounts = config.email_accounts

--- a/scripts/diagnose_connectivity.py
+++ b/scripts/diagnose_connectivity.py
@@ -13,7 +13,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.modules.email_ingestion import EmailIngestionManager
-from src.utils.config import Config
+from src.utils.config import Config, ConfigurationError
 
 # Set up basic logging
 logging.basicConfig(
@@ -33,6 +33,12 @@ def main():
 
     # Load email configurations from environment variables
     config = Config()
+    try:
+        config.validate()
+    except ConfigurationError as e:
+        logging.error("Configuration validation failed: %s", e)
+        sys.exit(1)
+
     email_accounts = config.email_accounts
     if not email_accounts:
         logging.error("No email accounts are configured. Please check your .env file.")

--- a/src/app_runner.py
+++ b/src/app_runner.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import List, NoReturn, Optional
 
 from src.utils.colors import Colors
-from src.utils.config import Config
+from src.utils.config import Config, ConfigurationError
 from src.utils.setup_wizard import run_setup_wizard
 
 
@@ -236,9 +236,11 @@ class AppRunner:
         )
 
     def validate_config(self) -> None:
-        """Validate the configuration to ensure default credentials aren't used."""
+        """Validate configuration before starting the pipeline."""
         try:
             config_validator = Config(self.config_file)
+            config_validator.validate()
+
             from src.utils.validators import check_default_credentials
 
             errors = check_default_credentials(config_validator)
@@ -267,6 +269,18 @@ class AppRunner:
                 )
                 sys.exit(1)
 
+        except ConfigurationError as e:
+            print("\n" + "✖ " + Colors.colorize("Configuration Error:", Colors.RED))
+            for error in e.args[0]:
+                print(f"  • {Colors.colorize(error, Colors.YELLOW)}")
+            print(
+                "\n"
+                + Colors.colorize(
+                    "Please edit your configuration file and ensure all settings are valid.",
+                    Colors.YELLOW,
+                )
+            )
+            sys.exit(1)
         except Exception as e:
             print(
                 Colors.colorize(

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 from dotenv import load_dotenv
 
-from .security_validators import is_safe_webhook_url
+from .security_validators import is_safe_webhook_url, validate_mail_server_host
 
 
 class ConfigurationError(Exception):
@@ -32,6 +32,7 @@ class EmailAccountConfig:
     folders: List[str]
     provider: str
     use_ssl: bool
+    smtp_server: Optional[str] = None
 
 
 @dataclass
@@ -135,6 +136,7 @@ class Config:
                     folders=self._parse_folders(os.getenv("GMAIL_FOLDERS", "INBOX")),
                     provider="gmail",
                     use_ssl=self._get_bool("GMAIL_USE_SSL", True),
+                    smtp_server=os.getenv("GMAIL_SMTP_SERVER", "smtp.gmail.com"),
                 )
             )
 
@@ -152,6 +154,7 @@ class Config:
                     folders=self._parse_folders(os.getenv("OUTLOOK_FOLDERS", "INBOX")),
                     provider="outlook",
                     use_ssl=self._get_bool("OUTLOOK_USE_SSL", True),
+                    smtp_server=os.getenv("OUTLOOK_SMTP_SERVER", "smtp.office365.com"),
                 )
             )
 
@@ -167,6 +170,7 @@ class Config:
                     folders=self._parse_folders(os.getenv("PROTON_FOLDERS", "INBOX")),
                     provider="proton",
                     use_ssl=self._get_bool("PROTON_USE_SSL", True),
+                    smtp_server=os.getenv("PROTON_SMTP_SERVER", "127.0.0.1"),
                 )
             )
 
@@ -277,6 +281,29 @@ class Config:
             return False
         return parsed.scheme == "https" and bool(parsed.hostname)
 
+    def _append_host_error(
+        self,
+        label: str,
+        server: str,
+        provider: str,
+        errors: List[str],
+    ) -> None:
+        """Validate a single mail server host and append any error."""
+        try:
+            validate_mail_server_host(server)
+        except ValueError as e:
+            errors.append(f"{label} server for {provider} account: {e}")
+
+    def _add_account_host_errors(
+        self, account: EmailAccountConfig, errors: List[str]
+    ) -> None:
+        """Validate an account's IMAP and SMTP hosts against the allowlist."""
+        self._append_host_error("IMAP", account.imap_server, account.provider, errors)
+        if account.smtp_server is not None:
+            self._append_host_error(
+                "SMTP", account.smtp_server, account.provider, errors
+            )
+
     def _validate_email_accounts(self) -> List[str]:
         """Validate email account configurations."""
         errors = []
@@ -290,6 +317,7 @@ class Config:
                 errors.append(f"No folders configured for {account.provider} account")
             if account.imap_port <= 0:
                 errors.append(f"Invalid IMAP port for {account.provider} account")
+            self._add_account_host_errors(account, errors)
         return errors
 
     def _validate_webhook_config(self, errors: List[str]) -> None:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -11,7 +11,11 @@ from urllib.parse import urlparse
 
 from dotenv import load_dotenv
 
-from .security_validators import is_safe_webhook_url, validate_mail_server_host
+from .security_validators import (
+    _normalize_mail_server_host,
+    is_safe_webhook_url,
+    validate_mail_server_host,
+)
 
 
 class ConfigurationError(Exception):
@@ -33,6 +37,12 @@ class EmailAccountConfig:
     provider: str
     use_ssl: bool
     smtp_server: Optional[str] = None
+
+    def __post_init__(self):
+        """Normalize server hostnames so comparisons and connections match."""
+        self.imap_server = _normalize_mail_server_host(self.imap_server)
+        if self.smtp_server is not None:
+            self.smtp_server = _normalize_mail_server_host(self.smtp_server)
 
 
 @dataclass
@@ -130,11 +140,10 @@ class Config:
         self,
         provider: str,
         prefix: str,
-        imap_default: str,
-        smtp_default: str,
-        port_default: int,
+        defaults: tuple,
     ) -> EmailAccountConfig:
         """Build an EmailAccountConfig from environment variables for one provider."""
+        imap_default, smtp_default, port_default = defaults
         return EmailAccountConfig(
             enabled=True,
             email=os.getenv(f"{prefix}_EMAIL", ""),
@@ -151,11 +160,7 @@ class Config:
         """Load email account configurations."""
         accounts = []
 
-        for provider, (
-            imap_default,
-            smtp_default,
-            port_default,
-        ) in self._PROVIDER_DEFAULTS.items():
+        for provider, defaults in self._PROVIDER_DEFAULTS.items():
             prefix = provider.upper()
             if not self._get_bool(f"{prefix}_ENABLED", False):
                 continue
@@ -163,9 +168,7 @@ class Config:
                 self._build_email_account(
                     provider,
                     prefix,
-                    imap_default,
-                    smtp_default,
-                    port_default,
+                    defaults,
                 )
             )
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -130,13 +130,13 @@ class Config:
                 EmailAccountConfig(
                     enabled=True,
                     email=os.getenv("GMAIL_EMAIL", ""),
-                    imap_server=os.getenv("GMAIL_IMAP_SERVER", "imap.gmail.com"),
+                    imap_server=os.getenv("GMAIL_IMAP_SERVER") or "imap.gmail.com",
                     imap_port=int(os.getenv("GMAIL_IMAP_PORT", "993")),
                     app_password=os.getenv("GMAIL_APP_PASSWORD", ""),
                     folders=self._parse_folders(os.getenv("GMAIL_FOLDERS", "INBOX")),
                     provider="gmail",
                     use_ssl=self._get_bool("GMAIL_USE_SSL", True),
-                    smtp_server=os.getenv("GMAIL_SMTP_SERVER", "smtp.gmail.com"),
+                    smtp_server=os.getenv("GMAIL_SMTP_SERVER") or "smtp.gmail.com",
                 )
             )
 
@@ -146,15 +146,15 @@ class Config:
                 EmailAccountConfig(
                     enabled=True,
                     email=os.getenv("OUTLOOK_EMAIL", ""),
-                    imap_server=os.getenv(
-                        "OUTLOOK_IMAP_SERVER", "outlook.office365.com"
-                    ),
+                    imap_server=os.getenv("OUTLOOK_IMAP_SERVER")
+                    or "outlook.office365.com",
                     imap_port=int(os.getenv("OUTLOOK_IMAP_PORT", "993")),
                     app_password=os.getenv("OUTLOOK_APP_PASSWORD", ""),
                     folders=self._parse_folders(os.getenv("OUTLOOK_FOLDERS", "INBOX")),
                     provider="outlook",
                     use_ssl=self._get_bool("OUTLOOK_USE_SSL", True),
-                    smtp_server=os.getenv("OUTLOOK_SMTP_SERVER", "smtp.office365.com"),
+                    smtp_server=os.getenv("OUTLOOK_SMTP_SERVER")
+                    or "smtp.office365.com",
                 )
             )
 
@@ -164,13 +164,13 @@ class Config:
                 EmailAccountConfig(
                     enabled=True,
                     email=os.getenv("PROTON_EMAIL", ""),
-                    imap_server=os.getenv("PROTON_IMAP_SERVER", "127.0.0.1"),
+                    imap_server=os.getenv("PROTON_IMAP_SERVER") or "127.0.0.1",
                     imap_port=int(os.getenv("PROTON_IMAP_PORT", "1143")),
                     app_password=os.getenv("PROTON_APP_PASSWORD", ""),
                     folders=self._parse_folders(os.getenv("PROTON_FOLDERS", "INBOX")),
                     provider="proton",
                     use_ssl=self._get_bool("PROTON_USE_SSL", True),
-                    smtp_server=os.getenv("PROTON_SMTP_SERVER", "127.0.0.1"),
+                    smtp_server=os.getenv("PROTON_SMTP_SERVER") or "127.0.0.1",
                 )
             )
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -105,6 +105,12 @@ class SystemConfig:
 class Config:
     """Main configuration class."""
 
+    _PROVIDER_DEFAULTS = {
+        "gmail": ("imap.gmail.com", "smtp.gmail.com", 993),
+        "outlook": ("outlook.office365.com", "smtp.office365.com", 993),
+        "proton": ("127.0.0.1", "127.0.0.1", 1143),
+    }
+
     def __init__(self, env_file: str = ".env"):
         """
         Initialize configuration from environment file.
@@ -120,57 +126,46 @@ class Config:
         self.alerts = self._load_alert_config()
         self.system = self._load_system_config()
 
+    def _build_email_account(
+        self,
+        provider: str,
+        prefix: str,
+        imap_default: str,
+        smtp_default: str,
+        port_default: int,
+    ) -> EmailAccountConfig:
+        """Build an EmailAccountConfig from environment variables for one provider."""
+        return EmailAccountConfig(
+            enabled=True,
+            email=os.getenv(f"{prefix}_EMAIL", ""),
+            imap_server=os.getenv(f"{prefix}_IMAP_SERVER") or imap_default,
+            imap_port=int(os.getenv(f"{prefix}_IMAP_PORT", str(port_default))),
+            app_password=os.getenv(f"{prefix}_APP_PASSWORD", ""),
+            folders=self._parse_folders(os.getenv(f"{prefix}_FOLDERS", "INBOX")),
+            provider=provider,
+            use_ssl=self._get_bool(f"{prefix}_USE_SSL", True),
+            smtp_server=os.getenv(f"{prefix}_SMTP_SERVER") or smtp_default,
+        )
+
     def _load_email_accounts(self) -> List[EmailAccountConfig]:
         """Load email account configurations."""
         accounts = []
 
-        # Gmail
-        if self._get_bool("GMAIL_ENABLED", False):
+        for provider, (
+            imap_default,
+            smtp_default,
+            port_default,
+        ) in self._PROVIDER_DEFAULTS.items():
+            prefix = provider.upper()
+            if not self._get_bool(f"{prefix}_ENABLED", False):
+                continue
             accounts.append(
-                EmailAccountConfig(
-                    enabled=True,
-                    email=os.getenv("GMAIL_EMAIL", ""),
-                    imap_server=os.getenv("GMAIL_IMAP_SERVER") or "imap.gmail.com",
-                    imap_port=int(os.getenv("GMAIL_IMAP_PORT", "993")),
-                    app_password=os.getenv("GMAIL_APP_PASSWORD", ""),
-                    folders=self._parse_folders(os.getenv("GMAIL_FOLDERS", "INBOX")),
-                    provider="gmail",
-                    use_ssl=self._get_bool("GMAIL_USE_SSL", True),
-                    smtp_server=os.getenv("GMAIL_SMTP_SERVER") or "smtp.gmail.com",
-                )
-            )
-
-        # Outlook
-        if self._get_bool("OUTLOOK_ENABLED", False):
-            accounts.append(
-                EmailAccountConfig(
-                    enabled=True,
-                    email=os.getenv("OUTLOOK_EMAIL", ""),
-                    imap_server=os.getenv("OUTLOOK_IMAP_SERVER")
-                    or "outlook.office365.com",
-                    imap_port=int(os.getenv("OUTLOOK_IMAP_PORT", "993")),
-                    app_password=os.getenv("OUTLOOK_APP_PASSWORD", ""),
-                    folders=self._parse_folders(os.getenv("OUTLOOK_FOLDERS", "INBOX")),
-                    provider="outlook",
-                    use_ssl=self._get_bool("OUTLOOK_USE_SSL", True),
-                    smtp_server=os.getenv("OUTLOOK_SMTP_SERVER")
-                    or "smtp.office365.com",
-                )
-            )
-
-        # Proton Mail
-        if self._get_bool("PROTON_ENABLED", False):
-            accounts.append(
-                EmailAccountConfig(
-                    enabled=True,
-                    email=os.getenv("PROTON_EMAIL", ""),
-                    imap_server=os.getenv("PROTON_IMAP_SERVER") or "127.0.0.1",
-                    imap_port=int(os.getenv("PROTON_IMAP_PORT", "1143")),
-                    app_password=os.getenv("PROTON_APP_PASSWORD", ""),
-                    folders=self._parse_folders(os.getenv("PROTON_FOLDERS", "INBOX")),
-                    provider="proton",
-                    use_ssl=self._get_bool("PROTON_USE_SSL", True),
-                    smtp_server=os.getenv("PROTON_SMTP_SERVER") or "127.0.0.1",
+                self._build_email_account(
+                    provider,
+                    prefix,
+                    imap_default,
+                    smtp_default,
+                    port_default,
                 )
             )
 

--- a/src/utils/security_validators.py
+++ b/src/utils/security_validators.py
@@ -57,6 +57,21 @@ WINDOWS_RESERVED_NAMES = {
     "LPT9",
 }
 
+# Allowed mail server hosts to prevent SSRF via attacker-controlled *_IMAP_SERVER
+# or *_SMTP_SERVER environment variables. Hostnames are normalized (lowercase,
+# stripped, trailing FQDN dot removed) before the allowlist check.
+ALLOWED_MAIL_SERVER_HOSTS = frozenset(
+    {
+        "127.0.0.1",
+        "localhost",
+        "host.docker.internal",
+        "imap.gmail.com",
+        "outlook.office365.com",
+        "smtp.gmail.com",
+        "smtp.office365.com",
+    }
+)
+
 
 # Lazily evaluated IP properties for SSRF protection
 _BAD_IP_PROPERTIES = (
@@ -70,6 +85,37 @@ _BAD_IP_PROPERTIES = (
 
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_mail_server_host(host: str) -> str:
+    """Normalize a mail server hostname for allowlist comparison."""
+    return host.strip().lower().rstrip(".")
+
+
+def validate_mail_server_host(host: str) -> None:
+    """
+    Validate a mail server hostname against the allowed server list.
+
+    SECURITY STORY: Prevents SSRF and credential leakage by ensuring IMAP/SMTP
+    hosts can only point to trusted, expected servers. The allowlist is
+    hard-coded (not configurable) because a configurable allowlist would itself
+    be attacker-controllable via environment variables and reintroduce the SSRF.
+
+    Args:
+        host: Mail server hostname to validate.
+
+    Raises:
+        ValueError: If the host is empty or not in the allowed list.
+
+    """
+    if not host:
+        raise ValueError("IMAP/SMTP host is empty")
+
+    normalized = _normalize_mail_server_host(host)
+    if normalized not in ALLOWED_MAIL_SERVER_HOSTS:
+        raise ValueError(
+            f"IMAP/SMTP host '{normalized}' is not in the allowed server list"
+        )
 
 
 def sanitize_filename(filename: str) -> str:

--- a/src/utils/security_validators.py
+++ b/src/utils/security_validators.py
@@ -92,7 +92,7 @@ def _normalize_mail_server_host(host: str) -> str:
     return host.strip().lower().rstrip(".")
 
 
-def validate_mail_server_host(host: str) -> None:
+def validate_mail_server_host(host: str) -> str:
     """
     Validate a mail server hostname against the allowed server list.
 
@@ -103,6 +103,9 @@ def validate_mail_server_host(host: str) -> None:
 
     Args:
         host: Mail server hostname to validate.
+
+    Returns:
+        The normalized host (lowercase, stripped, no trailing FQDN dot).
 
     Raises:
         ValueError: If the host is empty or not in the allowed list.
@@ -116,6 +119,8 @@ def validate_mail_server_host(host: str) -> None:
         raise ValueError(
             f"IMAP/SMTP host '{normalized}' is not in the allowed server list"
         )
+
+    return normalized
 
 
 def sanitize_filename(filename: str) -> str:

--- a/test_config.py
+++ b/test_config.py
@@ -203,9 +203,16 @@ def test_imap_connections(test_connections=True):
 
     try:
         from src.modules.email_ingestion import EmailIngestionManager
-        from src.utils.config import Config
+        from src.utils.config import Config, ConfigurationError
 
         config = Config(".env")
+        try:
+            config.validate()
+        except ConfigurationError as e:
+            print("❌ Configuration validation failed:")
+            for error in e.args[0]:
+                print(f"  - {error}")
+            return False
 
         if not config.email_accounts:
             print("⚠️  No email accounts configured, skipping connection test")

--- a/test_config.py
+++ b/test_config.py
@@ -191,6 +191,33 @@ def test_analyzer_initialization():
         return False
 
 
+def _validate_config_for_test(config) -> bool:
+    """Validate config for the connection test, printing any errors."""
+    from src.utils.config import ConfigurationError
+
+    try:
+        config.validate()
+        return True
+    except ConfigurationError as e:
+        print("❌ Configuration validation failed:")
+        for error in e.args[0]:
+            print(f"  - {error}")
+        return False
+
+
+def _print_client_folders(client, email: str) -> None:
+    """List folders for a connected client, printing results or errors."""
+    try:
+        folders = client.list_folders()
+        print(f"  - {email}: Found {len(folders)} folder(s)")
+        if folders:
+            print(
+                f"    Folders: {', '.join(folders[:5])}{'...' if len(folders) > 5 else ''}"
+            )
+    except Exception as e:
+        print(f"  - {email}: Error listing folders - {e}")
+
+
 def test_imap_connections(test_connections=True):
     """Test IMAP connections (optional)."""
     print("\n" + "=" * 60)
@@ -203,15 +230,10 @@ def test_imap_connections(test_connections=True):
 
     try:
         from src.modules.email_ingestion import EmailIngestionManager
-        from src.utils.config import Config, ConfigurationError
+        from src.utils.config import Config
 
         config = Config(".env")
-        try:
-            config.validate()
-        except ConfigurationError as e:
-            print("❌ Configuration validation failed:")
-            for error in e.args[0]:
-                print(f"  - {error}")
+        if not _validate_config_for_test(config):
             return False
 
         if not config.email_accounts:
@@ -232,15 +254,7 @@ def test_imap_connections(test_connections=True):
 
             # List folders for each account
             for email, client in ingestion_manager.clients.items():
-                try:
-                    folders = client.list_folders()
-                    print(f"  - {email}: Found {len(folders)} folder(s)")
-                    if folders:
-                        print(
-                            f"    Folders: {', '.join(folders[:5])}{'...' if len(folders) > 5 else ''}"
-                        )
-                except Exception as e:
-                    print(f"  - {email}: Error listing folders - {e}")
+                _print_client_folders(client, email)
 
             # Clean up
             ingestion_manager.close_all_connections()

--- a/tests/test_mail_server_validation.py
+++ b/tests/test_mail_server_validation.py
@@ -1,0 +1,256 @@
+"""
+Mail server host validation tests for SSRF prevention.
+
+Validates the unified ALLOWED_MAIL_SERVER_HOSTS allowlist and its integration
+into Config.validate() and the standalone connectivity scripts.
+"""
+
+import secrets
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add project root and scripts directory to path for standalone script imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+scripts_dir = str(Path(__file__).parent.parent / "scripts")
+sys.path.insert(0, scripts_dir)
+
+with patch("dotenv.load_dotenv"):
+    import check_mail_connectivity  # type: ignore[import-not-found]
+
+from src.utils.config import Config, ConfigurationError, EmailAccountConfig
+from src.utils.security_validators import (
+    ALLOWED_MAIL_SERVER_HOSTS,
+    validate_mail_server_host,
+)
+
+# Dummy credential used in tests. Generated at runtime so no static secret is
+# hard-coded in the source file.
+DUMMY_VALUE = secrets.token_hex(16)
+
+
+def _make_email_config(
+    imap_server: str = "imap.gmail.com",
+    smtp_server: str | None = None,
+    app_secret: str = DUMMY_VALUE,
+) -> EmailAccountConfig:
+    """Return a minimal EmailAccountConfig for tests."""
+    return EmailAccountConfig(
+        True,
+        "test@example.com",
+        imap_server,
+        993,
+        app_secret,
+        ["INBOX"],
+        "test",
+        True,
+        smtp_server,
+    )
+
+
+class TestValidateMailServerHost(unittest.TestCase):
+    """Unit tests for the unified mail-server host validator."""
+
+    def test_allowed_hosts_pass(self):
+        """All allowed hosts (including case/whitespace variants) must validate."""
+        for host in ALLOWED_MAIL_SERVER_HOSTS:
+            with self.subTest(host=host):
+                # Should not raise
+                validate_mail_server_host(host)
+                validate_mail_server_host(host.upper())
+                validate_mail_server_host(f"  {host}  ")
+                validate_mail_server_host(f"{host}.")
+
+    def test_disallowed_hosts_rejected(self):
+        """Known attacker-friendly hosts must be rejected."""
+        disallowed_hosts = [
+            "169.254.169.254",
+            "10.0.0.5",
+            "internal.evil.com",
+            "imap.evil.com",
+            "smtp.evil.com",
+            "localhost.localdomain",
+        ]
+        for host in disallowed_hosts:
+            with self.subTest(host=host):
+                with self.assertRaises(ValueError) as cm:
+                    validate_mail_server_host(host)
+                self.assertIn("not in the allowed server list", str(cm.exception))
+
+    def test_normalization_bypasses_blocked(self):
+        """Case, whitespace, and trailing-dot tricks must not bypass the allowlist."""
+        with self.assertRaises(ValueError) as cm:
+            validate_mail_server_host("  EVIL.COM. ")
+        self.assertIn("evil.com", str(cm.exception))
+
+    def test_empty_host_rejected(self):
+        """Empty hosts must be rejected cleanly."""
+        with self.assertRaises(ValueError) as cm:
+            validate_mail_server_host("")
+        self.assertIn("host is empty", str(cm.exception))
+
+    def test_allowed_host_normalized(self):
+        """Allowed hosts with normalization must pass."""
+        validate_mail_server_host(" IMAP.GMAIL.COM. ")
+        validate_mail_server_host("SMTP.GMAIL.COM")
+        validate_mail_server_host("  LocalHost  ")
+
+
+class TestConfigMailServerValidation(unittest.TestCase):
+    """Tests for Config.validate() mail server host enforcement."""
+
+    def _run_config_host_test(
+        self,
+        imap_server: str,
+        smtp_server: str,
+        expected_valid: bool,
+        app_secret: str | None = None,
+    ) -> None:
+        """Run Config.validate() with the given hosts and check the outcome."""
+        if app_secret is None:
+            app_secret = DUMMY_VALUE
+
+        account = _make_email_config(
+            imap_server=imap_server,
+            smtp_server=smtp_server,
+            app_secret=app_secret,
+        )
+
+        with patch("src.utils.config.load_dotenv"):
+            with patch("src.utils.config.os.getenv") as mock_getenv:
+                mock_getenv.side_effect = lambda key, default=None: default
+                with patch.object(
+                    Config, "_load_email_accounts", return_value=[account]
+                ):
+                    config = Config()
+                    if expected_valid:
+                        self.assertTrue(config.validate())
+                        return
+
+                    with self.assertRaises(ConfigurationError) as cm:
+                        config.validate()
+
+                    errors = cm.exception.args[0]
+                    error_blob = "\n".join(str(e) for e in errors)
+                    self.assertTrue(
+                        any("not in the allowed server list" in e for e in errors),
+                        f"Expected allowlist error, got: {errors}",
+                    )
+                    self.assertNotIn(
+                        app_secret,
+                        error_blob,
+                        "Validation error must not leak the app secret",
+                    )
+
+    def test_config_validates_allowed_imap_smtp(self):
+        """Valid allowed IMAP/SMTP hosts pass Config.validate()."""
+        self._run_config_host_test(
+            "imap.gmail.com", "smtp.gmail.com", expected_valid=True
+        )
+
+    def test_config_rejects_disallowed_imap(self):
+        """Disallowed IMAP host is caught without leaking credentials."""
+        self._run_config_host_test(
+            "169.254.169.254",
+            "smtp.gmail.com",
+            expected_valid=False,
+            app_secret=secrets.token_hex(16),
+        )
+
+    def test_config_rejects_disallowed_smtp(self):
+        """Disallowed SMTP host is caught by Config.validate()."""
+        self._run_config_host_test(
+            "imap.gmail.com",
+            "internal.evil.com",
+            expected_valid=False,
+        )
+
+
+class TestCheckMailConnectivityValidation(unittest.TestCase):
+    """Tests that scripts/check_mail_connectivity.py validates hosts before connecting."""
+
+    def _make_config(
+        self,
+        host: str = "169.254.169.254",
+        app_secret: str | None = None,
+    ) -> check_mail_connectivity.ConnectionConfig:
+        if app_secret is None:
+            app_secret = DUMMY_VALUE
+        return check_mail_connectivity.ConnectionConfig(
+            "Test",
+            host,
+            993,
+            True,
+            "test@example.com",
+            app_secret,
+            None,
+        )
+
+    @patch("check_mail_connectivity.imaplib.IMAP4_SSL")
+    def test_check_imap_rejects_disallowed_host(self, mock_imap_ssl):
+        """check_imap must reject a disallowed host and never open a socket."""
+        app_secret = secrets.token_hex(16)
+        config = self._make_config(host="10.0.0.5", app_secret=app_secret)
+
+        result = check_mail_connectivity.check_imap(config)
+
+        self.assertFalse(result["success"])
+        self.assertIn("not in the allowed server list", result["error"])
+        self.assertNotIn(app_secret, result["error"])
+        mock_imap_ssl.assert_not_called()
+
+    @patch("check_mail_connectivity.imaplib.IMAP4_SSL")
+    def test_check_imap_allows_allowed_host(self, mock_imap_ssl):
+        """check_imap with an allowed host should attempt a connection."""
+        mock_imap = MagicMock()
+        mock_imap_ssl.return_value = mock_imap
+
+        config = self._make_config(host="imap.gmail.com")
+        result = check_mail_connectivity.check_imap(config)
+
+        self.assertTrue(result["success"])
+        mock_imap_ssl.assert_called_once()
+
+    @patch("check_mail_connectivity.smtplib.SMTP_SSL")
+    def test_check_smtp_rejects_disallowed_host(self, mock_smtp_ssl):
+        """check_smtp must reject a disallowed host and never open a socket."""
+        app_secret = secrets.token_hex(16)
+        config = self._make_config(host="internal.evil.com", app_secret=app_secret)
+
+        result = check_mail_connectivity.check_smtp(config)
+
+        self.assertFalse(result["success"])
+        self.assertIn("not in the allowed server list", result["error"])
+        self.assertNotIn(app_secret, result["error"])
+        mock_smtp_ssl.assert_not_called()
+
+    @patch("check_mail_connectivity.smtplib.SMTP_SSL")
+    def test_check_smtp_allows_allowed_host(self, mock_smtp_ssl):
+        """check_smtp with an allowed host should attempt a connection."""
+        mock_smtp = MagicMock()
+        mock_smtp_ssl.return_value = mock_smtp
+
+        config = self._make_config(host="smtp.gmail.com")
+        result = check_mail_connectivity.check_smtp(config)
+
+        self.assertTrue(result["success"])
+        mock_smtp_ssl.assert_called_once()
+
+
+class TestEmailAccountConfigSMTPField(unittest.TestCase):
+    """Sanity checks for the new smtp_server field on EmailAccountConfig."""
+
+    def test_smtp_server_field_default(self):
+        """EmailAccountConfig still works without an explicit smtp_server."""
+        config = _make_email_config()
+        self.assertIsNone(config.smtp_server)
+
+    def test_smtp_server_field_set(self):
+        """EmailAccountConfig can carry an smtp_server value."""
+        config = _make_email_config(smtp_server="smtp.gmail.com")
+        self.assertEqual(config.smtp_server, "smtp.gmail.com")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a hard-coded, normalized hostname allowlist for every IMAP/SMTP connection point so attacker-controlled `*_IMAP_SERVER` / `*_SMTP_SERVER` environment variables cannot be used for SSRF or credential leakage.

Closes ABHI-1685

## What Changed and Why

- **Unified allowlist validator** (`src/utils/security_validators.py`):
  - `validate_mail_server_host(host)` normalizes input (`lower`, `strip`, `rstrip('.')`) and checks against an immutable `ALLOWED_MAIL_SERVER_HOSTS` frozenset.
  - Allowlist includes `127.0.0.1`, `localhost`, `host.docker.internal`, `imap.gmail.com`, `outlook.office365.com`, `smtp.gmail.com`, and `smtp.office365.com`.
  - The allowlist is **not** configurable; a configurable list would itself be attacker-controllable via environment variables.

- **Config validation** (`src/utils/config.py`):
  - `EmailAccountConfig` now carries `smtp_server` and normalizes both `imap_server` and `smtp_server` in `__post_init__`.
  - `_load_email_accounts()` reads `*_SMTP_SERVER` for each provider and treats blank `*_IMAP_SERVER` / `*_SMTP_SERVER` values as the provider default.
  - `_validate_email_accounts()` validates both `imap_server` and `smtp_server` through the allowlist, aggregating generic, credential-free errors.
  - Merged `origin/main` to resolve the `is_safe_email` import and keep validation in sync with the latest `main`.

- **Standalone scripts and entry points**:
  - `scripts/check_mail_connectivity.py` calls `validate_mail_server_host()` at the top of `check_imap()` and `check_smtp()` before opening any socket, and now treats blank `*_IMAP_SERVER` / `*_SMTP_SERVER` env vars as the provider default.
  - `diagnose_docker_connectivity.py` validates the host before attempting an IMAP connection, now exits non-zero on validation/auth failure, and treats blank server env vars as the provider default.
  - `scripts/diagnose_connectivity.py` validates email account configuration (not unrelated alert/system settings) before instantiating `EmailIngestionManager`.
  - `src/app_runner.py` runs full `Config.validate()` during startup.
  - Root `test_config.py` now runs `Config.validate()` before attempting connections.

- **Agent skill** (`.agents/skills/testing-email-security-pipeline-locally/SKILL.md`):
  - Documents how to exercise the allowlist gate and run the pipeline/diagnostic scripts with generated `.env` fixtures without real credentials.

- **Tests** (`tests/test_mail_server_validation.py`):
  - Covers allowed hosts, disallowed hosts, case/whitespace/trailing-dot normalization, and credential-free error output.
  - Covers `Config.validate()` and `scripts/check_mail_connectivity.py`.

## How Was This Tested

- `python3 -m pytest` — **754 passed**.
- `python3 -m pre_commit run --all-files` — all hooks passed.
- End-to-end validation against generated `.env` fixtures (allowed/disallowed/blank hosts) for `src.main`, `scripts/check_mail_connectivity.py`, `scripts/diagnose_connectivity.py`, and `diagnose_docker_connectivity.py`.
- Host normalization verified against case, whitespace, and trailing-dot variants.
- No real mailbox credentials were used; live fetch after auth was not verified.

## Security Implications

- This PR touches external network calls and credential handling.
- No secrets or credentials are introduced or exposed.
- Error messages from the validator include only the rejected hostname, never the account password.

## Checklist

- [x] Branch follows naming convention (`fix/`)
- [x] Commit messages are clear and descriptive
- [x] New or modified code includes relevant tests
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No secrets, credentials, or `.env` files are included in this PR

Link to Devin session: https://app.devin.ai/sessions/6a6e87e0f89b4d48bab01fbe0bfc5f49
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->