### PR TITLE
fix(security): ABHI-1686 validate email before subprocess and config use

### DIFF
--- a/scripts/diagnose_connectivity.py
+++ b/scripts/diagnose_connectivity.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from src.modules.email_ingestion import EmailIngestionManager
 from src.utils.config import Config
+from src.utils.security_validators import is_safe_email
 
 # Set up basic logging
 logging.basicConfig(
@@ -30,6 +31,10 @@ def main():
     )
     parser.add_argument("email", help="The email address of the account to diagnose.")
     args = parser.parse_args()
+
+    if not is_safe_email(args.email):
+        logging.error(f"Invalid or unsafe email address: {args.email}")
+        sys.exit(1)
 
     # Load email configurations from environment variables
     config = Config()

--- a/scripts/diagnose_connectivity.py
+++ b/scripts/diagnose_connectivity.py
@@ -33,7 +33,8 @@ def main():
     args = parser.parse_args()
 
     if not is_safe_email(args.email):
-        logging.error(f"Invalid or unsafe email address: {args.email}")
+        # Use %r and truncation to prevent log-forging from attacker-controlled input.
+        logging.error("Invalid or unsafe email address: %r", args.email[:80])
         sys.exit(1)
 
     # Load email configurations from environment variables

--- a/scripts/diagnose_connectivity.py
+++ b/scripts/diagnose_connectivity.py
@@ -12,8 +12,6 @@ import sys
 # Add the project root directory to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from src.modules.email_ingestion import EmailIngestionManager
-from src.utils.config import Config
 from src.utils.security_validators import is_safe_email
 
 # Set up basic logging
@@ -36,6 +34,10 @@ def main():
         # Use %r and truncation to prevent log-forging from attacker-controlled input.
         logging.error("Invalid or unsafe email address: %r", args.email[:80])
         sys.exit(1)
+
+    # Import heavier project modules only after input validation succeeds.
+    from src.modules.email_ingestion import EmailIngestionManager
+    from src.utils.config import Config
 
     # Load email configurations from environment variables
     config = Config()

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -287,8 +287,10 @@ class Config:
             if not account.email or not account.app_password:
                 errors.append(f"Missing credentials for {account.provider} account")
             elif not is_safe_email(account.email):
+                # Avoid echoing long/attacker-controlled values verbatim.
+                email_display = str(account.email)[:80]
                 errors.append(
-                    f"Invalid email format for {account.provider} account: {account.email}"
+                    f"Invalid email format for {account.provider} account: {email_display!r}"
                 )
             if not account.folders:
                 errors.append(f"No folders configured for {account.provider} account")

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 from dotenv import load_dotenv
 
-from .security_validators import is_safe_webhook_url
+from .security_validators import is_safe_email, is_safe_webhook_url
 
 
 class ConfigurationError(Exception):
@@ -286,6 +286,10 @@ class Config:
         for account in self.email_accounts:
             if not account.email or not account.app_password:
                 errors.append(f"Missing credentials for {account.provider} account")
+            elif not is_safe_email(account.email):
+                errors.append(
+                    f"Invalid email format for {account.provider} account: {account.email}"
+                )
             if not account.folders:
                 errors.append(f"No folders configured for {account.provider} account")
             if account.imap_port <= 0:

--- a/src/utils/security_validators.py
+++ b/src/utils/security_validators.py
@@ -133,13 +133,29 @@ _MAX_EMAIL_LENGTH = 254
 
 # Whitelist pattern for an email address.
 # Local part allows letters, digits, dots, underscores, percent, plus, and hyphens.
-# Domain part follows hostname-style characters (letters, digits, underscores,
-# dots, and hyphens) to remain compatible with the setup wizard validator.
+# Domain part follows hostname-style ASCII characters (letters, digits, dots,
+# and hyphens) to keep the whitelist strict and avoid Unicode/underscore drift.
 # The TLD is required to be at least two letters.
 # Does NOT allow shell metacharacters such as ; | & ` $ < > \ or whitespace.
 _SAFE_EMAIL_PATTERN = re.compile(
-    r"^[a-zA-Z0-9._%+-]+@[\w.-]+\.[a-zA-Z]{2,}$"
+    r"^[a-zA-Z0-9._%+-]+@[A-Za-z0-9.-]+\.[a-zA-Z]{2,}$"
 )
+
+
+def _is_safe_label(label: str) -> bool:
+    """Return True if a domain label does not start/end with '.' or '-'."""
+    if not label:
+        return False
+    if label.startswith((".", "-")) or label.endswith((".", "-")):
+        return False
+    return True
+
+
+def _is_safe_local(local: str) -> bool:
+    """Return True if the local part does not start/end with '.' or '-'."""
+    if local.startswith((".", "-")) or local.endswith((".", "-")):
+        return False
+    return True
 
 
 def is_safe_email(email: str) -> bool:
@@ -174,13 +190,11 @@ def is_safe_email(email: str) -> bool:
 
     local, _, domain = email.partition("@")
 
-    # Local part must not start/end with a dot or hyphen.
-    if local.startswith((".", "-")) or local.endswith((".", "-")):
+    if not _is_safe_local(local):
         return False
 
-    # Domain labels must not start/end with a dot or hyphen and must be non-empty.
     for label in domain.split("."):
-        if not label or label.startswith((".", "-")) or label.endswith((".", "-")):
+        if not _is_safe_label(label):
             return False
 
     return True

--- a/src/utils/security_validators.py
+++ b/src/utils/security_validators.py
@@ -144,18 +144,14 @@ _SAFE_EMAIL_PATTERN = re.compile(
 
 def _is_safe_label(label: str) -> bool:
     """Return True if a domain label does not start/end with '.' or '-'."""
-    if not label:
-        return False
-    if label.startswith((".", "-")) or label.endswith((".", "-")):
-        return False
-    return True
+    return bool(label) and not (
+        label.startswith((".", "-")) or label.endswith((".", "-"))
+    )
 
 
 def _is_safe_local(local: str) -> bool:
     """Return True if the local part does not start/end with '.' or '-'."""
-    if local.startswith((".", "-")) or local.endswith((".", "-")):
-        return False
-    return True
+    return not (local.startswith((".", "-")) or local.endswith((".", "-")))
 
 
 def is_safe_email(email: str) -> bool:
@@ -179,10 +175,6 @@ def is_safe_email(email: str) -> bool:
 
     # Reject consecutive dots anywhere in the address.
     if ".." in email:
-        return False
-
-    # Reject addresses that start or end with a dot.
-    if email.startswith(".") or email.endswith("."):
         return False
 
     if not _SAFE_EMAIL_PATTERN.match(email):

--- a/src/utils/security_validators.py
+++ b/src/utils/security_validators.py
@@ -128,6 +128,64 @@ def sanitize_filename(filename: str) -> str:
     return sanitized[:255]
 
 
+# Maximum length for a valid email address (RFC 5321)
+_MAX_EMAIL_LENGTH = 254
+
+# Whitelist pattern for an email address.
+# Local part allows letters, digits, dots, underscores, percent, plus, and hyphens.
+# Domain part follows hostname-style characters (letters, digits, underscores,
+# dots, and hyphens) to remain compatible with the setup wizard validator.
+# The TLD is required to be at least two letters.
+# Does NOT allow shell metacharacters such as ; | & ` $ < > \ or whitespace.
+_SAFE_EMAIL_PATTERN = re.compile(
+    r"^[a-zA-Z0-9._%+-]+@[\w.-]+\.[a-zA-Z]{2,}$"
+)
+
+
+def is_safe_email(email: str) -> bool:
+    """
+    Validate an email address for safe use in command arguments and IMAP config.
+
+    SECURITY STORY: Email addresses loaded from user configuration are passed
+    directly to subprocess calls and IMAP clients. A malicious value could
+    contain shell metacharacters (e.g., `;`, `|`, `&`, backticks) or be
+    interpreted as a command-line flag (e.g., a leading `-`). This validator
+    uses a strict whitelist to reject unsafe characters and structural issues.
+
+    Args:
+        email: Email address to validate.
+
+    Returns:
+        True if the email appears safe and well-formed, False otherwise.
+    """
+    if not isinstance(email, str) or len(email) > _MAX_EMAIL_LENGTH:
+        return False
+
+    # Reject consecutive dots anywhere in the address.
+    if ".." in email:
+        return False
+
+    # Reject addresses that start or end with a dot.
+    if email.startswith(".") or email.endswith("."):
+        return False
+
+    if not _SAFE_EMAIL_PATTERN.match(email):
+        return False
+
+    local, _, domain = email.partition("@")
+
+    # Local part must not start/end with a dot or hyphen.
+    if local.startswith((".", "-")) or local.endswith((".", "-")):
+        return False
+
+    # Domain labels must not start/end with a dot or hyphen and must be non-empty.
+    for label in domain.split("."):
+        if not label or label.startswith((".", "-")) or label.endswith((".", "-")):
+            return False
+
+    return True
+
+
 def create_secure_ssl_context() -> ssl.SSLContext:
     """
     Create a secure SSL context with modern TLS settings.

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -28,17 +28,17 @@ class WizardSkipped(Exception):
     """Raised when the user intentionally skips interactive setup."""
 
 
+from src.utils.security_validators import is_safe_email
+
 try:
     from src.modules.imap_connection import IMAPConnection
     from src.utils.config import EmailAccountConfig
-    from src.utils.security_validators import is_safe_email
     from src.utils.ui import Spinner
 except ImportError:
     # If these imports fail, we might be in a constrained environment
     # or running standalone without full context. We can't verify credentials.
     EmailAccountConfig = None
     IMAPConnection = None
-    is_safe_email = None
     Spinner = None
 
 # Centralized Outlook troubleshooting tip to avoid duplication/drift
@@ -49,13 +49,7 @@ OUTLOOK_AUTH_ERROR_TIP = Colors.colorize(
 
 def _is_valid_email(email: str) -> bool:
     """Check if the email format is valid."""
-    if is_safe_email is not None:
-        return is_safe_email(email)
-    # Fallback if the shared validator is unavailable.
-    if ".." in email:
-        return False
-    pattern = r"^[\w\.\-\+]+@[\w\.-]+\.\w+$"
-    return re.match(pattern, email) is not None
+    return is_safe_email(email)
 
 
 def _styled_input(prompt: str) -> str:

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -31,12 +31,14 @@ class WizardSkipped(Exception):
 try:
     from src.modules.imap_connection import IMAPConnection
     from src.utils.config import EmailAccountConfig
+    from src.utils.security_validators import is_safe_email
     from src.utils.ui import Spinner
 except ImportError:
     # If these imports fail, we might be in a constrained environment
     # or running standalone without full context. We can't verify credentials.
     EmailAccountConfig = None
     IMAPConnection = None
+    is_safe_email = None
     Spinner = None
 
 # Centralized Outlook troubleshooting tip to avoid duplication/drift
@@ -47,10 +49,11 @@ OUTLOOK_AUTH_ERROR_TIP = Colors.colorize(
 
 def _is_valid_email(email: str) -> bool:
     """Check if the email format is valid."""
-    # Disallow consecutive dots
+    if is_safe_email is not None:
+        return is_safe_email(email)
+    # Fallback if the shared validator is unavailable.
     if ".." in email:
         return False
-    # Simple regex for email validation (supports aliases with +)
     pattern = r"^[\w\.\-\+]+@[\w\.-]+\.\w+$"
     return re.match(pattern, email) is not None
 

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -28,7 +28,12 @@ class WizardSkipped(Exception):
     """Raised when the user intentionally skips interactive setup."""
 
 
-from src.utils.security_validators import is_safe_email
+try:
+    from src.utils.security_validators import is_safe_email
+except ImportError:
+    # Allow running this file directly from src/utils/ when the package root
+    # is not on sys.path (the module only depends on the standard library).
+    from security_validators import is_safe_email
 
 try:
     from src.modules.imap_connection import IMAPConnection

--- a/test_config.py
+++ b/test_config.py
@@ -13,6 +13,8 @@ from typing import Optional
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent))
 
+from src.utils.security_validators import is_safe_email
+
 
 def test_config_loading():
     """Test that configuration loads correctly."""
@@ -310,8 +312,13 @@ def _run_diagnostics_script(
     script_path: str, email: str
 ) -> subprocess.CompletedProcess:
     """Run the diagnostics script and return the result."""
+    if not is_safe_email(email):
+        raise ValueError(f"Invalid or unsafe email address for diagnostics: {email}")
+
+    # nosec B603: email is validated by is_safe_email(); script_path is a
+    # repository-controlled constant, not user input.
     return subprocess.run(
-        ["python3", script_path, email],
+        [sys.executable, script_path, email],
         capture_output=True,
         text=True,
         check=False,

--- a/test_config.py
+++ b/test_config.py
@@ -13,8 +13,6 @@ from typing import Optional
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent))
 
-from src.utils.security_validators import is_safe_email
-
 
 def test_config_loading():
     """Test that configuration loads correctly."""
@@ -312,12 +310,12 @@ def _run_diagnostics_script(
     script_path: str, email: str
 ) -> subprocess.CompletedProcess:
     """Run the diagnostics script and return the result."""
+    from src.utils.security_validators import is_safe_email
+
     if not is_safe_email(email):
         raise ValueError(f"Invalid or unsafe email address for diagnostics: {email}")
 
-    # nosec B603: email is validated by is_safe_email(); script_path is a
-    # repository-controlled constant, not user input.
-    return subprocess.run(
+    return subprocess.run(  # nosec B603: email is validated by is_safe_email(); script_path is a repository-controlled constant, not user input.
         [sys.executable, script_path, email],
         capture_output=True,
         text=True,

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -163,7 +163,8 @@ class TestEmailValidation(unittest.TestCase):
             "GMAIL_FOLDERS": "INBOX",
             "GMAIL_USE_SSL": "true",
         }
-        with patch.dict(os.environ, env, clear=False):
+        # Use clear=True so ambient environment variables cannot affect these tests.
+        with patch.dict(os.environ, env, clear=True):
             config = Config(env_file="nonexistent.env")
             try:
                 config.validate()

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -1,5 +1,6 @@
 import os
-import subprocess
+import secrets
+import subprocess  # nosec B404
 import sys
 import unittest
 from pathlib import Path
@@ -8,6 +9,9 @@ from unittest.mock import patch
 import test_config
 from src.utils.config import AlertConfig, AnalysisConfig, Config, ConfigurationError, EmailAccountConfig
 from src.utils.security_validators import is_safe_email
+
+# Deterministic-feeling secret for tests; generated so it is not a hardcoded password.
+_TEST_APP_SECRET = secrets.token_hex(16)
 
 
 class TestConfigSecurity(unittest.TestCase):
@@ -144,11 +148,16 @@ class TestEmailValidation(unittest.TestCase):
         for email in malformed:
             self.assertFalse(is_safe_email(email), f"Expected malformed: {email}")
 
-    def test_config_validate_rejects_malformed_email(self):
+    def _validate_email_env(self, email: str) -> str | None:
+        """Build a minimal Gmail config with the given email and validate it.
+
+        Returns the ConfigurationError message if validation fails, or None
+        if validation succeeds.
+        """
         env = {
             "GMAIL_ENABLED": "true",
-            "GMAIL_EMAIL": "bad;email@example.com",
-            "GMAIL_APP_PASSWORD": "test_password",
+            "GMAIL_EMAIL": email,
+            "GMAIL_APP_PASSWORD": _TEST_APP_SECRET,
             "GMAIL_IMAP_SERVER": "imap.gmail.com",
             "GMAIL_IMAP_PORT": "993",
             "GMAIL_FOLDERS": "INBOX",
@@ -156,23 +165,19 @@ class TestEmailValidation(unittest.TestCase):
         }
         with patch.dict(os.environ, env, clear=False):
             config = Config(env_file="nonexistent.env")
-            with self.assertRaises(ConfigurationError) as ctx:
+            try:
                 config.validate()
-            self.assertIn("Invalid email format", str(ctx.exception))
+                return None
+            except ConfigurationError as exc:
+                return str(exc)
+
+    def test_config_validate_rejects_malformed_email(self):
+        error = self._validate_email_env("bad;email@example.com")
+        self.assertIsNotNone(error)
+        self.assertIn("Invalid email format", error)
 
     def test_config_validate_accepts_valid_email(self):
-        env = {
-            "GMAIL_ENABLED": "true",
-            "GMAIL_EMAIL": "valid@gmail.com",
-            "GMAIL_APP_PASSWORD": "test_password",
-            "GMAIL_IMAP_SERVER": "imap.gmail.com",
-            "GMAIL_IMAP_PORT": "993",
-            "GMAIL_FOLDERS": "INBOX",
-            "GMAIL_USE_SSL": "true",
-        }
-        with patch.dict(os.environ, env, clear=False):
-            config = Config(env_file="nonexistent.env")
-            self.assertTrue(config.validate())
+        self.assertIsNone(self._validate_email_env("valid@gmail.com"))
 
     def test_run_diagnostics_script_rejects_unsafe_email(self):
         with self.assertRaises(ValueError):
@@ -197,11 +202,12 @@ class TestDiagnoseConnectivityValidation(unittest.TestCase):
     def test_rejects_unsafe_email_argument(self):
         repo_root = Path(__file__).resolve().parents[1]
         script = repo_root / "scripts" / "diagnose_connectivity.py"
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             [sys.executable, str(script), "bad;email@example.com"],
             cwd=repo_root,
             capture_output=True,
             text=True,
+            timeout=30,
         )
         self.assertEqual(result.returncode, 1)
         self.assertIn("Invalid or unsafe email address", result.stderr)

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -1,6 +1,13 @@
+import os
+import subprocess
+import sys
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
-from src.utils.config import AlertConfig, AnalysisConfig, EmailAccountConfig
+import test_config
+from src.utils.config import AlertConfig, AnalysisConfig, Config, ConfigurationError, EmailAccountConfig
+from src.utils.security_validators import is_safe_email
 
 
 class TestConfigSecurity(unittest.TestCase):
@@ -77,6 +84,127 @@ class TestConfigSecurity(unittest.TestCase):
             repr_str,
             "deepfake_api_key field name shouldn't be in __repr__ if excluded",
         )
+
+
+class TestEmailValidation(unittest.TestCase):
+    """SECURITY STORY: Email addresses from configuration must be validated
+    before being passed to subprocesses or IMAP clients. These tests guard
+    against command-injection vectors and argparse option-injection via
+    malformed addresses."""
+
+    def test_is_safe_email_accepts_valid_addresses(self):
+        valid_emails = [
+            "test@example.com",
+            "user.name+tag@sub.domain.co.uk",
+            "user_name@example.com",
+            "user-name@example.com",
+            "user%name@example.com",
+            "a@b.co",
+        ]
+        for email in valid_emails:
+            self.assertTrue(is_safe_email(email), f"Expected valid: {email}")
+
+    def test_is_safe_email_rejects_shell_metacharacters(self):
+        unsafe_emails = [
+            "user;cmd@example.com",
+            "user|cmd@example.com",
+            "user&cmd@example.com",
+            "user`cmd@example.com",
+            "user$(cmd)@example.com",
+            "user$var@example.com",
+            "user<foo@example.com",
+            "user>foo@example.com",
+            "user\\foo@example.com",
+            "user foo@example.com",
+            "user\tfoo@example.com",
+            "user\ncmd@example.com",
+        ]
+        for email in unsafe_emails:
+            self.assertFalse(is_safe_email(email), f"Expected unsafe: {email}")
+
+    def test_is_safe_email_rejects_structural_issues(self):
+        malformed = [
+            "invalid-email",
+            "user@",
+            "@domain.com",
+            "user@domain",
+            "user..name@domain.com",
+            ".user@example.com",
+            "user.@example.com",
+            "-user@example.com",
+            "user@-example.com",
+            "user@example-.com",
+            "user@.example.com",
+            "user@example.com.",
+            "user@example..com",
+            "user@example.c",
+            "",
+            "a" * 250 + "@example.com",  # exceeds 254 char max
+        ]
+        for email in malformed:
+            self.assertFalse(is_safe_email(email), f"Expected malformed: {email}")
+
+    def test_config_validate_rejects_malformed_email(self):
+        env = {
+            "GMAIL_ENABLED": "true",
+            "GMAIL_EMAIL": "bad;email@example.com",
+            "GMAIL_APP_PASSWORD": "test_password",
+            "GMAIL_IMAP_SERVER": "imap.gmail.com",
+            "GMAIL_IMAP_PORT": "993",
+            "GMAIL_FOLDERS": "INBOX",
+            "GMAIL_USE_SSL": "true",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            config = Config(env_file="nonexistent.env")
+            with self.assertRaises(ConfigurationError) as ctx:
+                config.validate()
+            self.assertIn("Invalid email format", str(ctx.exception))
+
+    def test_config_validate_accepts_valid_email(self):
+        env = {
+            "GMAIL_ENABLED": "true",
+            "GMAIL_EMAIL": "valid@gmail.com",
+            "GMAIL_APP_PASSWORD": "test_password",
+            "GMAIL_IMAP_SERVER": "imap.gmail.com",
+            "GMAIL_IMAP_PORT": "993",
+            "GMAIL_FOLDERS": "INBOX",
+            "GMAIL_USE_SSL": "true",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            config = Config(env_file="nonexistent.env")
+            self.assertTrue(config.validate())
+
+    def test_run_diagnostics_script_rejects_unsafe_email(self):
+        with self.assertRaises(ValueError):
+            test_config._run_diagnostics_script(
+                "scripts/diagnose_connectivity.py", "bad;email@example.com"
+            )
+
+    def test_run_diagnostics_script_passes_valid_email(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = unittest.mock.MagicMock()
+            test_config._run_diagnostics_script(
+                "scripts/diagnose_connectivity.py", "valid@example.com"
+            )
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            self.assertEqual(args[0], sys.executable)
+            self.assertEqual(args[1], "scripts/diagnose_connectivity.py")
+            self.assertEqual(args[2], "valid@example.com")
+
+
+class TestDiagnoseConnectivityValidation(unittest.TestCase):
+    def test_rejects_unsafe_email_argument(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        script = repo_root / "scripts" / "diagnose_connectivity.py"
+        result = subprocess.run(
+            [sys.executable, str(script), "bad;email@example.com"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Invalid or unsafe email address", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
  Thank you for contributing to the Email Security Pipeline!
  Please fill in as much of the template as possible. Reviewers use this
  information to understand the purpose and safety of your changes.
-->

## Summary

Adds a shared `is_safe_email()` validator and wires it into the subprocess invocation in `test_config.py`, `Config.validate()`, `scripts/diagnose_connectivity.py`, and `setup_wizard.py` to close the potential command-injection / argparse option-injection vector described in ABHI-1686.

Closes #1426

---

## Type of Change

- [x] `fix` – bug fix
- [x] `test` – test additions or improvements

---

## What Changed and Why

- Added `is_safe_email()` to `src/utils/security_validators.py` with an anchored whitelist regex that rejects shell metacharacters (`;`, `|`, `&`, `` ` ``, `$`, `<`, `>`, `\`, whitespace), consecutive dots, leading/trailing dots/hyphens, and malformed domain labels. The TLD is required to be at least two letters.
- `Config._validate_email_accounts()` now calls `is_safe_email()` so malformed/weaponized addresses fail fast at config-validation time before reaching any consumer.
- `test_config.py:_run_diagnostics_script()` validates the email before `subprocess.run`, switches from the bare `python3` interpreter to `sys.executable`, and adds a justified `# nosec B603`.
- `scripts/diagnose_connectivity.py` validates its CLI `email` argument before loading the config.
- `src/utils/setup_wizard.py` now delegates `_is_valid_email()` to the shared validator instead of duplicating a separate regex.
- Added regression tests in `tests/test_config_security.py` covering valid addresses, shell metacharacters, argparse option-injection (`-user@...`), structural defects (`..`, missing TLD, leading/trailing dots/hyphens), and the diagnostics-script subprocess path.

This is defense-in-depth: the current `subprocess.run` call already uses an argument list (`shell=False`), so classic shell injection is not exploitable today. The validation protects against residual risks such as argparse flag injection and provides a single source of truth for email shape checking across the codebase.

---

## How Was This Tested?

- Added unit/integration tests in `tests/test_config_security.py`.
- `python3 -m pytest` — 737 passed.
- `python3 -m pre_commit run --all-files` — passed.
- `python3 -m bandit -r . -ll -c .bandit` — no issues identified.

---

## Security Implications

- Touches input validation for an email address passed to a subprocess and IMAP configuration.
- No secrets or credentials are introduced or exposed.
- The validator is intentionally conservative: it rejects shell metacharacters and malformed addresses while remaining compatible with the existing setup-wizard test cases.

---

## Checklist

- [x] Branch follows naming convention
- [x] Commit messages are clear and descriptive
- [x] New or modified code includes relevant tests
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No secrets, credentials, or `.env` files are included in this PR

Link to Devin session: https://app.devin.ai/sessions/2a2abbbc82264877b7870bf94e9348ba
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->