### PR TITLE
🎨 Palette: Fix terminal output truncation to prevent layout shifts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-24 - Prevent terminal layout shifts in dynamic UX loops
+**Learning:** When printing dynamic terminal text that updates via carriage return, standard length calculations fail because they count ANSI escape sequence characters. This causes the text to wrap visually and floods the terminal with new lines, breaking the loop UX.
+**Action:** Use regex to strip ANSI escape sequences when calculating text length for terminal truncation.

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -4,9 +4,47 @@ Provides user-friendly output components like countdown timers.
 """
 
 import itertools
+import os
+import re
+import shutil
 import sys
 import threading
 import time
+
+ANSI_ESCAPE_PATTERN = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
+
+def get_visual_length(text: str) -> int:
+    if not text:
+        return 0
+    if "\x1b" in text:
+        return len(ANSI_ESCAPE_PATTERN.sub("", text))
+    return len(text)
+
+def truncate_ansi(text: str, max_width: int) -> str:
+    if max_width <= 0:
+        return ""
+    if get_visual_length(text) <= max_width:
+        return text
+    result = []
+    current_length = 0
+    parts = re.split(r'(\x1b\[[0-9;]*[a-zA-Z])', text)
+    for part in parts:
+        if not part:
+            continue
+        if ANSI_ESCAPE_PATTERN.match(part):
+            result.append(part)
+        else:
+            remaining = max_width - current_length
+            if len(part) > remaining:
+                if remaining > 0:
+                    result.append(part[:remaining - 1] + "…")
+                break
+            else:
+                result.append(part)
+                current_length += len(part)
+    result.append("\033[0m")
+    return "".join(result)
+
 
 from .colors import Colors
 
@@ -74,7 +112,10 @@ class CountdownTimer:
                 colored_bar = Colors.colorize(progress_bar, Colors.CYAN)
 
                 # \r moves cursor to start of line, \033[K clears the line
-                sys.stdout.write(f"\r{self.message}: {colored_bar} {time_str} \033[K")
+                full_text = f"{self.message}: {colored_bar} {time_str} "
+                term_width = shutil.get_terminal_size((80, 20)).columns
+                truncated = truncate_ansi(full_text, term_width - 1)
+                sys.stdout.write(f"\r{truncated}\033[K")
                 sys.stdout.flush()
 
                 time.sleep(self.interval)
@@ -159,7 +200,10 @@ class Spinner:
 
             # \r moves cursor to start of line, \033[K clears the line
             spin_char = Colors.colorize(next(self.spinner), Colors.CYAN)
-            sys.stdout.write(f"\r{spin_char} {display_msg}{time_str}   \033[K")
+            full_text = f"{spin_char} {display_msg}{time_str}   "
+            term_width = shutil.get_terminal_size((80, 20)).columns
+            truncated = truncate_ansi(full_text, term_width - 1)
+            sys.stdout.write(f"\r{truncated}\033[K")
             sys.stdout.flush()
             time.sleep(self.delay)
             # Check again to avoid writing after stop


### PR DESCRIPTION
💡 **What:** Added ANSI-aware truncation to dynamic terminal components (CountdownTimer and Spinner).
🎯 **Why:** To prevent horizontal layout shifts and new line flooding caused by ANSI escape sequences inflating character counts.
♿ **Accessibility:** Improves CLI stability and predictability for all users.

---
*PR created automatically by Jules for task [9458815125855996493](https://jules.google.com/task/9458815125855996493) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/email-security-pipeline/pull/1524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->