### PR TITLE
🎨 Palette: Add explicit formatting hint to email prompt

### DIFF
--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -221,6 +221,7 @@ def _prompt_for_email(provider_name: str) -> str:
         prompt = (
             Colors.colorize("? ", Colors.CYAN)
             + Colors.colorize(f"Enter your {provider_name} email address ", Colors.BOLD)
+            + Colors.colorize("(e.g. user@domain.com) ", Colors.GREY)
             + Colors.colorize("*", Colors.RED)
             + Colors.colorize(": ", Colors.BOLD)
         )


### PR DESCRIPTION
* 💡 What: Added a GREY `(e.g. user@domain.com)` hint to the email prompt.
* 🎯 Why: Users might be unsure of the expected email format (e.g. username vs full address). The hint provides immediate clarity.
* 📸 Before/After: Screenshots if visual change: Terminal output now clearly displays the example format before asking for input.
* ♿ Accessibility: Reduces cognitive load and prevents validation errors before they occur.

---
*PR created automatically by Jules for task [14934008199382478428](https://jules.google.com/task/14934008199382478428) started by @abhimehro*