### PR TITLE
🎨 Palette: Fix terminal UI layout shifts in spinner and timer components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-13 - [Fix Terminal UI Layout Shifts]
+**Learning:** When building terminal UIs, replacing unformatted placeholder text (like `Waiting...`) with dynamically sized components mid-operation causes jarring horizontal layout shifts. Screen readers also benefit from immediately parsing the full UI structure.
+**Action:** Always render the fully formatted initial state (including progress bars, zeroed timers, and colored symbols) in the static setup frame before beginning the dynamic refresh loop.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -43,7 +43,17 @@ class CountdownTimer:
         # Accessibility: Print an initial static line so screen readers
         # have a chance to read the message before we start rapidly
         # clearing and redrawing it with carriage returns.
-        sys.stdout.write(f"{self.message}...")
+        # We render the fully formatted initial state to prevent horizontal layout shifts.
+        if self.duration >= 60:
+            time_str = f"{self.duration // 60:02d}:{self.duration % 60:02d}"
+        else:
+            width = len(str(self.duration))
+            time_str = f"{self.duration:{width}d}s"
+
+        progress_bar = "█" * self.PROGRESS_BAR_WIDTH
+        colored_bar = Colors.colorize(progress_bar, Colors.CYAN)
+
+        sys.stdout.write(f"\r{self.message}: {colored_bar} {time_str} \033[K")
         sys.stdout.flush()
 
         try:
@@ -182,7 +192,15 @@ class Spinner:
         # Accessibility: Print an initial static line so screen readers
         # have a chance to read the message before we start rapidly
         # clearing and redrawing it with carriage returns.
-        sys.stdout.write(msg)
+        # We render the fully formatted initial state to prevent horizontal layout shifts.
+
+        # Remove the ellipsis that was added in __enter__ for non-TTY compat,
+        # as we are now going to draw the full spinner frame.
+        clean_msg = msg[:-3] if msg.endswith("...") else msg
+        spin_char = Colors.colorize("⠋", Colors.CYAN)
+        time_str = Colors.colorize(" [ 0.0s]", Colors.GREY)
+
+        sys.stdout.write(f"\r{spin_char} {clean_msg}{time_str}   \033[K")
         sys.stdout.flush()
 
         self.busy = True

--- a/tests/test_ui_countdown.py
+++ b/tests/test_ui_countdown.py
@@ -134,7 +134,7 @@ class TestCountdownTimerTTY(unittest.TestCase):
         timer = CountdownTimer(duration=1, message="Waiting")
         timer.start()
         output = mock_stdout.getvalue()
-        self.assertIn("Waiting...", output)
+        self.assertIn("Waiting: ", output)
         self.assertIn("\r\033[K", output)  # Clears line at end
 
     @patch("time.sleep", side_effect=KeyboardInterrupt)


### PR DESCRIPTION
* 💡 What: Fixed horizontal UI layout shifts in `CountdownTimer` and `Spinner`.
* 🎯 Why: To improve UX and accessibility by ensuring the initial static frame is fully formatted before the dynamic refresh loop starts.
* 📸 Before/After: Before, `Spinner` printed "Loading...", after it prints "⠋ Loading [ 0.0s]". Before `CountdownTimer` printed "Waiting...", after it prints "Waiting: ████████████████████ 30s".
* ♿ Accessibility: Screen readers can now parse the full UI structure immediately.

---
*PR created automatically by Jules for task [7067302012685974866](https://jules.google.com/task/7067302012685974866) started by @abhimehro*