### PR TITLE
🎨 Palette: Prevent layout shift in dynamic timers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -585,3 +585,7 @@ throughout the entire lifecycle of the countdown element.
 ## 2026-08-10 - Prevent Layout Shift in Dynamic Timers
 **Learning:** Toggling the visibility of dynamic elements (like a timer) based on elapsed time causes horizontal visual layout shifts that are jarring.
 **Action:** Unconditionally display the timer using fixed-width formatting (e.g. `[{elapsed:4.1f}s]`) from the start.
+
+## 2024-08-12 - Prevent layout shift in countdown timers
+**Learning:** Screen readers and terminal UIs suffer from layout shifting when dynamic elements like a countdown timer don't immediately display the full initial state before the rapid drawing loop starts.
+**Action:** When initializing terminal UI components like a `CountdownTimer` or a `Spinner` that rapidly updates using carriage returns, always render an initial static frame that includes the full progress bar, initial timer, and exact required formatting before the loop begins. This prevents horizontal layout shift and gives screen readers a stable state to announce.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -166,16 +166,20 @@ class Spinner:
             if not self.busy:
                 break
 
+    def _get_tty_msg(self) -> str:
+        if CTRL_C_HINT in self.message:
+            return self.message
+        return self.message + Colors.colorize(CTRL_C_HINT, Colors.GREY)
+
+    def _get_non_tty_msg(self) -> str:
+        return self.message if self.message.endswith("...") else f"{self.message}..."
+
     def __enter__(self):
         self.start_time = time.time()
         if sys.stdout.isatty():
-            display_msg = self.message
-            if CTRL_C_HINT not in display_msg:
-                display_msg += Colors.colorize(CTRL_C_HINT, Colors.GREY)
-            self._start_tty_spinner(display_msg)
+            self._start_tty_spinner(self._get_tty_msg())
         else:
-            msg = self.message if self.message.endswith("...") else f"{self.message}..."
-            print(msg)
+            print(self._get_non_tty_msg())
         return self
 
     def _start_tty_spinner(self, msg: str):

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -40,10 +40,18 @@ class CountdownTimer:
         sys.stdout.write(CURSOR_HIDE)
         sys.stdout.flush()
 
-        # Accessibility: Print an initial static line so screen readers
-        # have a chance to read the message before we start rapidly
-        # clearing and redrawing it with carriage returns.
-        sys.stdout.write(f"{self.message}...")
+        # Format initial time based on duration to prevent layout shift
+        if self.duration >= 60:
+            initial_time = f"{self.duration // 60:02d}:{self.duration % 60:02d}"
+        else:
+            width = len(str(self.duration))
+            initial_time = f"{self.duration:{width}d}s"
+
+        # Accessibility & UX: Print an initial static frame so screen readers
+        # have a chance to read the message and prevent layout shift before the loop.
+        full_bar = "█" * self.PROGRESS_BAR_WIDTH
+        colored_bar = Colors.colorize(full_bar, Colors.CYAN)
+        sys.stdout.write(f"{self.message}: {colored_bar} {initial_time}")
         sys.stdout.flush()
 
         try:
@@ -166,11 +174,10 @@ class Spinner:
             if CTRL_C_HINT not in display_msg:
                 display_msg += Colors.colorize(CTRL_C_HINT, Colors.GREY)
 
-        msg = display_msg if display_msg.endswith("...") else f"{display_msg}..."
-
         if sys.stdout.isatty():
-            self._start_tty_spinner(msg)
+            self._start_tty_spinner(display_msg)
         else:
+            msg = display_msg if display_msg.endswith("...") else f"{display_msg}..."
             print(msg)
         return self
 
@@ -179,10 +186,11 @@ class Spinner:
         # Hide cursor
         sys.stdout.write(CURSOR_HIDE)
 
-        # Accessibility: Print an initial static line so screen readers
-        # have a chance to read the message before we start rapidly
-        # clearing and redrawing it with carriage returns.
-        sys.stdout.write(msg)
+        # Accessibility & UX: Print an initial static frame so screen readers
+        # can read it, and include the elapsed time to prevent layout shift.
+        initial_time = Colors.colorize(" [ 0.0s]", Colors.GREY)
+        spin_char = Colors.colorize(next(self.spinner), Colors.CYAN)
+        sys.stdout.write(f"{spin_char} {msg}{initial_time}")
         sys.stdout.flush()
 
         self.busy = True

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -168,16 +168,13 @@ class Spinner:
 
     def __enter__(self):
         self.start_time = time.time()
-        # We don't mutate self.message, we just format the display string
-        display_msg = self.message
         if sys.stdout.isatty():
+            display_msg = self.message
             if CTRL_C_HINT not in display_msg:
                 display_msg += Colors.colorize(CTRL_C_HINT, Colors.GREY)
-
-        if sys.stdout.isatty():
             self._start_tty_spinner(display_msg)
         else:
-            msg = display_msg if display_msg.endswith("...") else f"{display_msg}..."
+            msg = self.message if self.message.endswith("...") else f"{self.message}..."
             print(msg)
         return self
 

--- a/tests/test_ui_countdown.py
+++ b/tests/test_ui_countdown.py
@@ -134,7 +134,7 @@ class TestCountdownTimerTTY(unittest.TestCase):
         timer = CountdownTimer(duration=1, message="Waiting")
         timer.start()
         output = mock_stdout.getvalue()
-        self.assertIn("Waiting...", output)
+        self.assertIn("Waiting: ", output)
         self.assertIn("\r\033[K", output)  # Clears line at end
 
     @patch("time.sleep", side_effect=KeyboardInterrupt)

--- a/tests/test_ui_palette.py
+++ b/tests/test_ui_palette.py
@@ -62,11 +62,11 @@ class TestPaletteUI(TestCase):
                 spinner = Spinner("Testing")
                 spinner.__enter__()
                 # Since message is no longer mutated, verify it's passed to _start_tty_spinner correctly
-                mock_start.assert_called_with("Testing (Press Ctrl+C to stop)...")
+                mock_start.assert_called_with("Testing (Press Ctrl+C to stop)")
 
                 spinner_with_hint = Spinner("Testing (Press Ctrl+C to stop)")
                 spinner_with_hint.__enter__()
-                mock_start.assert_called_with("Testing (Press Ctrl+C to stop)...")
+                mock_start.assert_called_with("Testing (Press Ctrl+C to stop)")
 
     def _run_spinner_interrupt_test(self, is_tty: bool):
         from src.utils.ui import Spinner


### PR DESCRIPTION
* 💡 What: Added initial static frames to `CountdownTimer` and `Spinner` components that include full time/progress formatting before background loops start.
* 🎯 Why: To prevent jarring horizontal layout shifts and ensure terminal UI elements have a stable initial state when rendered, reducing visual stutter.
* 📸 Before/After: Screenshots if visual change: N/A (Terminal UI adjustment)
* ♿ Accessibility: Improves the experience for screen readers by providing a fully-formed static string to read initially, rather than a rapidly updating carriage-return loop starting in a partial state.

---
*PR created automatically by Jules for task [7543323447588272046](https://jules.google.com/task/7543323447588272046) started by @abhimehro*