### PR TITLE
🎨 Palette: Prevent layout shifts in terminal timers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -578,3 +578,6 @@ throughout the entire lifecycle of the countdown element.
 ## 2025-03-02 - Dynamic Log Highlighting by Risk Level
 **Learning:** Hardcoding success colors (like GREEN) for operation completions is dangerous UX when the operation result itself represents a high-severity alert (e.g. "Analysis complete: risk=HIGH"). Green signals safety, contradicting the high-risk state.
 **Action:** Always parse the context or risk level in log formatters before applying semantic colors to completion messages, ensuring the visual cue matches the actual risk state.
+## 2025-03-02 - Fixed Widths for Dynamic Time Displays
+**Learning:** When displaying dynamic textual time elements like elapsed time on a terminal spinner, dynamically varying widths (e.g., from `[0.1s]` to `[1.0s]`, or `[9.9s]` to `[10.0s]`) causes horizontal visual layout shifts that are jarring and degrade the overall UX. Also, persisting the elapsed time when it is less than 1.0s ensures consistent visual structure.
+**Action:** Use fixed-width formatting (e.g. `[{elapsed:4.1f}s]`) for dynamic time displays to ensure consistent character length and prevent horizontal layout shifts during rapid updates. Show the timer display string even when time is < 1s to match the fixed width from the start.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -56,7 +56,8 @@ class CountdownTimer:
                 if self.duration >= 60:
                     time_str = f"{remaining // 60:02d}:{remaining % 60:02d}"
                 else:
-                    time_str = f"{remaining}s"
+                    width = len(str(self.duration))
+                    time_str = f"{remaining:{width}d}s"
 
                 # Progress bar
                 pct = remaining / self.duration if self.duration > 0 else 0
@@ -142,11 +143,8 @@ class Spinner:
 
         while self.busy:
             elapsed = time.time() - getattr(self, "start_time", time.time())
-            time_str = (
-                Colors.colorize(f" [{elapsed:.1f}s]", Colors.GREY)
-                if elapsed >= 1.0
-                else ""
-            )
+            # UX: Fixed width time display to prevent horizontal layout shift
+            time_str = Colors.colorize(f" [{elapsed:4.1f}s]", Colors.GREY) if elapsed >= 0.1 else ""
             # \r moves cursor to start of line, \033[K clears the line
             spin_char = Colors.colorize(next(self.spinner), Colors.CYAN)
             display_msg = self.message
@@ -226,7 +224,8 @@ class Spinner:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         elapsed = time.time() - getattr(self, "start_time", time.time())
-        raw_time_str = f" [{elapsed:.1f}s]" if elapsed >= 1.0 else ""
+        # UX: Ensure completion matches the fixed width format
+        raw_time_str = f" [{elapsed:4.1f}s]"
 
         symbol, msg = self._get_final_message_components(exc_type)
 

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -141,16 +141,16 @@ class Spinner:
         # the initial message before the loop starts rapidly redrawing.
         time.sleep(0.1)
 
+        display_msg = self.message
+        if sys.stdout.isatty() and CTRL_C_HINT not in display_msg:
+            display_msg += Colors.colorize(CTRL_C_HINT, Colors.GREY)
+
         while self.busy:
             elapsed = time.time() - getattr(self, "start_time", time.time())
-            # UX: Fixed width time display to prevent horizontal layout shift
             time_str = Colors.colorize(f" [{elapsed:4.1f}s]", Colors.GREY) if elapsed >= 0.1 else ""
+
             # \r moves cursor to start of line, \033[K clears the line
             spin_char = Colors.colorize(next(self.spinner), Colors.CYAN)
-            display_msg = self.message
-            if sys.stdout.isatty():
-                if CTRL_C_HINT not in display_msg:
-                    display_msg += Colors.colorize(CTRL_C_HINT, Colors.GREY)
             sys.stdout.write(f"\r{spin_char} {display_msg}{time_str}   \033[K")
             sys.stdout.flush()
             time.sleep(self.delay)
@@ -224,7 +224,6 @@ class Spinner:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         elapsed = time.time() - getattr(self, "start_time", time.time())
-        # UX: Ensure completion matches the fixed width format
         raw_time_str = f" [{elapsed:4.1f}s]"
 
         symbol, msg = self._get_final_message_components(exc_type)

--- a/tests/test_ui_spinner.py
+++ b/tests/test_ui_spinner.py
@@ -201,7 +201,7 @@ class TestSpinner(unittest.TestCase):
             time.sleep(0.15)
 
         output = mock_stdout.getvalue()
-        self.assertRegex(output, r"\[1\.\d+s\]")
+        self.assertRegex(output, r"\[\s*1\.\d+s\]")
         self.assertIn("Press Ctrl+C to stop", output)
 
     @patch("sys.stdout", new_callable=StringIO)


### PR DESCRIPTION
* 💡 What: Use fixed-width formatting for dynamic time components (countdown, elapsed time spinner).
* 🎯 Why: Prevent jarring horizontal terminal layout shifts during updates.
* 📸 Before/After: Screenshots if visual change (N/A terminal UI output stability)
* ♿ Accessibility: Smoother UI progression without jarring redraw jumps.

---
*PR created automatically by Jules for task [3871969708708804601](https://jules.google.com/task/3871969708708804601) started by @abhimehro*