### PR TITLE
🎨 Palette: [UX improvement] Prevent terminal UI layout shifts in countdown timer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-14 - Prevent terminal UI layout shifts
+**Learning:** Terminal UI layout shifts occur when the initial static text (e.g., 'Loading...') doesn't match the structure of the dynamically updating frame (e.g., 'Loading: [progress_bar] [time]').
+**Action:** When starting dynamic terminal loops (spinners, countdowns), ensure the initial static frame contains the formatted components to prevent horizontal visual shifts and improve screen reader experience.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -43,7 +43,18 @@ class CountdownTimer:
         # Accessibility: Print an initial static line so screen readers
         # have a chance to read the message before we start rapidly
         # clearing and redrawing it with carriage returns.
-        sys.stdout.write(f"{self.message}...")
+        # Format time as MM:SS if initial duration >= 60s, else just seconds
+        if self.duration >= 60:
+            time_str = f"{self.duration // 60:02d}:{self.duration % 60:02d}"
+        else:
+            width = len(str(self.duration))
+            time_str = f"{self.duration:{width}d}s"
+
+        # Progress bar (initially full)
+        progress_bar = "█" * self.PROGRESS_BAR_WIDTH
+        colored_bar = Colors.colorize(progress_bar, Colors.CYAN)
+
+        sys.stdout.write(f"{self.message}: {colored_bar} {time_str} ")
         sys.stdout.flush()
 
         try:

--- a/tests/test_ui_countdown.py
+++ b/tests/test_ui_countdown.py
@@ -134,7 +134,8 @@ class TestCountdownTimerTTY(unittest.TestCase):
         timer = CountdownTimer(duration=1, message="Waiting")
         timer.start()
         output = mock_stdout.getvalue()
-        self.assertIn("Waiting...", output)
+        self.assertIn("Waiting: ", output)
+        self.assertIn("1s", output)
         self.assertIn("\r\033[K", output)  # Clears line at end
 
     @patch("time.sleep", side_effect=KeyboardInterrupt)


### PR DESCRIPTION
* 💡 What: Modified the initial static frame of the CountdownTimer to match the dynamically updating frame (including the progress bar and time).
* 🎯 Why: To prevent horizontal visual layout shifts when the timer begins its loop, providing a smoother experience.
* 📸 Before/After: Screenshots if visual change
* ♿ Accessibility: Improves the experience for screen readers by announcing a structured frame initially rather than jumping from "Waiting..." to the formatted layout.

---
*PR created automatically by Jules for task [3196119773158262155](https://jules.google.com/task/3196119773158262155) started by @abhimehro*