### PR TITLE
automation: bind pathlib.Path at runtime (salvage #1514)

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 import json
 import re
+from pathlib import Path
 from typing import Any
 
 from repository_automation_common import (


### PR DESCRIPTION
## Stage 2 salvage (ESP #1514)

**Provenance:** `abhimehro/email-security-pipeline#1514@cb9f2dd6c791cf53574d5c82b61c3c7a17ceab9d`
**Work item:** `s2-20260822-esp-1514-path-import`
**Repair:** Add a real top-level `from pathlib import Path` so `Path` is bound at runtime. Jules #1514 only imported it under `if typing.TYPE_CHECKING`.
**Allowed:** `.github/scripts/repository_automation_tasks.py`
**Prohibited (untouched):** `.github/workflows`, `.env`, `src/modules`
**Test:** `python3 -m pytest` — 754 passed, 40 subtests passed, exit 0
**Original left OPEN.** Do not close #1514 because this replacement exists.

## Summary
Binds `pathlib.Path` at module import time in `repository_automation_tasks.py`. `Path` is used at runtime (`Path(root)` in `_write_atomic_text` and `_atomic_replace`); a TYPE_CHECKING-only import leaves `NameError` on those paths.

## Test plan
- [x] `python3 -m pytest` on current main + this one-line import (754 passed)
- [x] Runtime check: `from repository_automation_tasks import Path` succeeds after import

## Classification
BOT / FEATURE / ROUTINE. Merge method for this repo: GITHUB_SQUASH (Stage 1 re-ingest).