### PR TITLE
🎨 Palette: Provide manual fallback instructions on setup cancellation UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -593,3 +593,7 @@ throughout the entire lifecycle of the countdown element.
 ## 2026-08-16 - Semantic Colors for Standalone Scripts
 **Learning:** Standalone scripts often lack the visual polish of the main application, causing a disjointed UX. Textual output with symbols (like ❌) are more scannable when combined with semantic colors.
 **Action:** Use the centralized `Colors.colorize` utility to add semantic colors (Green for success, Red for errors, Yellow for warnings) to standalone scripts, aligning their visual hierarchy with the core CLI application.
+
+## 2026-08-18 - Actionable Fallback for Interrupts
+**Learning:** When users cancel an interactive setup wizard via Ctrl+C (KeyboardInterrupt), simply acknowledging the cancellation without providing fallback instructions leaves them in a dead-end state. Ensuring consistent actionable manual setup instructions are provided on cancellation matches other failure branches (like skipping or validation errors) and significantly improves the UX.
+**Action:** When handling a KeyboardInterrupt in setup scripts, explicitly print manual fallback instructions before exiting.

--- a/src/utils/setup_wizard.py
+++ b/src/utils/setup_wizard.py
@@ -621,6 +621,7 @@ def run_setup_wizard(
             "Setup cancelled by user. No changes were made.", Colors.YELLOW
         )
         print(f"\n\n{warning} {message}")
+        _print_manual_setup_instructions(config_file, template_file)
         return False
 
 


### PR DESCRIPTION
🎨 Palette: Provide manual fallback instructions on setup cancellation UX

💡 **What:** Added a call to `_print_manual_setup_instructions` inside the `KeyboardInterrupt` handler in the setup wizard.
🎯 **Why:** Previously, cancelling the setup wizard with Ctrl+C would print a warning and exit, leaving users without clear next steps. This enhancement aligns the cancellation path with other error/fallback paths, ensuring consistent and actionable manual setup instructions are always provided.
📸 **Before/After:** Not applicable (terminal output change).
♿ **Accessibility:** Reduces cognitive load by providing explicit instructions rather than forcing the user to remember or guess the fallback command.

---
*PR created automatically by Jules for task [1623542883002548648](https://jules.google.com/task/1623542883002548648) started by @abhimehro*