### PR TITLE
[repo-health] Remove DATABASE_* stubs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,7 +99,3 @@ MAX_ATTACHMENT_COUNT=10
 MAX_BODY_SIZE_KB=1024
 # Maximum number of accounts processed simultaneously (parallel ingestion)
 MAX_PARALLEL_ACCOUNTS=3
-
-# === Database (Optional / reserved — not yet consumed by runtime) ===
-DATABASE_ENABLED=false
-DATABASE_PATH=data/email_analysis.db

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -104,8 +104,6 @@ class SystemConfig:
     check_interval: int
     max_emails_per_batch: int
     rate_limit_delay: int
-    database_enabled: bool
-    database_path: Optional[str]
     max_attachment_size_mb: int
     max_total_attachment_size_mb: int
     max_attachment_count: int
@@ -229,8 +227,6 @@ class Config:
             check_interval=int(os.getenv("CHECK_INTERVAL", "300")),
             max_emails_per_batch=int(os.getenv("MAX_EMAILS_PER_BATCH", "50")),
             rate_limit_delay=int(os.getenv("RATE_LIMIT_DELAY", "1")),
-            database_enabled=self._get_bool("DATABASE_ENABLED", False),
-            database_path=os.getenv("DATABASE_PATH"),
             max_attachment_size_mb=int(os.getenv("MAX_ATTACHMENT_SIZE_MB", "25")),
             max_total_attachment_size_mb=int(
                 os.getenv("MAX_TOTAL_ATTACHMENT_SIZE_MB", "100")

--- a/tests/test_config_edge_cases.py
+++ b/tests/test_config_edge_cases.py
@@ -289,8 +289,6 @@ class TestConfigurationDefaults(unittest.TestCase):
             check_interval=int(os.getenv("CHECK_INTERVAL", "300")),
             max_emails_per_batch=int(os.getenv("MAX_EMAILS_PER_BATCH", "50")),
             rate_limit_delay=int(os.getenv("RATE_LIMIT_DELAY", "1")),
-            database_enabled=False,
-            database_path=None,
             max_attachment_size_mb=int(os.getenv("MAX_ATTACHMENT_SIZE_MB", "25")),
             max_total_attachment_size_mb=int(
                 os.getenv("MAX_TOTAL_ATTACHMENT_SIZE_MB", "100")
@@ -303,7 +301,6 @@ class TestConfigurationDefaults(unittest.TestCase):
         # Verify conservative defaults
         self.assertEqual(config.max_attachment_size_mb, 25)  # Limited, not unlimited
         self.assertEqual(config.max_body_size_kb, 1024)  # 1MB limit
-        self.assertFalse(config.database_enabled)  # Opt-in feature
 
     def test_rate_limit_default(self):
         """
@@ -322,8 +319,6 @@ class TestConfigurationDefaults(unittest.TestCase):
             check_interval=300,
             max_emails_per_batch=50,
             rate_limit_delay=int(os.getenv("RATE_LIMIT_DELAY", "1")),
-            database_enabled=False,
-            database_path=None,
             max_attachment_size_mb=25,
             max_total_attachment_size_mb=100,
             max_attachment_count=10,


### PR DESCRIPTION
Addresses issue #1475 by removing the unused `DATABASE_ENABLED` and `DATABASE_PATH` configuration stubs from `.env.example`, `src/utils/config.py`, and `tests/test_config_edge_cases.py`. These variables were reserved but unconsumed by the runtime. Tests have been updated and run successfully.

---
*PR created automatically by Jules for task [13934448994643682990](https://jules.google.com/task/13934448994643682990) started by @abhimehro*