### PR TITLE
🎨 Palette: Fix visual shift in spinner elapsed time

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -581,3 +581,7 @@ throughout the entire lifecycle of the countdown element.
 ## 2025-03-02 - Fixed Widths for Dynamic Time Displays
 **Learning:** When displaying dynamic textual time elements like elapsed time on a terminal spinner, dynamically varying widths (e.g., from `[0.1s]` to `[1.0s]`, or `[9.9s]` to `[10.0s]`) causes horizontal visual layout shifts that are jarring and degrade the overall UX. Also, persisting the elapsed time when it is less than 1.0s ensures consistent visual structure.
 **Action:** Use fixed-width formatting (e.g. `[{elapsed:4.1f}s]`) for dynamic time displays to ensure consistent character length and prevent horizontal layout shifts during rapid updates. Show the timer display string even when time is < 1s to match the fixed width from the start.
+
+## 2026-08-10 - Prevent Layout Shift in Dynamic Timers
+**Learning:** Toggling the visibility of dynamic elements (like a timer) based on elapsed time causes horizontal visual layout shifts that are jarring.
+**Action:** Unconditionally display the timer using fixed-width formatting (e.g. `[{elapsed:4.1f}s]`) from the start.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -147,7 +147,7 @@ class Spinner:
 
         while self.busy:
             elapsed = time.time() - getattr(self, "start_time", time.time())
-            time_str = Colors.colorize(f" [{elapsed:4.1f}s]", Colors.GREY) if elapsed >= 0.1 else ""
+            time_str = Colors.colorize(f" [{elapsed:4.1f}s]", Colors.GREY)
 
             # \r moves cursor to start of line, \033[K clears the line
             spin_char = Colors.colorize(next(self.spinner), Colors.CYAN)


### PR DESCRIPTION
* 💡 **What:** Ensured spinner elapsed time uses consistent fixed-width formatting unconditionally.
* 🎯 **Why:** To prevent jarring horizontal layout shifts during rapid terminal updates.
* 📸 **Before/After:** Not applicable.
* ♿ **Accessibility:** Prevents layout shifting that might confuse users or screen readers tracking terminal output.

---
*PR created automatically by Jules for task [7679063661850298225](https://jules.google.com/task/7679063661850298225) started by @abhimehro*